### PR TITLE
[codex] collect post-merge review fix-forwards

### DIFF
--- a/plugins/kimi/scripts/kimi-companion.mjs
+++ b/plugins/kimi/scripts/kimi-companion.mjs
@@ -172,7 +172,7 @@ function invocationFromRecord(record) {
 function parsePositiveTimeoutMs(value, fallback) {
   if (value === undefined || value === null || value === "") return fallback;
   const parsed = Number(value);
-  if (!Number.isFinite(parsed) || parsed <= 0 || !Number.isInteger(parsed)) {
+  if (parsed <= 0 || !Number.isInteger(parsed)) {
     fail("bad_args", `--timeout-ms must be a positive integer number of milliseconds; got ${JSON.stringify(value)}`);
   }
   return parsed;

--- a/plugins/kimi/scripts/kimi-companion.mjs
+++ b/plugins/kimi/scripts/kimi-companion.mjs
@@ -172,8 +172,8 @@ function invocationFromRecord(record) {
 function parsePositiveTimeoutMs(value, fallback) {
   if (value === undefined || value === null || value === "") return fallback;
   const parsed = Number(value);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    fail("bad_args", `--timeout-ms must be a positive number of milliseconds; got ${JSON.stringify(value)}`);
+  if (!Number.isFinite(parsed) || parsed <= 0 || !Number.isInteger(parsed)) {
+    fail("bad_args", `--timeout-ms must be a positive integer number of milliseconds; got ${JSON.stringify(value)}`);
   }
   return parsed;
 }

--- a/tests/smoke/kimi-companion.smoke.test.mjs
+++ b/tests/smoke/kimi-companion.smoke.test.mjs
@@ -150,6 +150,19 @@ test("kimi ping classifies timeout as transient latency", () => {
   }
 });
 
+test("kimi ping rejects fractional timeout milliseconds", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "kimi-ping-timeout-fraction-"));
+  try {
+    const result = runCompanion(["ping", "--timeout-ms", "0.5"], { cwd });
+    assert.equal(result.status, 1);
+    const parsed = parseJson(result.stdout);
+    assert.equal(parsed.error, "bad_args");
+    assert.match(parsed.message, /positive integer number of milliseconds/);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 for (const mode of ["review", "adversarial-review", "custom-review"]) {
   test(`kimi ${mode} prompt requires a self-contained final verdict`, () => withRepo((cwd) => {
     const result = runCompanion(kimiPromptAssertionArgs(cwd, mode), {

--- a/tests/smoke/kimi-companion.smoke.test.mjs
+++ b/tests/smoke/kimi-companion.smoke.test.mjs
@@ -206,8 +206,9 @@ test("kimi foreground review timeout returns actionable JobRecord", () => withRe
   assert.equal(record.mode, "custom-review");
   assert.equal(record.status, "failed");
   assert.equal(record.error_code, "timeout");
-  assert.match(record.error_summary, /timed out/i);
+  assert.match(record.error_summary, /^Kimi Code CLI timed out/);
   assert.match(record.suggested_action, /retry/i);
+  assert.match(record.suggested_action, /run `kimi` interactively/);
   const { record: persisted } = readOnlyJobRecord(result.dataDir);
   assert.equal(persisted.job_id, record.job_id);
   assert.equal(persisted.error_code, "timeout");

--- a/tests/unit/job-record.test.mjs
+++ b/tests/unit/job-record.test.mjs
@@ -568,8 +568,8 @@ test("buildJobRecord: timedOut wins over signal (timeout, not cancelled)", () =>
   assert.equal(rec.error_code, "timeout");
 });
 
-test("kimi buildJobRecord: timeout diagnostics use invocation target display name", () => {
-  const kimi = buildKimiJobRecord(makeInvocation({ target: "kimi", binary: "kimi" }), {
+test("kimi buildJobRecord: timeout diagnostics use Kimi target display name", () => {
+  const rec = buildKimiJobRecord(makeInvocation({ target: "kimi", binary: "kimi" }), {
     exitCode: null,
     signal: "SIGTERM",
     timedOut: true,
@@ -578,14 +578,16 @@ test("kimi buildJobRecord: timeout diagnostics use invocation target display nam
     pidInfo: makePidInfo(),
     kimiSessionId: null,
   }, []);
-  assert.equal(kimi.status, "failed");
-  assert.equal(kimi.error_code, "timeout");
-  assert.match(kimi.error_summary, /^Kimi Code CLI timed out/);
-  assert.match(kimi.error_cause, /foreground Kimi process/);
-  assert.match(kimi.suggested_action, /check Kimi service status/);
-  assert.match(kimi.suggested_action, /run `kimi` interactively/);
+  assert.equal(rec.status, "failed");
+  assert.equal(rec.error_code, "timeout");
+  assert.match(rec.error_summary, /^Kimi Code CLI timed out/);
+  assert.match(rec.error_cause, /foreground Kimi process/);
+  assert.match(rec.suggested_action, /check Kimi service status/);
+  assert.match(rec.suggested_action, /run `kimi` interactively/);
+});
 
-  const claude = buildKimiJobRecord(makeInvocation({ target: "claude", binary: "claude" }), {
+test("kimi buildJobRecord: timeout diagnostics use Claude target display name", () => {
+  const rec = buildKimiJobRecord(makeInvocation({ target: "claude", binary: "claude" }), {
     exitCode: null,
     signal: "SIGTERM",
     timedOut: true,
@@ -594,12 +596,12 @@ test("kimi buildJobRecord: timeout diagnostics use invocation target display nam
     pidInfo: makePidInfo(),
     kimiSessionId: null,
   }, []);
-  assert.equal(claude.status, "failed");
-  assert.equal(claude.error_code, "timeout");
-  assert.match(claude.error_summary, /^Claude Code CLI timed out/);
-  assert.match(claude.error_cause, /foreground Claude process/);
-  assert.match(claude.suggested_action, /check Claude service status/);
-  assert.match(claude.suggested_action, /run `claude` interactively/);
+  assert.equal(rec.status, "failed");
+  assert.equal(rec.error_code, "timeout");
+  assert.match(rec.error_summary, /^Claude Code CLI timed out/);
+  assert.match(rec.error_cause, /foreground Claude process/);
+  assert.match(rec.suggested_action, /check Claude service status/);
+  assert.match(rec.suggested_action, /run `claude` interactively/);
 });
 
 test("gemini buildJobRecord: signal-driven exit classifies as cancelled", () => {

--- a/tests/unit/job-record.test.mjs
+++ b/tests/unit/job-record.test.mjs
@@ -569,7 +569,7 @@ test("buildJobRecord: timedOut wins over signal (timeout, not cancelled)", () =>
 });
 
 test("kimi buildJobRecord: timeout diagnostics use invocation target display name", () => {
-  const rec = buildKimiJobRecord(makeInvocation({ target: "claude", binary: "claude" }), {
+  const kimi = buildKimiJobRecord(makeInvocation({ target: "kimi", binary: "kimi" }), {
     exitCode: null,
     signal: "SIGTERM",
     timedOut: true,
@@ -578,12 +578,28 @@ test("kimi buildJobRecord: timeout diagnostics use invocation target display nam
     pidInfo: makePidInfo(),
     kimiSessionId: null,
   }, []);
-  assert.equal(rec.status, "failed");
-  assert.equal(rec.error_code, "timeout");
-  assert.match(rec.error_summary, /^Claude Code CLI timed out/);
-  assert.match(rec.error_cause, /foreground Claude process/);
-  assert.match(rec.suggested_action, /check Claude service status/);
-  assert.match(rec.suggested_action, /run `claude` interactively/);
+  assert.equal(kimi.status, "failed");
+  assert.equal(kimi.error_code, "timeout");
+  assert.match(kimi.error_summary, /^Kimi Code CLI timed out/);
+  assert.match(kimi.error_cause, /foreground Kimi process/);
+  assert.match(kimi.suggested_action, /check Kimi service status/);
+  assert.match(kimi.suggested_action, /run `kimi` interactively/);
+
+  const claude = buildKimiJobRecord(makeInvocation({ target: "claude", binary: "claude" }), {
+    exitCode: null,
+    signal: "SIGTERM",
+    timedOut: true,
+    parsed: { ok: false, reason: "empty_stdout", result: null,
+      structured: null, denials: [] },
+    pidInfo: makePidInfo(),
+    kimiSessionId: null,
+  }, []);
+  assert.equal(claude.status, "failed");
+  assert.equal(claude.error_code, "timeout");
+  assert.match(claude.error_summary, /^Claude Code CLI timed out/);
+  assert.match(claude.error_cause, /foreground Claude process/);
+  assert.match(claude.suggested_action, /check Claude service status/);
+  assert.match(claude.suggested_action, /run `claude` interactively/);
 });
 
 test("gemini buildJobRecord: signal-driven exit classifies as cancelled", () => {


### PR DESCRIPTION
## Summary

- Reject fractional `--timeout-ms` values for Kimi commands by requiring positive integer milliseconds.
- Pin Kimi timeout diagnostic wording in smoke/unit coverage so Kimi-targeted paths assert `Kimi Code CLI` and the interactive `kimi` retry hint.
- Apply low-risk review polish: split Kimi/Claude timeout diagnostic unit cases and remove the redundant finite check from timeout parsing.

## Commit Structure

- `538aa30` fixes fractional timeout validation.
- `12a63e8` adds explicit Kimi timeout diagnostic wording coverage.
- `1a363e5` applies low cosmetic review polish from the PR #48 external review pass.

## Verification

- RED: `npm run smoke:kimi` failed on fractional `--timeout-ms 0.5` before the validation fix.
- GREEN: `npm run smoke:kimi` passed, 15/15.
- GREEN: `node --test --test-reporter=spec tests/unit/job-record.test.mjs` passed, 45/45.
- `git diff --check`
- `npm run lint`
- `npm test` passed, 586 pass / 6 skipped.

## Review Status

External reviews on the prior head reported PASS. The only low cosmetic items called out by Claude were addressed in `1a363e5`. This remains a draft PR for collecting fix-forward commits; do not merge until explicitly approved.