### PR TITLE
docs: clarify plugin skill verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,20 @@ without the other.
 ## Verify skill discovery after installation
 
 After enabling the plugins, open Codex's skill picker or ask Codex what plugin
-skills are available. The installed skill list should include
-`claude-delegation` and `gemini-delegation`. If they are missing, the plugin
-is either not enabled in that Codex profile or the manifests are not exposing
-the bundled `skills/` roots correctly.
+skills are available. Current Codex builds expose plugin skills with their
+plugin namespace; the installed skill list should include
+`claude:claude-delegation` and `gemini:gemini-delegation`.
+
+For a non-interactive check against the current Codex profile, run:
+
+```bash
+codex debug prompt-input 'list skills'
+```
+
+If you are testing a disposable profile, set `CODEX_HOME` to that profile before
+running the same command. If the namespaced skills are missing, the plugin is
+either not enabled in that Codex profile or the manifests are not exposing the
+bundled `skills/` roots correctly.
 
 ## Current Codex 0.125.0 TUI limitation
 
@@ -129,6 +139,11 @@ inspect the terminal record.
   file count, and byte count without launching the target provider. Use
   `custom-review` plus explicit `--scope-paths` for pinned review bundles, and
   prompt with relative paths inside the selected scope.
+- **Host-owned pre-launch denials stay outside companion control.** If Codex
+  blocks an external provider review before launching the companion process, the
+  plugin cannot emit a JobRecord. That host-owned gap is tracked in #27. Choose
+  an approved provider, run local/Codex-only review, or use `preflight` to
+  inspect disclosure before requesting an external review.
 - **Rescue is write-capable.** Rescue modes are intended for investigation and
   fixes. Review and adversarial-review are the safer choices when you only want
   critique.

--- a/tests/unit/docs-contracts.test.mjs
+++ b/tests/unit/docs-contracts.test.mjs
@@ -231,3 +231,14 @@ test("README documents shipped install path, first commands, and safety posture"
     "gemini cancel is wired (PR #22); README must not claim it's deferred");
   assert.match(readme, /docs\/e2e\.md/);
 });
+
+test("README documents host-owned pre-launch provider denials as outside companion control", () => {
+  const readme = readRepoFile("README.md");
+
+  assert.match(readme, /pre-launch/i);
+  assert.match(readme, /host-owned/i);
+  assert.match(readme, /cannot emit a JobRecord/i);
+  assert.match(readme, /approved provider/i);
+  assert.match(readme, /local\/Codex-only review/i);
+  assert.match(readme, /#27/);
+});

--- a/tests/unit/manifests.test.mjs
+++ b/tests/unit/manifests.test.mjs
@@ -81,8 +81,10 @@ test("claude and gemini expose user-invocable skill fallbacks", () => {
 test("README documents install verification for discoverable delegation skills", () => {
   const readme = readFileSync(path.join(REPO_ROOT, "README.md"), "utf8");
   assert.match(readme, /Verify skill discovery after installation/);
-  assert.match(readme, /claude-delegation/);
-  assert.match(readme, /gemini-delegation/);
+  assert.match(readme, /codex debug prompt-input 'list skills'/);
+  assert.match(readme, /claude:claude-delegation/);
+  assert.match(readme, /gemini:gemini-delegation/);
+  assert.match(readme, /CODEX_HOME/);
 });
 
 test("release docs disclose current Codex slash-command limitation", () => {


### PR DESCRIPTION
## Summary
- document current namespaced Codex plugin skill discovery for #20
- add a non-interactive `codex debug prompt-input 'list skills'` verification path, including disposable `CODEX_HOME` guidance
- document #27 as a host-owned pre-launch external-provider denial gap where the companion cannot emit a JobRecord

Closes #20.
References #27.

## Verification
- RED: `node --test --test-reporter=spec tests/unit/manifests.test.mjs tests/unit/docs-contracts.test.mjs` failed on the missing namespaced skill verification and #27 host-boundary wording
- GREEN: `node --test --test-reporter=spec tests/unit/manifests.test.mjs tests/unit/docs-contracts.test.mjs` passed, 23/23
- `npm run lint`
- `npm run lint:self-test`
- `git diff --check`
- `npm test` passed, 501 pass / 6 skipped
- `npm run smoke:claude` passed, 40/40
- `npm run smoke:gemini` passed, 34/34
- `npm run test:coverage` passed, 645 pass / 18 skipped, coverage target met at 85%
- `codex debug prompt-input 'list skills' | rg -n "claude:claude-delegation|gemini:gemini-delegation"` confirmed both installed plugin skills in the real Codex profile

## Notes
- Bypassed the local pre-commit audit-only gate with `--no-verify` because the task explicitly said not to use audit/jury gates. The hook's `npm test` run completed green before that gate blocked the commit.
- #13 was checked against upstream `openai/codex` main at `ff27d01676a93be7467b3893e82f41a7af7e1418`; plugin command-file support is still absent, and issue #13 was updated with that evidence.
