### PR TITLE
test: cover reviewer prompt context modes

### DIFF
--- a/tests/smoke/api-reviewers.smoke.test.mjs
+++ b/tests/smoke/api-reviewers.smoke.test.mjs
@@ -108,6 +108,7 @@ test("DeepSeek direct API custom-review completes and persists JobRecord", async
     env: {
       API_REVIEWERS_PLUGIN_DATA: dataDir,
       API_REVIEWERS_MOCK_RESPONSE: mockResponse("deepseek-v4-flash"),
+      API_REVIEWERS_MOCK_ASSERT_PROMPT_INCLUDES: "Live verification context",
       DEEPSEEK_API_KEY: "secret-test-value",
     },
   });
@@ -136,6 +137,7 @@ test("branch-diff default reviews committed changes against main with scrubbed g
     env: {
       API_REVIEWERS_PLUGIN_DATA: dataDir,
       API_REVIEWERS_MOCK_RESPONSE: mockResponse("deepseek-v4-flash"),
+      API_REVIEWERS_MOCK_ASSERT_PROMPT_INCLUDES: "Live verification context",
       DEEPSEEK_API_KEY: "secret-test-value",
       GIT_DIR: path.join(cwd, "not-a-repo"),
       GIT_CONFIG_GLOBAL: path.join(cwd, "malicious-gitconfig"),

--- a/tests/smoke/kimi-companion.smoke.test.mjs
+++ b/tests/smoke/kimi-companion.smoke.test.mjs
@@ -63,6 +63,30 @@ function assertPreflightSafetyFields(result) {
   assert.equal(result.requires_external_provider_consent, true);
 }
 
+function kimiPromptAssertionArgs(cwd, mode) {
+  const extraArgs = [];
+  if (mode === "adversarial-review") {
+    writeFileSync(path.join(cwd, "changed.txt"), "changed\n");
+    assert.equal(fixtureGit(cwd, ["add", "changed.txt"]).status, 0);
+    assert.equal(fixtureGit(cwd, ["commit", "-q", "-m", "changed"]).status, 0);
+    extraArgs.push("--scope-base", "HEAD~1");
+  }
+  if (mode === "custom-review") {
+    extraArgs.push("--scope-paths", "seed.txt");
+  }
+  return [
+    "run",
+    "--mode",
+    mode,
+    "--cwd",
+    cwd,
+    ...extraArgs,
+    "--foreground",
+    "--",
+    "Review this file.",
+  ];
+}
+
 test("kimi ping reports OAuth readiness and ignored API-key diagnostics", () => {
   const cwd = mkdtempSync(path.join(tmpdir(), "kimi-ping-"));
   try {
@@ -106,47 +130,27 @@ test("kimi ping classifies missing binary with readiness fields", () => {
   }
 });
 
-test("kimi review prompts require a self-contained final verdict", () => withRepo((cwd) => {
-  const result = runCompanion([
-    "run",
-    "--mode",
-    "custom-review",
-    "--cwd",
-    cwd,
-    "--scope-paths",
-    "seed.txt",
-    "--foreground",
-    "--",
-    "Review this file.",
-  ], {
-    cwd,
-    env: {
-      KIMI_MOCK_ASSERT_PROMPT_INCLUDES: "Your final answer must be self-contained",
-    },
-  });
-  assert.equal(result.status, 0, result.stderr);
-}));
+for (const mode of ["review", "adversarial-review", "custom-review"]) {
+  test(`kimi ${mode} prompt requires a self-contained final verdict`, () => withRepo((cwd) => {
+    const result = runCompanion(kimiPromptAssertionArgs(cwd, mode), {
+      cwd,
+      env: {
+        KIMI_MOCK_ASSERT_PROMPT_INCLUDES: "Your final answer must be self-contained",
+      },
+    });
+    assert.equal(result.status, 0, result.stderr);
+  }));
 
-test("kimi review prompts include provider live-verification context", () => withRepo((cwd) => {
-  const result = runCompanion([
-    "run",
-    "--mode",
-    "custom-review",
-    "--cwd",
-    cwd,
-    "--scope-paths",
-    "seed.txt",
-    "--foreground",
-    "--",
-    "Review this file.",
-  ], {
-    cwd,
-    env: {
-      KIMI_MOCK_ASSERT_PROMPT_INCLUDES: "Live verification context",
-    },
-  });
-  assert.equal(result.status, 0, result.stderr);
-}));
+  test(`kimi ${mode} prompt includes provider live-verification context`, () => withRepo((cwd) => {
+    const result = runCompanion(kimiPromptAssertionArgs(cwd, mode), {
+      cwd,
+      env: {
+        KIMI_MOCK_ASSERT_PROMPT_INCLUDES: "Live verification context",
+      },
+    });
+    assert.equal(result.status, 0, result.stderr);
+  }));
+}
 
 test("kimi preflight success and bad_args emit safety fields", () => withRepo((cwd) => {
   const ok = runCompanion(["preflight", "--mode", "review", "--cwd", cwd], { cwd });


### PR DESCRIPTION
## Summary

- Add live-context prompt assertions to the DeepSeek custom-review and branch-diff API reviewer smoke paths.
- Broaden Kimi prompt-framing smoke coverage across `review`, `adversarial-review`, and `custom-review` plan-mode profiles.

## Issue Mapping

Fixes #44.

This PR is deliberately test-only and does not address Kimi live latency/timeouts. That remains tracked by #41.

## Verification

- `npm run smoke:api-reviewers`
- `npm run smoke:kimi`
- `git diff --check`
- `npm run lint`
- `npm test` (573 tests: 567 pass, 6 skipped)

## Notes

Addresses Greptile's P2 coverage comments on PR #42. No audit/jury was run.