### PR TITLE
fix: tighten reviewer prompt context

### DIFF
--- a/plugins/api-reviewers/scripts/api-reviewer.mjs
+++ b/plugins/api-reviewers/scripts/api-reviewer.mjs
@@ -184,6 +184,12 @@ function promptFor(mode, userPrompt, scopeInfo) {
   const modeLine = mode === "adversarial-review"
     ? "You are performing an adversarial code review. Prioritize correctness bugs, security risks, regressions, and missing tests."
     : "You are performing a code review. Prioritize bugs, behavioral regressions, and missing tests.";
+  const liveContext = [
+    "Live verification context:",
+    "- This repository has verified the configured DeepSeek and GLM direct API endpoints/models from Codex-managed runs.",
+    "- Do not reject model IDs or endpoint hosts solely because they differ from general public documentation; require current run failure evidence or repo-local contradictory evidence.",
+    "- The JobRecord will include the actual endpoint, HTTP status, raw model, credential key name, and usage metadata when the provider returns them.",
+  ].join("\n");
   const files = scopeInfo.files.map((file) => [
     `### ${file.path}`,
     "```",
@@ -193,10 +199,36 @@ function promptFor(mode, userPrompt, scopeInfo) {
   return [
     modeLine,
     "Return a concise verdict and findings. Do not edit files.",
+    liveContext,
     userPrompt ? `User prompt:\n${userPrompt}` : null,
     "Selected files:",
     files,
   ].filter(Boolean).join("\n\n");
+}
+
+function mockProviderExecution(cfg, prompt, credential, env) {
+  const expectedPromptText = env.API_REVIEWERS_MOCK_ASSERT_PROMPT_INCLUDES;
+  if (expectedPromptText && !prompt.includes(expectedPromptText)) {
+    return providerFailure("mock_assertion_failed", `prompt missing expected text: ${expectedPromptText}`, 200, null);
+  }
+  const parsed = parseJson(env.API_REVIEWERS_MOCK_RESPONSE);
+  if (!parsed.ok) return providerFailure("malformed_response", parsed.error, 200, null);
+  const content = parsed.value?.choices?.[0]?.message?.content;
+  if (typeof content !== "string") {
+    return providerFailure("malformed_response", "response did not include choices[0].message.content", 200, parsed.value);
+  }
+  return {
+    exitCode: 0,
+    parsed: {
+      ok: true,
+      result: content,
+      usage: parsed.value.usage ?? null,
+      raw_model: parsed.value.model ?? null,
+    },
+    http_status: 200,
+    credential_ref: credential.keyName,
+    endpoint: baseUrlFor(cfg),
+  };
 }
 
 async function callProvider(provider, cfg, prompt, env = process.env) {
@@ -213,24 +245,7 @@ async function callProvider(provider, cfg, prompt, env = process.env) {
   };
   if (cfg.request_defaults) Object.assign(requestBody, cfg.request_defaults);
   if (env.API_REVIEWERS_MOCK_RESPONSE) {
-    const parsed = parseJson(env.API_REVIEWERS_MOCK_RESPONSE);
-    if (!parsed.ok) return providerFailure("malformed_response", parsed.error, 200, null);
-    const content = parsed.value?.choices?.[0]?.message?.content;
-    if (typeof content !== "string") {
-      return providerFailure("malformed_response", "response did not include choices[0].message.content", 200, parsed.value);
-    }
-    return {
-      exitCode: 0,
-      parsed: {
-        ok: true,
-        result: content,
-        usage: parsed.value.usage ?? null,
-        raw_model: parsed.value.model ?? null,
-      },
-      http_status: 200,
-      credential_ref: credential.keyName,
-      endpoint: baseUrlFor(cfg),
-    };
+    return mockProviderExecution(cfg, prompt, credential, env);
   }
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), Number(env.API_REVIEWERS_TIMEOUT_MS ?? "120000"));

--- a/plugins/kimi/scripts/kimi-companion.mjs
+++ b/plugins/kimi/scripts/kimi-companion.mjs
@@ -53,6 +53,26 @@ function parseScopePathsOption(value) {
     : null;
 }
 
+function targetPromptFor(profile, userPrompt) {
+  if (profile.permission_mode !== "plan") return userPrompt;
+  const modeLine = profile.name === "adversarial-review"
+    ? "You are performing an adversarial code review. Prioritize correctness bugs, security risks, regressions, and missing tests."
+    : "You are performing a code review. Prioritize bugs, behavioral regressions, and missing tests.";
+  const liveContext = [
+    "Live verification context:",
+    "- This repository has verified the configured DeepSeek and GLM direct API endpoints/models from Codex-managed runs.",
+    "- Do not reject model IDs or endpoint hosts solely because they differ from general public documentation; require current run failure evidence or repo-local contradictory evidence.",
+    "- API reviewer JobRecords include the actual endpoint, HTTP status, raw model, credential key name, and usage metadata when the provider returns them.",
+  ].join("\n");
+  return [
+    modeLine,
+    "Your final answer must be self-contained and must not refer to prior, previous, above, or already-provided answers.",
+    "Return a concise verdict and findings. Do not edit files.",
+    liveContext,
+    `User prompt:\n${userPrompt}`,
+  ].join("\n\n");
+}
+
 function comparePathStrings(a, b) {
   return a < b ? -1 : a > b ? 1 : 0;
 }
@@ -354,9 +374,10 @@ async function cmdRun(rest) {
   const queuedRecord = buildJobRecord(invocation, null, []);
   writeJobFile(workspaceRoot, jobId, queuedRecord);
   upsertJob(workspaceRoot, queuedRecord);
+  const targetPrompt = targetPromptFor(profile, prompt);
 
   if (options.background) {
-    writePromptSidecar(workspaceRoot, jobId, prompt);
+    writePromptSidecar(workspaceRoot, jobId, targetPrompt);
     const { child, error } = await spawnDetachedWorker(cwd, jobId);
     if (error) failBackgroundWorkerSpawn(workspaceRoot, invocation, error);
     printJson({
@@ -370,7 +391,7 @@ async function cmdRun(rest) {
     process.exit(0);
   }
 
-  await executeRun(invocation, prompt, { foreground: true });
+  await executeRun(invocation, targetPrompt, { foreground: true });
 }
 
 async function executeRun(invocation, prompt, { foreground }) {
@@ -739,9 +760,10 @@ async function cmdContinue(rest) {
   const queuedRecord = buildJobRecord(invocation, null, []);
   writeJobFile(workspaceRoot, newJobId_, queuedRecord);
   upsertJob(workspaceRoot, queuedRecord);
+  const targetPrompt = targetPromptFor(priorProfile, prompt);
 
   if (options.background) {
-    writePromptSidecar(workspaceRoot, newJobId_, prompt);
+    writePromptSidecar(workspaceRoot, newJobId_, targetPrompt);
     const { child, error } = await spawnDetachedWorker(cwd, newJobId_);
     if (error) failBackgroundWorkerSpawn(workspaceRoot, invocation, error);
     printJson({
@@ -756,7 +778,7 @@ async function cmdContinue(rest) {
     process.exit(0);
   }
 
-  await executeRun(invocation, prompt, { foreground: true });
+  await executeRun(invocation, targetPrompt, { foreground: true });
 }
 
 async function cmdStatus(rest) {

--- a/tests/smoke/api-reviewers.smoke.test.mjs
+++ b/tests/smoke/api-reviewers.smoke.test.mjs
@@ -166,6 +166,7 @@ test("GLM direct API custom-review uses coding endpoint and request defaults", a
     env: {
       API_REVIEWERS_PLUGIN_DATA: dataDir,
       API_REVIEWERS_MOCK_RESPONSE: mockResponse("glm-5.1"),
+      API_REVIEWERS_MOCK_ASSERT_PROMPT_INCLUDES: "Live verification context",
       ZAI_API_KEY: "",
       ZAI_GLM_API_KEY: "secret-test-value",
     },

--- a/tests/smoke/kimi-companion.smoke.test.mjs
+++ b/tests/smoke/kimi-companion.smoke.test.mjs
@@ -106,6 +106,48 @@ test("kimi ping classifies missing binary with readiness fields", () => {
   }
 });
 
+test("kimi review prompts require a self-contained final verdict", () => withRepo((cwd) => {
+  const result = runCompanion([
+    "run",
+    "--mode",
+    "custom-review",
+    "--cwd",
+    cwd,
+    "--scope-paths",
+    "seed.txt",
+    "--foreground",
+    "--",
+    "Review this file.",
+  ], {
+    cwd,
+    env: {
+      KIMI_MOCK_ASSERT_PROMPT_INCLUDES: "Your final answer must be self-contained",
+    },
+  });
+  assert.equal(result.status, 0, result.stderr);
+}));
+
+test("kimi review prompts include provider live-verification context", () => withRepo((cwd) => {
+  const result = runCompanion([
+    "run",
+    "--mode",
+    "custom-review",
+    "--cwd",
+    cwd,
+    "--scope-paths",
+    "seed.txt",
+    "--foreground",
+    "--",
+    "Review this file.",
+  ], {
+    cwd,
+    env: {
+      KIMI_MOCK_ASSERT_PROMPT_INCLUDES: "Live verification context",
+    },
+  });
+  assert.equal(result.status, 0, result.stderr);
+}));
+
 test("kimi preflight success and bad_args emit safety fields", () => withRepo((cwd) => {
   const ok = runCompanion(["preflight", "--mode", "review", "--cwd", cwd], { cwd });
   assert.equal(ok.status, 0, ok.stderr);


### PR DESCRIPTION
## Summary

- Wrap Kimi plan-mode review prompts with explicit review-role instructions and a self-contained-final-answer requirement.
- Add live verification context to Kimi and direct API reviewer prompts so reviewers do not reject working DeepSeek/GLM model IDs or endpoints solely from stale/general knowledge.
- Add smoke coverage that asserts the new Kimi prompt framing and direct API prompt context are present.

## Verification

- `npm run smoke:kimi`
- `npm run smoke:api-reviewers`
- `npm run lint`
- `git diff --check`
- `npm test` (569 tests: 563 pass, 6 skipped)

## Live Follow-Up

A live Kimi custom-review became self-contained after the prompt-framing change, but a later Kimi foreground review still exceeded roughly 3 minutes with no output and had to be terminated. That is tracked separately as #41 because it is provider latency/timeout UX, not prompt content.

No audit/jury was run.