### PR TITLE
[codex] fix Kimi timeout diagnostics

### DIFF
--- a/plugins/kimi/scripts/kimi-companion.mjs
+++ b/plugins/kimi/scripts/kimi-companion.mjs
@@ -32,6 +32,7 @@ const MODELS_CONFIG_PATH = resolvePath(PLUGIN_ROOT, "config/models.json");
 const CONTINUABLE_STATUSES = new Set(["completed", "failed", "cancelled", "stale"]);
 const RUN_MODES = Object.freeze(["review", "adversarial-review", "custom-review", "rescue"]);
 const PREFLIGHT_MODES = Object.freeze(["review", "adversarial-review", "custom-review"]);
+const DEFAULT_KIMI_REVIEW_TIMEOUT_MS = 180000;
 
 configureState({
   pluginDataEnv: "KIMI_PLUGIN_DATA",
@@ -166,6 +167,15 @@ function invocationFromRecord(record) {
     binary: record.binary,
     started_at: record.started_at,
   };
+}
+
+function parsePositiveTimeoutMs(value, fallback) {
+  if (value === undefined || value === null || value === "") return fallback;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    fail("bad_args", `--timeout-ms must be a positive number of milliseconds; got ${JSON.stringify(value)}`);
+  }
+  return parsed;
 }
 
 function promptSidecarPath(workspaceRoot, jobId) {
@@ -311,7 +321,7 @@ function cmdPreflight(rest) {
 
 async function cmdRun(rest) {
   const { options, positionals } = parseArgs(rest, {
-    valueOptions: ["mode", "model", "cwd", "binary", "scope-base", "scope-paths", "override-dispose"],
+    valueOptions: ["mode", "model", "cwd", "binary", "scope-base", "scope-paths", "override-dispose", "timeout-ms"],
     booleanOptions: ["background", "foreground"],
   });
   const mode = options.mode;
@@ -338,6 +348,7 @@ async function cmdRun(rest) {
     return profile.dispose_default;
   })();
   const scopePaths = parseScopePathsOption(options["scope-paths"]);
+  const timeoutMs = parsePositiveTimeoutMs(options["timeout-ms"], DEFAULT_KIMI_REVIEW_TIMEOUT_MS);
 
   const jobId = newJobId();
   const invocation = Object.freeze({
@@ -358,6 +369,7 @@ async function cmdRun(rest) {
     prompt_head: prompt.slice(0, 200),
     schema_spec: null,
     binary: options.binary ?? process.env.KIMI_BINARY ?? "kimi",
+    timeout_ms: timeoutMs,
     started_at: new Date().toISOString(),
   });
 
@@ -469,6 +481,7 @@ async function executeRun(invocation, prompt, { foreground }) {
         cwd: neutralCwd ?? containment.path,
         binary: invocation.binary,
         resumeId,
+        timeoutMs: foreground ? invocation.timeout_ms : 0,
         onSpawn: (pidInfo) => {
           const runningRecord = buildJobRecord(attemptInvocation, {
             status: "running",
@@ -680,7 +693,7 @@ async function cmdRunWorker(rest) {
 
 async function cmdContinue(rest) {
   const { options, positionals } = parseArgs(rest, {
-    valueOptions: ["job", "cwd", "model", "binary"],
+    valueOptions: ["job", "cwd", "model", "binary", "timeout-ms"],
     booleanOptions: ["background", "foreground"],
   });
   if (!options.job) fail("bad_args", "--job <id> is required");
@@ -726,6 +739,7 @@ async function cmdContinue(rest) {
   const priorModeName = prior.mode_profile_name ?? prior.mode;
   const priorProfile = resolveProfile(priorModeName);
   const priorResumeChain = Array.isArray(prior.resume_chain) ? prior.resume_chain : [];
+  const timeoutMs = parsePositiveTimeoutMs(options["timeout-ms"], DEFAULT_KIMI_REVIEW_TIMEOUT_MS);
   const invocation = Object.freeze({
     job_id: newJobId_,
     target: "kimi",
@@ -744,6 +758,7 @@ async function cmdContinue(rest) {
     prompt_head: prompt.slice(0, 200),
     schema_spec: prior.schema_spec ?? null,
     binary: options.binary ?? process.env.KIMI_BINARY ?? "kimi",
+    timeout_ms: timeoutMs,
     started_at: new Date().toISOString(),
   });
 
@@ -852,6 +867,15 @@ function pingRateLimitedFields() {
   };
 }
 
+function pingTimeoutFields(timeoutMs) {
+  return {
+    ready: false,
+    summary: "Kimi Code CLI ping timed out before readiness could be confirmed.",
+    next_action: "Retry setup after a short wait. If it repeats, check Kimi service status or run `kimi` interactively.",
+    timeout_ms: timeoutMs,
+  };
+}
+
 function pingNotFoundFields() {
   return {
     ready: false,
@@ -903,6 +927,7 @@ async function cmdPing(rest) {
     ? [options.model]
     : resolveModelCandidatesForProfile(profile, modelsConfig);
   const candidates = modelCandidates.length > 0 ? modelCandidates : [model];
+  const timeoutMs = parsePositiveTimeoutMs(options["timeout-ms"], 30000);
   try {
     let execution = null;
     let selectedModel = model;
@@ -915,7 +940,7 @@ async function cmdPing(rest) {
         promptText: PING_PROMPT,
         cwd: "/tmp",
         binary: options.binary ?? process.env.KIMI_BINARY ?? "kimi",
-        timeoutMs: Number(options["timeout-ms"] ?? 30000),
+        timeoutMs,
       });
       if (
         execution.exitCode !== 0 &&
@@ -947,6 +972,10 @@ async function cmdPing(rest) {
       process.exit(0);
     }
     const detail = pingFailureDetail(execution);
+    if (execution?.timedOut === true) {
+      printJson({ status: "transient_timeout", ...pingTimeoutFields(timeoutMs), ...ignoredApiKeyAuthFields(), detail });
+      process.exit(2);
+    }
     if (/rate limit|429|overloaded/i.test(detail)) {
       printJson({ status: "rate_limited", ...pingRateLimitedFields(), ...ignoredApiKeyAuthFields(), detail });
       process.exit(2);

--- a/plugins/kimi/scripts/lib/job-record.mjs
+++ b/plugins/kimi/scripts/lib/job-record.mjs
@@ -226,6 +226,16 @@ function buildErrorDiagnostic(invocation, status, error_code, error_message) {
     suggested_action: null,
     disclosure_note: null,
   };
+  if (status === "failed" && error_code === "timeout") {
+    return {
+      error_summary: "Kimi Code CLI timed out before returning a review result.",
+      error_cause:
+        "The foreground Kimi process exceeded the configured timeout. This is usually provider latency, a cold start, or a stuck interactive CLI call rather than an OAuth failure.",
+      suggested_action:
+        "Retry the review after a short wait. If it repeats, check Kimi service status or run `kimi` interactively from a normal terminal.",
+      disclosure_note: null,
+    };
+  }
   if (status !== "failed" || error_code !== "scope_failed" || !error_message) {
     return empty;
   }

--- a/plugins/kimi/scripts/lib/job-record.mjs
+++ b/plugins/kimi/scripts/lib/job-record.mjs
@@ -226,13 +226,16 @@ function buildErrorDiagnostic(invocation, status, error_code, error_message) {
     suggested_action: null,
     disclosure_note: null,
   };
+  const target = targetDisplayName(invocation.target);
   if (status === "failed" && error_code === "timeout") {
     return {
-      error_summary: "Kimi Code CLI timed out before returning a review result.",
+      error_summary: `${target.displayName} Code CLI timed out before returning a review result.`,
       error_cause:
-        "The foreground Kimi process exceeded the configured timeout. This is usually provider latency, a cold start, or a stuck interactive CLI call rather than an OAuth failure.",
+        `The foreground ${target.displayName} process exceeded the configured timeout. ` +
+        "This is usually provider latency, a cold start, or a stuck interactive CLI call rather than an OAuth failure.",
       suggested_action:
-        "Retry the review after a short wait. If it repeats, check Kimi service status or run `kimi` interactively from a normal terminal.",
+        `Retry the review after a short wait. If it repeats, check ${target.displayName} ` +
+        `service status or run \`${target.binaryName}\` interactively from a normal terminal.`,
       disclosure_note: null,
     };
   }
@@ -241,9 +244,8 @@ function buildErrorDiagnostic(invocation, status, error_code, error_message) {
   }
 
   const message = String(error_message);
-  const target = invocation.target === "claude" ? "Claude" : "Kimi";
   const disclosure =
-    `Scope preparation failed before ${target} launch. The target CLI was not spawned, ` +
+    `Scope preparation failed before ${target.displayName} launch. The target CLI was not spawned, ` +
     "so rejected scope content was not sent to the target CLI or external provider. " +
     "Branch-diff reduces scope, but any successful external review still sends selected source content to the target provider.";
 
@@ -358,6 +360,11 @@ function buildErrorDiagnostic(invocation, status, error_code, error_message) {
       "Check the raw error_message, fix the scope input, and retry. For committed branch changes, prefer branch-diff with an explicit --scope-base <ref>.",
     disclosure_note: disclosure,
   };
+}
+
+function targetDisplayName(target) {
+  if (target === "claude") return { displayName: "Claude", binaryName: "claude" };
+  return { displayName: "Kimi", binaryName: "kimi" };
 }
 
 /**

--- a/tests/smoke/kimi-companion.smoke.test.mjs
+++ b/tests/smoke/kimi-companion.smoke.test.mjs
@@ -130,6 +130,26 @@ test("kimi ping classifies missing binary with readiness fields", () => {
   }
 });
 
+test("kimi ping classifies timeout as transient latency", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "kimi-ping-timeout-"));
+  try {
+    const result = runCompanion(["ping", "--timeout-ms", "20"], {
+      cwd,
+      env: { KIMI_MOCK_DELAY_MS: "200" },
+    });
+    assert.equal(result.status, 2);
+    const parsed = parseJson(result.stdout);
+    assert.equal(parsed.status, "transient_timeout");
+    assert.equal(parsed.ready, false);
+    assert.match(parsed.summary, /timed out/i);
+    assert.match(parsed.next_action, /Retry/);
+    assert.equal(parsed.timeout_ms, 20);
+    assert.match(parsed.detail, /configured timeoutMs/);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 for (const mode of ["review", "adversarial-review", "custom-review"]) {
   test(`kimi ${mode} prompt requires a self-contained final verdict`, () => withRepo((cwd) => {
     const result = runCompanion(kimiPromptAssertionArgs(cwd, mode), {
@@ -151,6 +171,34 @@ for (const mode of ["review", "adversarial-review", "custom-review"]) {
     assert.equal(result.status, 0, result.stderr);
   }));
 }
+
+test("kimi foreground review timeout returns actionable JobRecord", () => withRepo((cwd) => {
+  const result = runCompanion([
+    "run",
+    "--mode",
+    "custom-review",
+    "--cwd",
+    cwd,
+    "--scope-paths",
+    "seed.txt",
+    "--foreground",
+    "--timeout-ms",
+    "20",
+    "--",
+    "Review this scope.",
+  ], { cwd, env: { KIMI_MOCK_DELAY_MS: "200" } });
+  assert.equal(result.status, 2);
+  const record = parseJson(result.stdout);
+  assert.equal(record.target, "kimi");
+  assert.equal(record.mode, "custom-review");
+  assert.equal(record.status, "failed");
+  assert.equal(record.error_code, "timeout");
+  assert.match(record.error_summary, /timed out/i);
+  assert.match(record.suggested_action, /retry/i);
+  const { record: persisted } = readOnlyJobRecord(result.dataDir);
+  assert.equal(persisted.job_id, record.job_id);
+  assert.equal(persisted.error_code, "timeout");
+}));
 
 test("kimi preflight success and bad_args emit safety fields", () => withRepo((cwd) => {
   const ok = runCompanion(["preflight", "--mode", "review", "--cwd", cwd], { cwd });

--- a/tests/unit/job-record.test.mjs
+++ b/tests/unit/job-record.test.mjs
@@ -20,6 +20,9 @@ import {
   buildJobRecord as buildGeminiJobRecord,
   SCHEMA_VERSION as GEMINI_SCHEMA_VERSION,
 } from "../../plugins/gemini/scripts/lib/job-record.mjs";
+import {
+  buildJobRecord as buildKimiJobRecord,
+} from "../../plugins/kimi/scripts/lib/job-record.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const SKILL_MD = resolvePath(HERE, "..", "..",
@@ -563,6 +566,24 @@ test("buildJobRecord: timedOut wins over signal (timeout, not cancelled)", () =>
   assert.equal(rec.status, "failed",
     "wall-clock timeouts must classify as failed/timeout, not cancelled");
   assert.equal(rec.error_code, "timeout");
+});
+
+test("kimi buildJobRecord: timeout diagnostics use invocation target display name", () => {
+  const rec = buildKimiJobRecord(makeInvocation({ target: "claude", binary: "claude" }), {
+    exitCode: null,
+    signal: "SIGTERM",
+    timedOut: true,
+    parsed: { ok: false, reason: "empty_stdout", result: null,
+      structured: null, denials: [] },
+    pidInfo: makePidInfo(),
+    kimiSessionId: null,
+  }, []);
+  assert.equal(rec.status, "failed");
+  assert.equal(rec.error_code, "timeout");
+  assert.match(rec.error_summary, /^Claude Code CLI timed out/);
+  assert.match(rec.error_cause, /foreground Claude process/);
+  assert.match(rec.suggested_action, /check Claude service status/);
+  assert.match(rec.suggested_action, /run `claude` interactively/);
 });
 
 test("gemini buildJobRecord: signal-driven exit classifies as cancelled", () => {


### PR DESCRIPTION
## Summary

- Classify Kimi `doctor`/`ping` timeout as `transient_timeout` with actionable retry/service-status guidance instead of a generic error.
- Add a default bounded foreground Kimi review timeout with `--timeout-ms` override for `run` and `continue` foreground paths.
- Surface timeout failures in Kimi JobRecords with clear `error_summary`, `error_cause`, and `suggested_action` fields.
- Use the invocation target display/binary name in Kimi timeout diagnostics so Claude-targeted paths do not report Kimi-specific wording.

Fixes #41.

## Verification

- RED: `npm run smoke:kimi` failed on the new ping timeout and foreground timeout JobRecord tests before implementation.
- RED: `node --test --test-reporter=spec tests/unit/job-record.test.mjs` failed on the new dynamic-target timeout diagnostic regression before the diagnostic fix.
- GREEN: `node --test --test-reporter=spec tests/unit/job-record.test.mjs` passed, 44/44.
- GREEN: `npm run smoke:kimi` passed, 14/14.
- `git diff --check`
- `npm run lint`
- `npm test` passed, 585 pass / 6 skipped.
- Pre-commit `npm test` reran and passed, 585 pass / 6 skipped; commit used `--no-verify` afterward only because the local external `/audit` gate would disclose repo content and the maintainer explicitly rejected that path.

## Review Status

- Gemini Code Assist dynamic-target diagnostic comment addressed in `1b1b559` and resolved.
- Greptile `timeout_ms` JobRecord comments were verified against the canonical JobRecord schema and resolved as inapplicable: `timeout_ms` is not a persisted JobRecord field, and adding it only for Kimi would create schema drift.
- Latest pushed head: `1b1b559fe8d29f99cb3f0987796b3319c9b2bb35`.