### PR TITLE
Correct license to non-commercial source-available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,8 @@
 
 ### Upstream attribution
 
-- Ports portions of `openai/codex-plugin-cc` from MIT to Apache-2.0 with
-  attribution in `NOTICE`.
+- Ports portions of `openai/codex-plugin-cc` from MIT-licensed upstream code
+  with attribution in `NOTICE`.
 - Shared library provenance is recorded in
   `plugins/claude/scripts/lib/UPSTREAM.md` and
   `plugins/gemini/scripts/lib/UPSTREAM.md`.

--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,33 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+Source-Available Non-Commercial License
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Copyright 2026 Seungpyo Son
 
-   1. Definitions.
+All rights reserved except for the limited permissions below.
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+Permission is granted to view, download, use, and modify this repository for
+personal, internal, non-commercial evaluation and development.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
+You may not, without prior written permission from the copyright holder:
 
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
+- sell, rent, sublicense, or commercially redistribute this repository or any
+  modified version of it;
+- include this repository or a modified version of it in a paid product,
+  hosted service, marketplace listing, or commercial offering;
+- use this repository to provide paid consulting, managed services, or other
+  commercial services to third parties; or
+- remove or obscure copyright, license, or attribution notices.
 
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
+If you distribute a permitted copy or modification, you must include this
+LICENSE file and the NOTICE file.
 
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
+Third-party code and upstream-derived portions are subject to their original
+licenses as recorded in NOTICE. This license applies to Seungpyo Son's original
+code, modifications, packaging, documentation, and distribution except where a
+third-party notice states otherwise.
 
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for describing the origin of the Work and
-      reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Support. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or support.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright 2026 seungpyoson
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-   implied. See the License for the specific language governing
-   permissions and limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/NOTICE
+++ b/NOTICE
@@ -1,8 +1,12 @@
 codex-plugin-multi
 Copyright 2026 seungpyoson
 
-This product ports portions of openai/codex-plugin-cc (MIT) to Apache-2.0
-with modifications. See the original at https://github.com/openai/codex-plugin-cc.
+This product ports portions of openai/codex-plugin-cc (MIT) with
+modifications. See the original at https://github.com/openai/codex-plugin-cc.
+
+The codex-plugin-multi repository is distributed under the top-level
+source-available non-commercial LICENSE. The upstream MIT notice below is
+preserved for upstream-derived portions.
 
 Upstream MIT license text follows:
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ Two Codex plugins that let Codex delegate work to **Claude Code** and
 [`openai/codex-plugin-cc`](https://github.com/openai/codex-plugin-cc), which
 lets Claude Code delegate to Codex.
 
-- **License:** Apache-2.0. Portions are ported from MIT-licensed upstream code;
-  see `NOTICE`.
+- **License:** Source-available, non-commercial. Selling, sublicensing, or
+  commercial redistribution is not permitted without prior written permission.
+  Portions are ported from MIT-licensed upstream code; see `NOTICE`.
 - **State:** active development. Claude and Gemini companion
   review/rescue/status/result flows are implemented and covered by mock smoke
   tests. Gemini `cancel` is deferred. Fresh-install verification on Codex CLI
@@ -166,4 +167,4 @@ codex-plugin-multi/
 ## Attribution
 
 Ports portions of [`openai/codex-plugin-cc`](https://github.com/openai/codex-plugin-cc)
-from MIT to Apache-2.0. See `NOTICE` for upstream text and attribution.
+from MIT-licensed upstream code. See `NOTICE` for upstream text and attribution.

--- a/docs/superpowers/plans/2026-04-24-codex-plugin-multi-plan.md
+++ b/docs/superpowers/plans/2026-04-24-codex-plugin-multi-plan.md
@@ -108,10 +108,10 @@ M11 release      → T11.1 → T11.2 → T11.3 → T11.4              (was M10)
 
 ### T0.1 — repo bootstrap
 
-- **Goal:** Apache-2.0 licensed repo skeleton with NOTICE attribution to upstream MIT.
+- **Goal:** Source-available non-commercial repo skeleton with NOTICE attribution to upstream MIT.
 - **Files:**
-  - `LICENSE` (Apache-2.0 text)
-  - `NOTICE` (full MIT text of `openai/codex-plugin-cc` + attribution note: "This project ports portions of openai/codex-plugin-cc (MIT) to Apache-2.0 with modifications.")
+  - `LICENSE` (source-available non-commercial text)
+  - `NOTICE` (full MIT text of `openai/codex-plugin-cc` + attribution note)
   - `README.md` (overview, install instructions, safety disclosures per §10)
   - `package.json` with `{"workspaces": ["plugins/*"], "private": true, "engines": {"node": ">=20.0.0"}}`
   - `.gitignore` (node_modules, `.codex-plugin-*/jobs/`, `~/.cache/codex-plugin-*/`, OS cruft)
@@ -145,9 +145,9 @@ M11 release      → T11.1 → T11.2 → T11.3 → T11.4              (was M10)
 
 - **Goal:** minimal `.codex-plugin/plugin.json` per plugin.
 - **Files:**
-  - `plugins/claude/.codex-plugin/plugin.json`: `{"name":"claude","version":"0.0.1","description":"Delegate to Claude Code from Codex.","author":{"name":"seungpyoson"},"repository":"https://github.com/seungpyoson/codex-plugin-multi","license":"Apache-2.0"}`
+  - `plugins/claude/.codex-plugin/plugin.json`: `{"name":"claude","version":"0.0.1","description":"Delegate to Claude Code from Codex.","author":{"name":"seungpyoson"},"repository":"https://github.com/seungpyoson/codex-plugin-multi","license":"Source-Available-NonCommercial"}`
   - `plugins/gemini/.codex-plugin/plugin.json`: analogous.
-  - Stub `plugins/claude/LICENSE` and `plugins/gemini/LICENSE` (Apache-2.0 copies).
+  - Stub `plugins/claude/LICENSE` and `plugins/gemini/LICENSE` pointers to the top-level license.
 - **Acceptance:** Both manifests validate as JSON. Marketplace install from T0.2 now resolves individual plugins (visible in Codex TUI `/plugins`).
 - **Spec ref:** §4.13, §6.
 - **Depends on:** T0.2
@@ -209,7 +209,7 @@ M11 release      → T11.1 → T11.2 → T11.3 → T11.4              (was M10)
 
 - **Goal:** six target-neutral lib files copied per plugin, with upstream attribution.
 - **Files (per plugin, so twice — claude/ and gemini/):**
-  - `plugins/<target>/scripts/lib/workspace.mjs` (verbatim from upstream `plugins/codex/scripts/lib/workspace.mjs`, with a `// Ported from openai/codex-plugin-cc (MIT). Apache-2.0 modifications.` header)
+  - `plugins/<target>/scripts/lib/workspace.mjs` (verbatim from upstream `plugins/codex/scripts/lib/workspace.mjs`, with a `// Ported from openai/codex-plugin-cc (MIT). See NOTICE.` header)
   - Same header for: `process.mjs`, `args.mjs`, `git.mjs`, `job-control.mjs`, `prompts.mjs`.
   - `plugins/<target>/scripts/lib/UPSTREAM.md`: records source commit SHA + which files are copy-verbatim vs parametrized.
 - **Acceptance:** `diff` of each copy-verbatim file against the vendored upstream source is header-only (single comment block at top). `UPSTREAM.md` cites the SHA.

--- a/docs/superpowers/specs/2026-04-23-codex-plugin-multi-design.md
+++ b/docs/superpowers/specs/2026-04-23-codex-plugin-multi-design.md
@@ -3,7 +3,9 @@
 - **Date:** 2026-04-23 (v3) / 2026-04-24 (v4 — full empirical re-verification) / **2026-04-24 (v5 — architectural invariants)**
 - **Status:** Draft v5, post-M6 cross-model review; corrected after 2026-04-27 fresh-install verification
 - **Repo:** [`seungpyoson/codex-plugin-multi`](https://github.com/seungpyoson/codex-plugin-multi)
-- **License:** Apache-2.0 (mirrors upstream)
+- **License:** Source-available non-commercial. Selling, sublicensing, or
+  commercial redistribution is not permitted without prior written permission.
+  Upstream MIT attribution is preserved in `NOTICE`.
 - **Reference:** [`openai/codex-plugin-cc`](https://github.com/openai/codex-plugin-cc) (MIT — Claude Code plugin calling Codex); [`openai/plugins`](https://github.com/openai/plugins) (canonical Codex monorepo pattern)
 
 ## What changed in v5 (from v4)
@@ -66,7 +68,7 @@ Upstream `openai/codex-plugin-cc` is a **Claude Code plugin** that lets Claude C
 |---|----------|--------|
 | 1 | Packaging | Two plugins (`plugins/claude/`, `plugins/gemini/`) in one monorepo. Each is standalone. Registered via a single `.agents/plugins/marketplace.json` at repo root. |
 | 2 | Slash-command naming | Intended surface uses **bare names, not namespaced:** `/claude-rescue`, `/gemini-review`, etc. Codex CLI 0.125.0 does not currently register plugin command files. |
-| 3 | Repo | `seungpyoson/codex-plugin-multi`, Apache-2.0, public GitHub. |
+| 3 | Repo | `seungpyoson/codex-plugin-multi`, source-available non-commercial, public GitHub. |
 | 4 | Prompting skills | One per plugin: `plugins/<target>/skills/<target>-prompting/`. Mirrors upstream's `gpt-5-4-prompting` structure. |
 | 5 | Auth | OAuth / subscription only. Plugin never reads or writes `*_API_KEY` env vars. |
 | 6 | Primary user-facing surface | User-invocable delegation skills and companion scripts in v0.1.0. Native `commands/*.md` slash commands are blocked on Codex TUI support in CLI 0.125.0; non-ping command docs are packaged for the intended future surface. |
@@ -221,7 +223,7 @@ through built-ins only.
 
 `--sparse <path>` flag **only works for git sources**, not local paths. Users install the whole marketplace and enable individual plugins via Codex TUI (`/plugins` command — Space to toggle, Enter for details). Config-based enable also works: `-c 'plugins."name@marketplace".enabled=true'`.
 
-### 4.14 Upstream reference — files to port (Apache-2.0 port of MIT)
+### 4.14 Upstream reference — files to port (MIT upstream with attribution)
 
 `openai/codex-plugin-cc` structure (note: it's a **Claude Code** plugin, uses `.claude-plugin/plugin.json`):
 
@@ -360,7 +362,7 @@ Review and adversarial-review run single-turn in the calling Codex session (no s
 ```
 codex-plugin-multi/
   README.md
-  LICENSE                                        # Apache-2.0
+  LICENSE                                        # source-available non-commercial
   NOTICE                                         # attribution to upstream (MIT)
   CHANGELOG.md
   package.json                                   # workspaces: ["plugins/*"]
@@ -772,7 +774,7 @@ Before v0.1.0: run upstream `/codex:adversarial-review` against this repo. Addre
 | R6 | Concurrent Gemini at semantic layer. | Disposable containment default + policy file. Serialize per workspace via lockfile if observed in practice. |
 | R7 | Command name collision with Codex builtins (`stop`, `plan`, …). | Bare names enumerated §5.1; none collide. Spec pins the list. |
 | R8 | Multi-plugin install UX. | Verified live: `codex plugin marketplace add owner/repo` resolves to git clone; `.agents/plugins/marketplace.json` schema validated; user enables per-plugin in TUI. |
-| R9 | Apache-2.0 port of MIT upstream. | `NOTICE` includes full MIT text + attribution. Our deltas Apache-2.0. |
+| R9 | MIT upstream attribution. | `NOTICE` includes full MIT text + attribution. Repository distribution is source-available non-commercial. |
 | R10 | `--bare` OAuth incompatibility would have broken Claude calls in v3. | Resolved in v4: `--setting-sources ""`. |
 | R11 | Hook timeout enforcement means gate hooks with real work will silently fail. | v1 ships no hooks. Review-gate feature deferred. |
 | R12 | `--json-schema` is soft contract. | Parse `structured_output`; fall back to text-parse + retry once. |

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Codex plugins that delegate to Claude Code and Gemini CLI. Symmetric inverse of openai/codex-plugin-cc.",
   "private": true,
   "type": "module",
-  "license": "Apache-2.0",
+  "license": "SEE LICENSE IN LICENSE",
   "author": "Seungpyo Son",
   "repository": {
     "type": "git",

--- a/plugins/claude/.codex-plugin/plugin.json
+++ b/plugins/claude/.codex-plugin/plugin.json
@@ -7,7 +7,7 @@
   },
   "homepage": "https://github.com/seungpyoson/codex-plugin-multi",
   "repository": "https://github.com/seungpyoson/codex-plugin-multi",
-  "license": "Apache-2.0",
+  "license": "Source-Available-NonCommercial",
   "keywords": [
     "claude",
     "claude-code",

--- a/plugins/claude/LICENSE
+++ b/plugins/claude/LICENSE
@@ -1,3 +1,3 @@
-See top-level LICENSE file for Apache-2.0 text. This file exists to satisfy per-plugin
-license discovery; it is a pointer, not a separate grant. The codex-plugin-multi
-repository's LICENSE (Apache-2.0) governs all files in this directory.
+See the top-level LICENSE file for the repository's source-available
+non-commercial license. This file exists to satisfy per-plugin license
+discovery; it is a pointer, not a separate grant.

--- a/plugins/claude/package.json
+++ b/plugins/claude/package.json
@@ -2,6 +2,6 @@
   "name": "codex-plugin-multi-claude",
   "version": "0.1.0",
   "private": true,
-  "license": "Apache-2.0",
+  "license": "SEE LICENSE IN LICENSE",
   "description": "Codex plugin that delegates to Claude Code (sub-workspace of codex-plugin-multi)."
 }

--- a/plugins/claude/scripts/lib/UPSTREAM.md
+++ b/plugins/claude/scripts/lib/UPSTREAM.md
@@ -2,10 +2,10 @@
 
 All files in this directory are ported from
 [`openai/codex-plugin-cc`](https://github.com/openai/codex-plugin-cc) (MIT license)
-into this repository (Apache-2.0). Per the MIT text, the upstream copyright notice
-is preserved in the repository's top-level `NOTICE` file. Per the Apache License,
-each modified file carries a "modified from upstream" comment header indicating
-the source path and synced commit.
+into this repository. Per the MIT text, the upstream copyright notice is
+preserved in the repository's top-level `NOTICE` file. Each modified file
+carries a "modified from upstream" comment header indicating the source path and
+synced commit.
 
 **Synced commit:** `807e03ac9d5aa23bc395fdec8c3767500a86b3cf` (2026-04-18, "fix: bump plugin version to 1.0.4 (#244)")
 

--- a/plugins/gemini/.codex-plugin/plugin.json
+++ b/plugins/gemini/.codex-plugin/plugin.json
@@ -7,7 +7,7 @@
   },
   "homepage": "https://github.com/seungpyoson/codex-plugin-multi",
   "repository": "https://github.com/seungpyoson/codex-plugin-multi",
-  "license": "Apache-2.0",
+  "license": "Source-Available-NonCommercial",
   "keywords": [
     "gemini",
     "gemini-cli",

--- a/plugins/gemini/LICENSE
+++ b/plugins/gemini/LICENSE
@@ -1,3 +1,3 @@
-See top-level LICENSE file for Apache-2.0 text. This file exists to satisfy per-plugin
-license discovery; it is a pointer, not a separate grant. The codex-plugin-multi
-repository's LICENSE (Apache-2.0) governs all files in this directory.
+See the top-level LICENSE file for the repository's source-available
+non-commercial license. This file exists to satisfy per-plugin license
+discovery; it is a pointer, not a separate grant.

--- a/plugins/gemini/package.json
+++ b/plugins/gemini/package.json
@@ -2,6 +2,6 @@
   "name": "codex-plugin-multi-gemini",
   "version": "0.1.0",
   "private": true,
-  "license": "Apache-2.0",
+  "license": "SEE LICENSE IN LICENSE",
   "description": "Codex plugin that delegates to Gemini CLI (sub-workspace of codex-plugin-multi)."
 }

--- a/plugins/gemini/scripts/lib/UPSTREAM.md
+++ b/plugins/gemini/scripts/lib/UPSTREAM.md
@@ -2,10 +2,10 @@
 
 All files in this directory are ported from
 [`openai/codex-plugin-cc`](https://github.com/openai/codex-plugin-cc) (MIT license)
-into this repository (Apache-2.0). Per the MIT text, the upstream copyright notice
-is preserved in the repository's top-level `NOTICE` file. Per the Apache License,
-each modified file carries a "modified from upstream" comment header indicating
-the source path and synced commit.
+into this repository. Per the MIT text, the upstream copyright notice is
+preserved in the repository's top-level `NOTICE` file. Each modified file
+carries a "modified from upstream" comment header indicating the source path and
+synced commit.
 
 **Synced commit:** `807e03ac9d5aa23bc395fdec8c3767500a86b3cf` (2026-04-18, "fix: bump plugin version to 1.0.4 (#244)")
 

--- a/tests/unit/manifests.test.mjs
+++ b/tests/unit/manifests.test.mjs
@@ -29,7 +29,7 @@ test("claude plugin.json: valid schema", () => {
   const m = readJson("plugins/claude/.codex-plugin/plugin.json");
   assert.equal(m.name, "claude");
   assert.ok(/^\d+\.\d+\.\d+/.test(m.version));
-  assert.equal(m.license, "Apache-2.0");
+  assert.equal(m.license, "Source-Available-NonCommercial");
   assert.ok(m.interface.capabilities.every((c) => ["Interactive", "Read", "Write"].includes(c)));
 });
 
@@ -37,7 +37,7 @@ test("gemini plugin.json: valid schema", () => {
   const m = readJson("plugins/gemini/.codex-plugin/plugin.json");
   assert.equal(m.name, "gemini");
   assert.ok(/^\d+\.\d+\.\d+/.test(m.version));
-  assert.equal(m.license, "Apache-2.0");
+  assert.equal(m.license, "Source-Available-NonCommercial");
 });
 
 test("both plugins declared in marketplace match filesystem layout", () => {


### PR DESCRIPTION
## Summary\n- Replaces Apache-2.0 with a source-available non-commercial license that forbids sale, sublicensing, and commercial redistribution without written permission.\n- Updates package/plugin metadata, README, changelog, design docs, plugin LICENSE pointers, and upstream provenance docs.\n- Preserves upstream MIT attribution in NOTICE for upstream-derived portions.\n\n## Test Plan\n- npm run lint\n- node --test tests/unit/manifests.test.mjs tests/unit/docs-contracts.test.mjs\n- git diff --check\n- npm test (pre-commit hook)