### PR TITLE
[codex] classify Kimi step-limit failures

### DIFF
--- a/docs/superpowers/specs/2026-04-23-codex-plugin-multi-design.md
+++ b/docs/superpowers/specs/2026-04-23-codex-plugin-multi-design.md
@@ -826,7 +826,7 @@ These are the rules M7+ code is judged against. Each invariant names a class of 
 | Field | Owner | Lifetime | Source |
 |---|---|---|---|
 | `job_id` | companion | per invocation | `randomUUID()` in companion |
-| `claude_session_id` (or `gemini_session_id`) | target CLI | per CLI session | **read from CLI stdout `parsed.session_id`**, not minted by companion |
+| `claude_session_id` (or `gemini_session_id` / `kimi_session_id`) | target CLI | per CLI session | **read from CLI stdout `parsed.session_id`**, not minted by companion |
 | `resume_chain[]` | companion | across `continue` calls | list of prior `*_session_id`s, newest-last |
 | `pid_info = {pid, starttime, argv0}` | OS | while process lives | `ps`/`/proc` at spawn time |
 
@@ -839,7 +839,7 @@ These are the rules M7+ code is judged against. Each invariant names a class of 
 **Required patterns:**
 
 - On `run`: companion generates `job_id`, passes `job_id` to Claude as `--session-id` for a new session, then records `claude_session_id = parsed.session_id` (Claude echoes it back). When Claude creates its own session ID without input, the record stores what Claude returned — never what the companion sent.
-- On `continue`: companion generates a fresh `job_id`, looks up the prior target session ID (`claude_session_id` or `gemini_session_id`) as the `--resume` UUID, appends it to the new record's `resume_chain`, records the new target session ID from stdout after the run.
+- On `continue`: companion generates a fresh `job_id`, looks up the prior target session ID (`claude_session_id`, `gemini_session_id`, or `kimi_session_id`) as the `--resume` UUID, appends it to the new record's `resume_chain`, records the new target session ID from stdout after the run.
 - On `cancel`: read `pid_info` tuple, re-verify `starttime` + `argv0` match before signaling. Mismatch → refuse with `stale_pid` error.
 
 **Why:** Finding #6 (chained continue breaks), #7 (PID-reuse kill), parts of #3 (result lost) all trace to identity conflation. The type rule makes the mistake unrepresentable.
@@ -897,12 +897,12 @@ ModeProfile {
 
 **Rule:** exactly one schema describes everything the companion durably persists about one invocation. The same schema is what `cmdResult` returns, what the `run --foreground` stdout prints (success path), and what the Claude result-handling skill and Gemini result command docs describe.
 
-**The schema (v7):**
+**The schema (v8):**
 
 ```
 JobRecord {
   // Identity (§21.1) — required
-  job_id, target, claude_session_id | gemini_session_id
+  job_id, target, claude_session_id | gemini_session_id | kimi_session_id
   parent_job_id?, resume_chain[]?
   pid_info? = { pid, starttime, argv0 }
 
@@ -927,7 +927,7 @@ JobRecord {
   cost_usd?, usage?
 
   // Bookkeeping — required
-  schema_version: 7
+  schema_version: 8
 }
 ```
 

--- a/plugins/claude/scripts/lib/job-record.mjs
+++ b/plugins/claude/scripts/lib/job-record.mjs
@@ -21,7 +21,7 @@
 // - Schema drift is a test failure (job-record.test.mjs asserts on keys AND
 //   on claude-result-handling/SKILL.md mentioning each field).
 
-export const SCHEMA_VERSION = 7;
+export const SCHEMA_VERSION = 8;
 
 /**
  * Canonical JobRecord field list. Exported so tests can reference it and
@@ -36,6 +36,7 @@ export const EXPECTED_KEYS = Object.freeze([
   "parent_job_id",
   "claude_session_id",
   "gemini_session_id",
+  "kimi_session_id",
   "resume_chain",
   "pid_info",
 
@@ -422,6 +423,7 @@ export function buildJobRecord(invocation, execution, mutations) {
     parent_job_id: invocation.parent_job_id ?? null,
     claude_session_id: execution?.claudeSessionId ?? null,
     gemini_session_id: execution?.geminiSessionId ?? null,
+    kimi_session_id: execution?.kimiSessionId ?? null,
     resume_chain: Array.isArray(invocation.resume_chain)
       ? [...invocation.resume_chain]
       : [],

--- a/plugins/claude/skills/claude-result-handling/SKILL.md
+++ b/plugins/claude/skills/claude-result-handling/SKILL.md
@@ -13,7 +13,7 @@ The companion returns the SAME JSON shape from three entry points — foreground
 (spec §21.3). Nothing is hand-assembled in memory; what goes to disk is what
 comes back to you.
 
-## Success path — JobRecord schema (v7)
+## Success path — JobRecord schema (v8)
 
 ```json
 {
@@ -23,6 +23,7 @@ comes back to you.
   "parent_job_id":       null | "<uuid>",   // set by `continue`; null on fresh runs
   "claude_session_id":   null | "<uuid>",   // from Claude's stdout, not minted
   "gemini_session_id":   null,              // present for schema parity; Gemini uses it
+  "kimi_session_id":     null,              // present for schema parity; Kimi uses it
   "resume_chain":        ["<uuid>", ...],   // newest-last; [] on first run
   "pid_info":            null | { "pid": N, "starttime": "...", "argv0": "..." },
 
@@ -59,7 +60,7 @@ comes back to you.
   "cost_usd":            null | 0.001,
   "usage":               null | { "input_tokens": N, ... },
 
-  "schema_version":      7
+  "schema_version":      8
 }
 ```
 

--- a/plugins/gemini/scripts/lib/job-record.mjs
+++ b/plugins/gemini/scripts/lib/job-record.mjs
@@ -21,7 +21,7 @@
 // - Schema drift is a test failure (job-record.test.mjs asserts on keys AND
 //   on claude-result-handling/SKILL.md mentioning each field).
 
-export const SCHEMA_VERSION = 7;
+export const SCHEMA_VERSION = 8;
 
 /**
  * Canonical JobRecord field list. Exported so tests can reference it and
@@ -36,6 +36,7 @@ export const EXPECTED_KEYS = Object.freeze([
   "parent_job_id",
   "claude_session_id",
   "gemini_session_id",
+  "kimi_session_id",
   "resume_chain",
   "pid_info",
 
@@ -418,6 +419,7 @@ export function buildJobRecord(invocation, execution, mutations) {
     parent_job_id: invocation.parent_job_id ?? null,
     claude_session_id: execution?.claudeSessionId ?? null,
     gemini_session_id: execution?.geminiSessionId ?? null,
+    kimi_session_id: execution?.kimiSessionId ?? null,
     resume_chain: Array.isArray(invocation.resume_chain)
       ? [...invocation.resume_chain]
       : [],

--- a/plugins/kimi/commands/kimi-adversarial-review.md
+++ b/plugins/kimi/commands/kimi-adversarial-review.md
@@ -1,19 +1,19 @@
 ---
 description: Get Kimi Code CLI to adversarially challenge the current design under read-only policy.
-argument-hint: "[--scope-base <ref>] [focus area]"
+argument-hint: "[--scope-base <ref>] [--max-steps-per-turn <n>] [focus area]"
 ---
 
 Adversarial review via Kimi Code CLI. Assumes the author is wrong; looks for failure modes, hidden assumptions, and missing edge cases.
 
 ## Arguments
 
-`$ARGUMENTS` — optional `--scope-base <ref>` followed by focus text. If present, pass `--scope-base <ref>` before `--`; pass the remaining focus text after `--`.
+`$ARGUMENTS` — optional `--scope-base <ref>` and `--max-steps-per-turn <n>` followed by focus text. If present, pass those flags before `--`; pass the remaining focus text after `--`.
 
 ## Workflow
 
 Run:
 ```
-node "<plugin-root>/scripts/kimi-companion.mjs" run --mode=adversarial-review --foreground [--scope-base <ref>] -- "<focus text>"
+node "<plugin-root>/scripts/kimi-companion.mjs" run --mode=adversarial-review --foreground [--scope-base <ref>] [--max-steps-per-turn <n>] -- "<focus text>"
 ```
 `branch-diff` is object-pure: checkout filters, replace refs, and grafts are ignored.
 It reduces the selected review scope, but a successful run still sends those

--- a/plugins/kimi/commands/kimi-review.md
+++ b/plugins/kimi/commands/kimi-review.md
@@ -1,19 +1,19 @@
 ---
 description: Get Kimi Code CLI's read-only review of the current diff, files, or focus area.
-argument-hint: "[--scope-base <ref>] [focus area]"
+argument-hint: "[--scope-base <ref>] [--max-steps-per-turn <n>] [focus area]"
 ---
 
 Review via Kimi Code CLI. Runs in Kimi plan mode over disposable scoped input; changes are detected post-hoc and never auto-reverted.
 
 ## Arguments
 
-`$ARGUMENTS` — optional `--scope-base <ref>` followed by focus text. If present, pass `--scope-base <ref>` before `--`; pass the remaining focus text after `--`.
+`$ARGUMENTS` — optional `--scope-base <ref>` and `--max-steps-per-turn <n>` followed by focus text. If present, pass those flags before `--`; pass the remaining focus text after `--`.
 
 ## Workflow
 
 Run:
 ```
-node "<plugin-root>/scripts/kimi-companion.mjs" run --mode=review --foreground [--scope-base <ref>] -- "<focus text>"
+node "<plugin-root>/scripts/kimi-companion.mjs" run --mode=review --foreground [--scope-base <ref>] [--max-steps-per-turn <n>] -- "<focus text>"
 ```
 
 For a pinned review bundle or selected files, first run `preflight`, then use

--- a/plugins/kimi/scripts/kimi-companion.mjs
+++ b/plugins/kimi/scripts/kimi-companion.mjs
@@ -146,7 +146,56 @@ function gitStatusLines(output) {
   return output.split("\n").map((line) => line.trimEnd()).filter((line) => line.length > 0);
 }
 
-function invocationFromRecord(record) {
+function runtimeOptionsSidecarPath(workspaceRoot, jobId) {
+  return `${resolveJobsDir(workspaceRoot)}/${jobId}.runtime-options`;
+}
+
+function runtimeOptionsForRecord(record, runtimeOptions = {}) {
+  const profile = resolveProfile(record.mode_profile_name ?? record.mode);
+  return {
+    max_steps_per_turn:
+      runtimeOptions.max_steps_per_turn ??
+      profile.max_steps_per_turn ??
+      8,
+  };
+}
+
+function writeRuntimeOptionsSidecar(workspaceRoot, jobId, options) {
+  const dir = resolveJobsDir(workspaceRoot);
+  mkdirSync(dir, { recursive: true });
+  const file = runtimeOptionsSidecarPath(workspaceRoot, jobId);
+  const tmpFile = `${file}.${process.pid}.${Date.now()}.tmp`;
+  const payload = {
+    max_steps_per_turn: options.max_steps_per_turn,
+  };
+  try {
+    writeFileSync(tmpFile, `${JSON.stringify(payload, null, 2)}\n`, { mode: 0o600, encoding: "utf8" });
+    try { chmodSync(tmpFile, 0o600); } catch { /* best-effort on non-POSIX */ }
+    renameSync(tmpFile, file);
+    try { chmodSync(file, 0o600); } catch { /* best-effort on non-POSIX */ }
+  } catch (e) {
+    try { unlinkSync(tmpFile); } catch { /* already gone */ }
+    throw e;
+  }
+}
+
+function readRuntimeOptionsSidecar(workspaceRoot, jobId) {
+  const file = runtimeOptionsSidecarPath(workspaceRoot, jobId);
+  if (!existsSync(file)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(file, "utf8"));
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    const maxSteps = parsed.max_steps_per_turn;
+    return Number.isInteger(maxSteps) && maxSteps > 0
+      ? { max_steps_per_turn: maxSteps }
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function invocationFromRecord(record, runtimeOptions = {}) {
+  const resolvedRuntimeOptions = runtimeOptionsForRecord(record, runtimeOptions);
   return {
     job_id: record.job_id,
     target: record.target,
@@ -165,7 +214,7 @@ function invocationFromRecord(record) {
     prompt_head: record.prompt_head,
     schema_spec: record.schema_spec ?? null,
     binary: record.binary,
-    max_steps_per_turn: record.max_steps_per_turn ?? null,
+    max_steps_per_turn: resolvedRuntimeOptions.max_steps_per_turn,
     started_at: record.started_at,
   };
 }
@@ -389,6 +438,7 @@ async function cmdRun(rest) {
   });
 
   const queuedRecord = buildJobRecord(invocation, null, []);
+  writeRuntimeOptionsSidecar(workspaceRoot, jobId, { max_steps_per_turn: maxStepsPerTurn });
   writeJobFile(workspaceRoot, jobId, queuedRecord);
   upsertJob(workspaceRoot, queuedRecord);
   const targetPrompt = targetPromptFor(profile, prompt);
@@ -683,7 +733,8 @@ async function cmdRunWorker(rest) {
   // call, side effects) and only the post-run consumer at executeRun would
   // convert "completed" → "cancelled".
   if (consumeCancelMarker(workspaceRoot, options.job)) {
-    const cancelledRecord = buildJobRecord(invocationFromRecord(meta), {
+    const runtimeOptions = readRuntimeOptionsSidecar(workspaceRoot, options.job);
+    const cancelledRecord = buildJobRecord(invocationFromRecord(meta, runtimeOptions), {
       status: "cancelled",
       exitCode: null, parsed: null, pidInfo: null, kimiSessionId: null,
     }, []);
@@ -703,7 +754,8 @@ async function cmdRunWorker(rest) {
     fail("bad_state", "prompt sidecar missing for job " + options.job);
   }
 
-  const invocation = invocationFromRecord(meta);
+  const runtimeOptions = readRuntimeOptionsSidecar(workspaceRoot, options.job);
+  const invocation = invocationFromRecord(meta, runtimeOptions);
   await executeRun(invocation, prompt, { foreground: false });
 }
 
@@ -755,10 +807,11 @@ async function cmdContinue(rest) {
   const priorModeName = prior.mode_profile_name ?? prior.mode;
   const priorProfile = resolveProfile(priorModeName);
   const priorResumeChain = Array.isArray(prior.resume_chain) ? prior.resume_chain : [];
+  const priorRuntimeOptions = readRuntimeOptionsSidecar(workspaceRoot, options.job);
   const timeoutMs = parsePositiveTimeoutMs(options["timeout-ms"], DEFAULT_KIMI_REVIEW_TIMEOUT_MS);
   const maxStepsPerTurn = parsePositiveMaxStepsPerTurn(
     options["max-steps-per-turn"],
-    prior.max_steps_per_turn ?? priorProfile.max_steps_per_turn ?? 8,
+    priorRuntimeOptions.max_steps_per_turn ?? priorProfile.max_steps_per_turn ?? 8,
   );
   const invocation = Object.freeze({
     job_id: newJobId_,
@@ -784,6 +837,7 @@ async function cmdContinue(rest) {
   });
 
   const queuedRecord = buildJobRecord(invocation, null, []);
+  writeRuntimeOptionsSidecar(workspaceRoot, newJobId_, { max_steps_per_turn: maxStepsPerTurn });
   writeJobFile(workspaceRoot, newJobId_, queuedRecord);
   upsertJob(workspaceRoot, queuedRecord);
   const targetPrompt = targetPromptFor(priorProfile, prompt);

--- a/plugins/kimi/scripts/kimi-companion.mjs
+++ b/plugins/kimi/scripts/kimi-companion.mjs
@@ -165,6 +165,7 @@ function invocationFromRecord(record) {
     prompt_head: record.prompt_head,
     schema_spec: record.schema_spec ?? null,
     binary: record.binary,
+    max_steps_per_turn: record.max_steps_per_turn ?? null,
     started_at: record.started_at,
   };
 }
@@ -174,6 +175,15 @@ function parsePositiveTimeoutMs(value, fallback) {
   const parsed = Number(value);
   if (parsed <= 0 || !Number.isInteger(parsed)) {
     fail("bad_args", `--timeout-ms must be a positive integer number of milliseconds; got ${JSON.stringify(value)}`);
+  }
+  return parsed;
+}
+
+function parsePositiveMaxStepsPerTurn(value, fallback) {
+  if (value === undefined || value === null || value === "") return fallback;
+  const parsed = Number(value);
+  if (parsed <= 0 || !Number.isInteger(parsed)) {
+    fail("bad_args", `--max-steps-per-turn must be a positive integer; got ${JSON.stringify(value)}`);
   }
   return parsed;
 }
@@ -321,7 +331,7 @@ function cmdPreflight(rest) {
 
 async function cmdRun(rest) {
   const { options, positionals } = parseArgs(rest, {
-    valueOptions: ["mode", "model", "cwd", "binary", "scope-base", "scope-paths", "override-dispose", "timeout-ms"],
+    valueOptions: ["mode", "model", "cwd", "binary", "scope-base", "scope-paths", "override-dispose", "timeout-ms", "max-steps-per-turn"],
     booleanOptions: ["background", "foreground"],
   });
   const mode = options.mode;
@@ -349,6 +359,10 @@ async function cmdRun(rest) {
   })();
   const scopePaths = parseScopePathsOption(options["scope-paths"]);
   const timeoutMs = parsePositiveTimeoutMs(options["timeout-ms"], DEFAULT_KIMI_REVIEW_TIMEOUT_MS);
+  const maxStepsPerTurn = parsePositiveMaxStepsPerTurn(
+    options["max-steps-per-turn"],
+    profile.max_steps_per_turn ?? 8,
+  );
 
   const jobId = newJobId();
   const invocation = Object.freeze({
@@ -370,6 +384,7 @@ async function cmdRun(rest) {
     schema_spec: null,
     binary: options.binary ?? process.env.KIMI_BINARY ?? "kimi",
     timeout_ms: timeoutMs,
+    max_steps_per_turn: maxStepsPerTurn,
     started_at: new Date().toISOString(),
   });
 
@@ -482,6 +497,7 @@ async function executeRun(invocation, prompt, { foreground }) {
         binary: invocation.binary,
         resumeId,
         timeoutMs: foreground ? invocation.timeout_ms : 0,
+        maxStepsPerTurn: invocation.max_steps_per_turn,
         onSpawn: (pidInfo) => {
           const runningRecord = buildJobRecord(attemptInvocation, {
             status: "running",
@@ -693,7 +709,7 @@ async function cmdRunWorker(rest) {
 
 async function cmdContinue(rest) {
   const { options, positionals } = parseArgs(rest, {
-    valueOptions: ["job", "cwd", "model", "binary", "timeout-ms"],
+    valueOptions: ["job", "cwd", "model", "binary", "timeout-ms", "max-steps-per-turn"],
     booleanOptions: ["background", "foreground"],
   });
   if (!options.job) fail("bad_args", "--job <id> is required");
@@ -740,6 +756,10 @@ async function cmdContinue(rest) {
   const priorProfile = resolveProfile(priorModeName);
   const priorResumeChain = Array.isArray(prior.resume_chain) ? prior.resume_chain : [];
   const timeoutMs = parsePositiveTimeoutMs(options["timeout-ms"], DEFAULT_KIMI_REVIEW_TIMEOUT_MS);
+  const maxStepsPerTurn = parsePositiveMaxStepsPerTurn(
+    options["max-steps-per-turn"],
+    prior.max_steps_per_turn ?? priorProfile.max_steps_per_turn ?? 8,
+  );
   const invocation = Object.freeze({
     job_id: newJobId_,
     target: "kimi",
@@ -759,6 +779,7 @@ async function cmdContinue(rest) {
     schema_spec: prior.schema_spec ?? null,
     binary: options.binary ?? process.env.KIMI_BINARY ?? "kimi",
     timeout_ms: timeoutMs,
+    max_steps_per_turn: maxStepsPerTurn,
     started_at: new Date().toISOString(),
   });
 

--- a/plugins/kimi/scripts/kimi-companion.mjs
+++ b/plugins/kimi/scripts/kimi-companion.mjs
@@ -147,7 +147,7 @@ function gitStatusLines(output) {
 }
 
 function runtimeOptionsSidecarPath(workspaceRoot, jobId) {
-  return `${resolveJobsDir(workspaceRoot)}/${jobId}.runtime-options`;
+  return `${resolveJobsDir(workspaceRoot)}/${jobId}/runtime-options.json`;
 }
 
 function runtimeOptionsForRecord(record, runtimeOptions = {}) {
@@ -161,7 +161,7 @@ function runtimeOptionsForRecord(record, runtimeOptions = {}) {
 }
 
 function writeRuntimeOptionsSidecar(workspaceRoot, jobId, options) {
-  const dir = resolveJobsDir(workspaceRoot);
+  const dir = `${resolveJobsDir(workspaceRoot)}/${jobId}`;
   mkdirSync(dir, { recursive: true });
   const file = runtimeOptionsSidecarPath(workspaceRoot, jobId);
   const tmpFile = `${file}.${process.pid}.${Date.now()}.tmp`;
@@ -172,7 +172,6 @@ function writeRuntimeOptionsSidecar(workspaceRoot, jobId, options) {
     writeFileSync(tmpFile, `${JSON.stringify(payload, null, 2)}\n`, { mode: 0o600, encoding: "utf8" });
     try { chmodSync(tmpFile, 0o600); } catch { /* best-effort on non-POSIX */ }
     renameSync(tmpFile, file);
-    try { chmodSync(file, 0o600); } catch { /* best-effort on non-POSIX */ }
   } catch (e) {
     try { unlinkSync(tmpFile); } catch { /* already gone */ }
     throw e;

--- a/plugins/kimi/scripts/lib/job-record.mjs
+++ b/plugins/kimi/scripts/lib/job-record.mjs
@@ -53,6 +53,7 @@ export const EXPECTED_KEYS = Object.freeze([
   "prompt_head",
   "schema_spec",
   "binary",
+  "max_steps_per_turn",
 
   // Lifecycle
   "status",
@@ -99,6 +100,7 @@ const EXPECTED_KEYS_SET = new Set(EXPECTED_KEYS);
  *                         Distinguished from spawn_failed so monitoring/automation
  *                         routing on error_code doesn't conflate disk/lock failures
  *                         with missing-binary errors. PR #21 review HIGH 1.
+ *   step_limit_exceeded — Kimi emitted its non-JSON max-step exhaustion sentinel.
  *   parse_error     — parsed.ok === false with reason starting "json_parse"/"empty_stdout".
  *   timeout         — execution.timedOut === true (companion's wall-clock kill).
  *   kimi_error    — exitCode !== 0 with parseable JSON from Kimi.
@@ -183,6 +185,13 @@ function classifyExecution(execution) {
   }
   if (parsed && parsed.ok === false) {
     const reason = parsed.reason ?? null;
+    if (reason === "step_limit_exceeded") {
+      return {
+        status: "failed",
+        error_code: "step_limit_exceeded",
+        error_message: parsed.error ?? reason,
+      };
+    }
     if (reason === "json_parse_error" || reason === "empty_stdout") {
       return {
         status: "failed",
@@ -236,6 +245,17 @@ function buildErrorDiagnostic(invocation, status, error_code, error_message) {
       suggested_action:
         `Retry the review after a short wait. If it repeats, check ${target.displayName} ` +
         `service status or run \`${target.binaryName}\` interactively from a normal terminal.`,
+      disclosure_note: null,
+    };
+  }
+  if (status === "failed" && error_code === "step_limit_exceeded") {
+    return {
+      error_summary: `${target.displayName} Code CLI exhausted its configured step limit before returning a review result.`,
+      error_cause:
+        `${target.displayName} emitted a plain-text max-step exhaustion sentinel instead of ` +
+        "the requested stream-json payload. The companion recognized the sentinel and preserved it as a provider resource-limit diagnostic.",
+      suggested_action:
+        "Retry with a higher step budget using --max-steps-per-turn <n>, or rerun with a narrower scope.",
       disclosure_note: null,
     };
   }
@@ -404,7 +424,7 @@ function assertInvocation(invocation) {
  *                    mode_profile_name, mode, model, cwd, workspace_root,
  *                    containment, scope, dispose_effective?,
  *                    scope_base?, scope_paths?, prompt_head, schema_spec?,
- *                    binary, started_at }
+ *                    binary, max_steps_per_turn?, started_at }
  *
  *   execution  — null when writing the pre-run/queued record. Otherwise:
  *                  { exitCode, parsed: {ok, result?, structured?, denials?,
@@ -454,6 +474,7 @@ export function buildJobRecord(invocation, execution, mutations) {
     prompt_head: invocation.prompt_head,
     schema_spec: invocation.schema_spec ?? null,
     binary: invocation.binary,
+    max_steps_per_turn: invocation.max_steps_per_turn ?? null,
 
     // Lifecycle
     status,

--- a/plugins/kimi/scripts/lib/job-record.mjs
+++ b/plugins/kimi/scripts/lib/job-record.mjs
@@ -21,7 +21,7 @@
 // - Schema drift is a test failure (job-record.test.mjs asserts on keys AND
 //   on claude-result-handling/SKILL.md mentioning each field).
 
-export const SCHEMA_VERSION = 7;
+export const SCHEMA_VERSION = 8;
 
 /**
  * Canonical JobRecord field list. Exported so tests can reference it and
@@ -35,6 +35,7 @@ export const EXPECTED_KEYS = Object.freeze([
   "target",
   "parent_job_id",
   "claude_session_id",
+  "gemini_session_id",
   "kimi_session_id",
   "resume_chain",
   "pid_info",
@@ -53,7 +54,6 @@ export const EXPECTED_KEYS = Object.freeze([
   "prompt_head",
   "schema_spec",
   "binary",
-  "max_steps_per_turn",
 
   // Lifecycle
   "status",
@@ -424,7 +424,7 @@ function assertInvocation(invocation) {
  *                    mode_profile_name, mode, model, cwd, workspace_root,
  *                    containment, scope, dispose_effective?,
  *                    scope_base?, scope_paths?, prompt_head, schema_spec?,
- *                    binary, max_steps_per_turn?, started_at }
+ *                    binary, started_at }
  *
  *   execution  — null when writing the pre-run/queued record. Otherwise:
  *                  { exitCode, parsed: {ok, result?, structured?, denials?,
@@ -454,6 +454,7 @@ export function buildJobRecord(invocation, execution, mutations) {
     target: invocation.target,
     parent_job_id: invocation.parent_job_id ?? null,
     claude_session_id: execution?.claudeSessionId ?? null,
+    gemini_session_id: execution?.geminiSessionId ?? null,
     kimi_session_id: execution?.kimiSessionId ?? null,
     resume_chain: Array.isArray(invocation.resume_chain)
       ? [...invocation.resume_chain]
@@ -474,7 +475,6 @@ export function buildJobRecord(invocation, execution, mutations) {
     prompt_head: invocation.prompt_head,
     schema_spec: invocation.schema_spec ?? null,
     binary: invocation.binary,
-    max_steps_per_turn: invocation.max_steps_per_turn ?? null,
 
     // Lifecycle
     status,

--- a/plugins/kimi/scripts/lib/kimi.mjs
+++ b/plugins/kimi/scripts/lib/kimi.mjs
@@ -20,10 +20,14 @@ export function buildKimiArgs(profile, runtimeInputs = {}) {
     model,
     includeDirPath = null,
     resumeId = null,
+    maxStepsPerTurn = profile.max_steps_per_turn ?? 8,
   } = runtimeInputs;
 
   if ((typeof model !== "string" || !model) && profile.name !== "ping") {
     throw new Error("buildKimiArgs: model is required (full ID, no aliases)");
+  }
+  if (!Number.isInteger(maxStepsPerTurn) || maxStepsPerTurn <= 0) {
+    throw new Error("buildKimiArgs: maxStepsPerTurn must be a positive integer");
   }
 
   const args = [
@@ -34,7 +38,7 @@ export function buildKimiArgs(profile, runtimeInputs = {}) {
     "--input-format",
     "text",
     "--max-steps-per-turn",
-    "8",
+    String(maxStepsPerTurn),
   ];
   if (typeof model === "string" && model) args.push("-m", model);
   args.push("--thinking");
@@ -59,6 +63,10 @@ function summarizeStderr(stderr) {
   return trimmed.length > 4000 ? `${trimmed.slice(0, 4000)}...` : trimmed;
 }
 
+function parseResumeSessionId(text) {
+  return /\bTo resume this session:\s+kimi\s+-r\s+([0-9a-fA-F-]+)/.exec(text)?.[1] ?? null;
+}
+
 export function parseKimiResult(stdout, stderr = "") {
   const trimmed = stdout.trim();
   if (!trimmed) {
@@ -68,8 +76,20 @@ export function parseKimiResult(stdout, stderr = "") {
     }
     return { ok: false, reason: "empty_stdout", raw: stdout };
   }
+  const stepLimitMatch = /^Max number of steps reached:\s*(\d+)\s*$/m.exec(trimmed);
+  if (stepLimitMatch) {
+    const error = stepLimitMatch[0].trim();
+    return {
+      ok: false,
+      reason: "step_limit_exceeded",
+      error,
+      stepLimit: Number(stepLimitMatch[1]),
+      sessionId: parseResumeSessionId(`${stdout}\n${stderr}`),
+      raw: stdout,
+    };
+  }
   let parsed;
-  const resumeMatch = /\bTo resume this session:\s+kimi\s+-r\s+([0-9a-fA-F-]+)/.exec(stdout);
+  const resumeMatch = parseResumeSessionId(`${stdout}\n${stderr}`);
   try {
     parsed = JSON.parse(trimmed);
   } catch (e) {
@@ -84,7 +104,7 @@ export function parseKimiResult(stdout, stderr = "") {
     : (typeof parsed.error === "string" ? parsed.error : JSON.stringify(parsed.error));
   return {
     ok: parsed.error == null,
-    sessionId: parsed.session_id ?? parsed.sessionId ?? resumeMatch?.[1] ?? null,
+    sessionId: parsed.session_id ?? parsed.sessionId ?? resumeMatch ?? null,
     result: typeof parsed.content === "string"
       ? parsed.content
       : (typeof parsed.response === "string" ? parsed.response : (typeof parsed.result === "string" ? parsed.result : null)),
@@ -108,13 +128,14 @@ export async function spawnKimi(profile, runtimeInputs = {}) {
     timeoutMs = 0,
     binary = "kimi",
     onSpawn = null,
+    maxStepsPerTurn,
   } = runtimeInputs;
 
   if (typeof promptText !== "string" || promptText.length === 0) {
     throw new Error("spawnKimi: promptText is required");
   }
 
-  const args = buildKimiArgs(profile, { model, includeDirPath, resumeId });
+  const args = buildKimiArgs(profile, { model, includeDirPath, resumeId, maxStepsPerTurn });
   const targetEnv = sanitizeTargetEnv(env);
 
   return new Promise((resolve, reject) => {

--- a/plugins/kimi/scripts/lib/kimi.mjs
+++ b/plugins/kimi/scripts/lib/kimi.mjs
@@ -76,7 +76,7 @@ export function parseKimiResult(stdout, stderr = "") {
     }
     return { ok: false, reason: "empty_stdout", raw: stdout };
   }
-  const stepLimitMatch = /^Max number of steps reached:\s*(\d+)\s*$/m.exec(trimmed);
+  const stepLimitMatch = /^Max number of steps reached:\s*(\d+)\s*$/.exec(trimmed);
   if (stepLimitMatch) {
     const error = stepLimitMatch[0].trim();
     return {

--- a/plugins/kimi/scripts/lib/mode-profiles.mjs
+++ b/plugins/kimi/scripts/lib/mode-profiles.mjs
@@ -37,6 +37,8 @@ const EMPTY_TOOLS = Object.freeze([]);
  *   add_dir          — pass `--add-dir <path>` at all?
  *   schema_allowed   — is `--json-schema` meaningful for this mode? When
  *                      false, jsonSchema runtime input is silently dropped.
+ *   max_steps_per_turn — Kimi CLI step budget. Larger review scopes need a
+ *                      higher default than ping/rescue probes.
  */
 export const MODE_PROFILES = Object.freeze({
   review: Object.freeze({
@@ -50,6 +52,7 @@ export const MODE_PROFILES = Object.freeze({
     dispose_default: true,
     add_dir: true,
     schema_allowed: true,
+    max_steps_per_turn: 16,
   }),
   "adversarial-review": Object.freeze({
     name: "adversarial-review",
@@ -62,6 +65,7 @@ export const MODE_PROFILES = Object.freeze({
     dispose_default: true,
     add_dir: true,
     schema_allowed: true,
+    max_steps_per_turn: 32,
   }),
   "custom-review": Object.freeze({
     name: "custom-review",
@@ -74,6 +78,7 @@ export const MODE_PROFILES = Object.freeze({
     dispose_default: true,
     add_dir: true,
     schema_allowed: true,
+    max_steps_per_turn: 32,
   }),
   rescue: Object.freeze({
     name: "rescue",
@@ -86,6 +91,7 @@ export const MODE_PROFILES = Object.freeze({
     dispose_default: false,
     add_dir: true,
     schema_allowed: false,
+    max_steps_per_turn: 8,
   }),
   ping: Object.freeze({
     name: "ping",
@@ -98,6 +104,7 @@ export const MODE_PROFILES = Object.freeze({
     dispose_default: false,
     add_dir: false, // ping is a bare OAuth probe — no directory is granted
     schema_allowed: false,
+    max_steps_per_turn: 8,
   }),
 });
 

--- a/plugins/kimi/scripts/lib/reconcile.mjs
+++ b/plugins/kimi/scripts/lib/reconcile.mjs
@@ -66,6 +66,7 @@ function invocationFromMeta(meta) {
     prompt_head: meta.prompt_head ?? "",
     schema_spec: meta.schema_spec ?? null,
     binary: meta.binary,
+    max_steps_per_turn: meta.max_steps_per_turn ?? null,
     started_at: meta.started_at,
   };
 }

--- a/plugins/kimi/scripts/lib/reconcile.mjs
+++ b/plugins/kimi/scripts/lib/reconcile.mjs
@@ -66,7 +66,6 @@ function invocationFromMeta(meta) {
     prompt_head: meta.prompt_head ?? "",
     schema_spec: meta.schema_spec ?? null,
     binary: meta.binary,
-    max_steps_per_turn: meta.max_steps_per_turn ?? null,
     started_at: meta.started_at,
   };
 }

--- a/plugins/kimi/skills/kimi-delegation/SKILL.md
+++ b/plugins/kimi/skills/kimi-delegation/SKILL.md
@@ -29,11 +29,11 @@ In the repository checkout, it is `plugins/kimi`.
   ```
 - Read-only review:
   ```bash
-  node "<plugin-root>/scripts/kimi-companion.mjs" run --mode=review --foreground --cwd "<workspace>" -- "<review focus>"
+  node "<plugin-root>/scripts/kimi-companion.mjs" run --mode=review --foreground --cwd "<workspace>" [--max-steps-per-turn <n>] -- "<review focus>"
   ```
 - Adversarial review:
   ```bash
-  node "<plugin-root>/scripts/kimi-companion.mjs" run --mode=adversarial-review --foreground --cwd "<workspace>" -- "<design or diff to challenge>"
+  node "<plugin-root>/scripts/kimi-companion.mjs" run --mode=adversarial-review --foreground --cwd "<workspace>" [--max-steps-per-turn <n>] -- "<design or diff to challenge>"
   ```
 - Disclosure/scope preflight:
   ```bash
@@ -41,7 +41,7 @@ In the repository checkout, it is `plugins/kimi`.
   ```
 - Pinned bundle or selected-file review:
   ```bash
-  node "<plugin-root>/scripts/kimi-companion.mjs" run --mode=custom-review --foreground --cwd "<bundle-or-workspace>" --scope-paths "PR.diff,docs/*.md" -- "<review focus using relative paths>"
+  node "<plugin-root>/scripts/kimi-companion.mjs" run --mode=custom-review --foreground --cwd "<bundle-or-workspace>" --scope-paths "PR.diff,docs/*.md" [--max-steps-per-turn <n>] -- "<review focus using relative paths>"
   ```
 - Rescue/investigation:
   ```bash

--- a/tests/smoke/claude-companion.smoke.test.mjs
+++ b/tests/smoke/claude-companion.smoke.test.mjs
@@ -124,7 +124,7 @@ test("run --mode=review --foreground: emits JobRecord with status=completed", ()
     assert.ok(result.job_id, "job_id set");
     assert.equal(result.result, "Mock Claude response.");
     assert.deepEqual(result.permission_denials, []);
-    assert.equal(result.schema_version, 7, "schema_version bumped for scope diagnostics");
+    assert.equal(result.schema_version, 8, "schema_version bumped for canonical Kimi session parity");
     assert.equal("prompt" in result, false,
       "§21.3.1: full prompt must not appear on JobRecord");
     assert.equal("ok" in result, false,
@@ -240,7 +240,7 @@ test("run: meta.json persisted to workspace state", () => {
     assert.equal(meta.session_id, undefined,
       "legacy session_id field must not be present on new-shape records");
     // JobRecord schema version and full-prompt omission stay explicit.
-    assert.equal(meta.schema_version, 7);
+    assert.equal(meta.schema_version, 8);
     assert.equal("prompt" in meta, false,
       "§21.3.1: full `prompt` field must not be persisted");
     // T7.4: result field populated on foreground completion (symmetry with bg).

--- a/tests/smoke/invariants.test.mjs
+++ b/tests/smoke/invariants.test.mjs
@@ -473,7 +473,7 @@ test("M6-finding-1-H1: background worker persists parsed.result on terminal JobR
     assert.deepEqual(meta.permission_denials, []);
     assert.ok("mutations" in meta, "background JobRecord carries mutations array");
     assert.ok("cost_usd" in meta, "background JobRecord carries cost_usd");
-    assert.equal(meta.schema_version, 7);
+    assert.equal(meta.schema_version, 8);
   } finally {
     rmTempTree(dataDir);
     rmTempTree(cwd);

--- a/tests/smoke/kimi-companion.smoke.test.mjs
+++ b/tests/smoke/kimi-companion.smoke.test.mjs
@@ -53,6 +53,24 @@ function readOnlyJobRecord(dataDir) {
   return records[0];
 }
 
+function findJobPaths(dataDir, jobId) {
+  const stateRoot = path.join(dataDir, "state");
+  for (const workspaceDir of readdirSync(stateRoot)) {
+    const jobsDir = path.join(stateRoot, workspaceDir, "jobs");
+    const metaPath = path.join(jobsDir, `${jobId}.json`);
+    if (existsSync(metaPath)) {
+      return {
+        jobsDir,
+        metaPath,
+        sidecarDir: path.join(jobsDir, jobId),
+        runtimeOptionsPath: path.join(jobsDir, jobId, "runtime-options.json"),
+        legacyRuntimeOptionsPath: path.join(jobsDir, `${jobId}.runtime-options`),
+      };
+    }
+  }
+  assert.fail(`job ${jobId} not found under ${stateRoot}`);
+}
+
 function parseJson(stdout) {
   return JSON.parse(stdout);
 }
@@ -327,6 +345,9 @@ test("kimi background review preserves configured max-step budget outside public
   assert.equal(record.status, "completed");
   assert.equal(record.result, "Mock Kimi response.");
   assert.equal("max_steps_per_turn" in record, false);
+  const paths = findJobPaths(dataDir, payload.job_id);
+  assert.equal(existsSync(paths.legacyRuntimeOptionsPath), false);
+  assert.equal(existsSync(paths.runtimeOptionsPath), true);
 }));
 
 test("kimi continue reuses prior private max-step budget without JobRecord drift", () => withRepo((cwd) => {

--- a/tests/smoke/kimi-companion.smoke.test.mjs
+++ b/tests/smoke/kimi-companion.smoke.test.mjs
@@ -57,6 +57,24 @@ function parseJson(stdout) {
   return JSON.parse(stdout);
 }
 
+function waitForTerminalRecord(dataDir, jobId, { timeoutMs = 5000 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  let last = null;
+  while (Date.now() < deadline) {
+    const stateRoot = path.join(dataDir, "state");
+    if (existsSync(stateRoot)) {
+      for (const workspaceDir of readdirSync(stateRoot)) {
+        const metaPath = path.join(stateRoot, workspaceDir, "jobs", `${jobId}.json`);
+        if (!existsSync(metaPath)) continue;
+        last = JSON.parse(readFileSync(metaPath, "utf8"));
+        if (["completed", "failed", "cancelled", "stale"].includes(last.status)) return last;
+      }
+    }
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 50);
+  }
+  assert.fail(`job ${jobId} did not become terminal; last=${JSON.stringify(last)}`);
+}
+
 function assertPreflightSafetyFields(result) {
   assert.equal(result.target_spawned, false);
   assert.equal(result.selected_scope_sent_to_provider, false);
@@ -223,6 +241,92 @@ test("kimi foreground review timeout returns actionable JobRecord", () => withRe
   const { record: persisted } = readOnlyJobRecord(result.dataDir);
   assert.equal(persisted.job_id, record.job_id);
   assert.equal(persisted.error_code, "timeout");
+}));
+
+test("kimi foreground review step-limit exhaustion returns actionable JobRecord", () => withRepo((cwd) => {
+  const result = runCompanion([
+    "run",
+    "--mode",
+    "custom-review",
+    "--cwd",
+    cwd,
+    "--scope-paths",
+    "seed.txt",
+    "--foreground",
+    "--max-steps-per-turn",
+    "48",
+    "--",
+    "Review this scope.",
+  ], {
+    cwd,
+    env: {
+      KIMI_MOCK_ASSERT_MAX_STEPS_PER_TURN: "48",
+      KIMI_MOCK_STEP_LIMIT: "1",
+    },
+  });
+  assert.equal(result.status, 2);
+  const record = parseJson(result.stdout);
+  assert.equal(record.target, "kimi");
+  assert.equal(record.mode, "custom-review");
+  assert.equal(record.status, "failed");
+  assert.equal(record.error_code, "step_limit_exceeded");
+  assert.match(record.error_message, /Max number of steps reached: 1/);
+  assert.match(record.suggested_action, /higher step budget/i);
+  assert.match(record.suggested_action, /narrower scope/i);
+  const { record: persisted } = readOnlyJobRecord(result.dataDir);
+  assert.equal(persisted.job_id, record.job_id);
+  assert.equal(persisted.error_code, "step_limit_exceeded");
+}));
+
+test("kimi run rejects invalid max-step budgets before target launch", () => withRepo((cwd) => {
+  const result = runCompanion([
+    "run",
+    "--mode",
+    "custom-review",
+    "--cwd",
+    cwd,
+    "--scope-paths",
+    "seed.txt",
+    "--foreground",
+    "--max-steps-per-turn",
+    "0.5",
+    "--",
+    "Review this scope.",
+  ], { cwd });
+  assert.equal(result.status, 1);
+  const parsed = parseJson(result.stdout);
+  assert.equal(parsed.error, "bad_args");
+  assert.match(parsed.message, /--max-steps-per-turn/);
+}));
+
+test("kimi background review preserves configured max-step budget through queued JobRecord", () => withRepo((cwd) => {
+  const dataDir = mkdtempSync(path.join(tmpdir(), "kimi-background-max-steps-data-"));
+  const launched = runCompanion([
+    "run",
+    "--mode",
+    "custom-review",
+    "--cwd",
+    cwd,
+    "--scope-paths",
+    "seed.txt",
+    "--background",
+    "--max-steps-per-turn",
+    "48",
+    "--",
+    "Review this scope.",
+  ], {
+    cwd,
+    dataDir,
+    env: { KIMI_MOCK_ASSERT_MAX_STEPS_PER_TURN: "48" },
+  });
+  assert.equal(launched.status, 0, launched.stderr);
+  const payload = parseJson(launched.stdout);
+  assert.equal(payload.event, "launched");
+
+  const record = waitForTerminalRecord(dataDir, payload.job_id);
+  assert.equal(record.status, "completed");
+  assert.equal(record.result, "Mock Kimi response.");
+  assert.equal(record.max_steps_per_turn, 48);
 }));
 
 test("kimi preflight success and bad_args emit safety fields", () => withRepo((cwd) => {

--- a/tests/smoke/kimi-companion.smoke.test.mjs
+++ b/tests/smoke/kimi-companion.smoke.test.mjs
@@ -299,7 +299,7 @@ test("kimi run rejects invalid max-step budgets before target launch", () => wit
   assert.match(parsed.message, /--max-steps-per-turn/);
 }));
 
-test("kimi background review preserves configured max-step budget through queued JobRecord", () => withRepo((cwd) => {
+test("kimi background review preserves configured max-step budget outside public JobRecord", () => withRepo((cwd) => {
   const dataDir = mkdtempSync(path.join(tmpdir(), "kimi-background-max-steps-data-"));
   const launched = runCompanion([
     "run",
@@ -326,7 +326,53 @@ test("kimi background review preserves configured max-step budget through queued
   const record = waitForTerminalRecord(dataDir, payload.job_id);
   assert.equal(record.status, "completed");
   assert.equal(record.result, "Mock Kimi response.");
-  assert.equal(record.max_steps_per_turn, 48);
+  assert.equal("max_steps_per_turn" in record, false);
+}));
+
+test("kimi continue reuses prior private max-step budget without JobRecord drift", () => withRepo((cwd) => {
+  const dataDir = mkdtempSync(path.join(tmpdir(), "kimi-continue-max-steps-data-"));
+  const first = runCompanion([
+    "run",
+    "--mode",
+    "custom-review",
+    "--cwd",
+    cwd,
+    "--scope-paths",
+    "seed.txt",
+    "--foreground",
+    "--max-steps-per-turn",
+    "48",
+    "--",
+    "Review this scope.",
+  ], {
+    cwd,
+    dataDir,
+    env: { KIMI_MOCK_ASSERT_MAX_STEPS_PER_TURN: "48" },
+  });
+  assert.equal(first.status, 0, first.stderr);
+  const firstRecord = parseJson(first.stdout);
+  assert.equal(firstRecord.status, "completed");
+  assert.equal("max_steps_per_turn" in firstRecord, false);
+
+  const continued = runCompanion([
+    "continue",
+    "--job",
+    firstRecord.job_id,
+    "--cwd",
+    cwd,
+    "--foreground",
+    "--",
+    "Continue this review.",
+  ], {
+    cwd,
+    dataDir,
+    env: { KIMI_MOCK_ASSERT_MAX_STEPS_PER_TURN: "48" },
+  });
+  assert.equal(continued.status, 0, continued.stderr);
+  const continuedRecord = parseJson(continued.stdout);
+  assert.equal(continuedRecord.status, "completed");
+  assert.equal(continuedRecord.parent_job_id, firstRecord.job_id);
+  assert.equal("max_steps_per_turn" in continuedRecord, false);
 }));
 
 test("kimi preflight success and bad_args emit safety fields", () => withRepo((cwd) => {

--- a/tests/smoke/kimi-mock.mjs
+++ b/tests/smoke/kimi-mock.mjs
@@ -51,6 +51,14 @@ if (expectedPromptText && !prompt.includes(expectedPromptText)) {
   process.exit(1);
 }
 
+const expectedMaxSteps = process.env.KIMI_MOCK_ASSERT_MAX_STEPS_PER_TURN;
+if (expectedMaxSteps && String(parsed.flags["--max-steps-per-turn"] ?? "") !== expectedMaxSteps) {
+  process.stderr.write(
+    `kimi-mock: --max-steps-per-turn mismatch: expected ${expectedMaxSteps}, got ${parsed.flags["--max-steps-per-turn"] ?? "<missing>"}\n`,
+  );
+  process.exit(1);
+}
+
 if (process.env.KIMI_MOCK_CAPACITY_MODEL === model) {
   process.stderr.write(JSON.stringify({
     error: {
@@ -63,6 +71,13 @@ if (process.env.KIMI_MOCK_CAPACITY_MODEL === model) {
       }],
     },
   }) + "\n");
+  process.exit(1);
+}
+
+if (process.env.KIMI_MOCK_STEP_LIMIT) {
+  const limit = process.env.KIMI_MOCK_STEP_LIMIT;
+  process.stdout.write(`Max number of steps reached: ${limit}\n`);
+  process.stderr.write(`To resume this session: kimi -r ${sessionId}\n`);
   process.exit(1);
 }
 

--- a/tests/unit/job-record.test.mjs
+++ b/tests/unit/job-record.test.mjs
@@ -586,6 +586,28 @@ test("kimi buildJobRecord: timeout diagnostics use Kimi target display name", ()
   assert.match(rec.suggested_action, /run `kimi` interactively/);
 });
 
+test("kimi buildJobRecord: step-limit exhaustion is actionable, not parse_error", () => {
+  const rec = buildKimiJobRecord(makeInvocation({ target: "kimi", binary: "kimi" }), {
+    exitCode: 1,
+    parsed: {
+      ok: false,
+      reason: "step_limit_exceeded",
+      error: "Max number of steps reached: 1",
+      result: null,
+      structured: null,
+      denials: [],
+    },
+    pidInfo: makePidInfo(),
+    kimiSessionId: null,
+  }, []);
+  assert.equal(rec.status, "failed");
+  assert.equal(rec.error_code, "step_limit_exceeded");
+  assert.equal(rec.error_message, "Max number of steps reached: 1");
+  assert.match(rec.error_summary, /step limit/i);
+  assert.match(rec.suggested_action, /higher step budget/i);
+  assert.match(rec.suggested_action, /narrower scope/i);
+});
+
 test("kimi buildJobRecord: timeout diagnostics use Claude target display name", () => {
   const rec = buildKimiJobRecord(makeInvocation({ target: "claude", binary: "claude" }), {
     exitCode: null,

--- a/tests/unit/job-record.test.mjs
+++ b/tests/unit/job-record.test.mjs
@@ -18,10 +18,13 @@ import {
 } from "../../plugins/claude/scripts/lib/job-record.mjs";
 import {
   buildJobRecord as buildGeminiJobRecord,
+  EXPECTED_KEYS as GEMINI_EXPECTED_KEYS,
   SCHEMA_VERSION as GEMINI_SCHEMA_VERSION,
 } from "../../plugins/gemini/scripts/lib/job-record.mjs";
 import {
   buildJobRecord as buildKimiJobRecord,
+  EXPECTED_KEYS as KIMI_EXPECTED_KEYS,
+  SCHEMA_VERSION as KIMI_SCHEMA_VERSION,
 } from "../../plugins/kimi/scripts/lib/job-record.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -33,8 +36,9 @@ const CLAUDE_UUID = "11111111-2222-4333-8444-555555555555";
 const GEMINI_UUID = "22222222-3333-4444-9555-666666666666";
 
 test("JobRecord schema_version is bumped for scope diagnostics", () => {
-  assert.equal(SCHEMA_VERSION, 7);
-  assert.equal(GEMINI_SCHEMA_VERSION, 7);
+  assert.equal(SCHEMA_VERSION, 8);
+  assert.equal(GEMINI_SCHEMA_VERSION, 8);
+  assert.equal(KIMI_SCHEMA_VERSION, 8);
 });
 
 // Helper — minimal valid invocation captured at cmdRun entry.
@@ -68,7 +72,7 @@ function makePidInfo() {
 
 test("EXPECTED_KEYS is the spec §21.3 canonical list", () => {
   const required = [
-    "id", "job_id", "target", "parent_job_id", "claude_session_id", "gemini_session_id",
+    "id", "job_id", "target", "parent_job_id", "claude_session_id", "gemini_session_id", "kimi_session_id",
     "resume_chain", "pid_info",
     "mode", "mode_profile_name", "model", "cwd", "workspace_root",
     "containment", "scope", "dispose_effective", "scope_base", "scope_paths",
@@ -80,6 +84,20 @@ test("EXPECTED_KEYS is the spec §21.3 canonical list", () => {
     "schema_version",
   ];
   assert.deepEqual([...EXPECTED_KEYS].sort(), required.sort());
+});
+
+test("EXPECTED_KEYS are identical across provider companions", () => {
+  assert.deepEqual([...GEMINI_EXPECTED_KEYS], [...EXPECTED_KEYS]);
+  assert.deepEqual([...KIMI_EXPECTED_KEYS], [...EXPECTED_KEYS]);
+});
+
+test("Kimi JobRecord does not persist private runtime-only options", () => {
+  const rec = buildKimiJobRecord(
+    makeInvocation({ target: "kimi", binary: "kimi", max_steps_per_turn: 48 }),
+    null,
+    [],
+  );
+  assert.equal("max_steps_per_turn" in rec, false);
 });
 
 test("buildJobRecord: foreground success path has EXACTLY the expected keys", () => {

--- a/tests/unit/kimi-dispatcher.test.mjs
+++ b/tests/unit/kimi-dispatcher.test.mjs
@@ -1,8 +1,10 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { buildKimiArgs } from "../../plugins/kimi/scripts/lib/kimi.mjs";
+import { buildKimiArgs, parseKimiResult } from "../../plugins/kimi/scripts/lib/kimi.mjs";
 import { MODE_PROFILES, resolveProfile } from "../../plugins/kimi/scripts/lib/mode-profiles.mjs";
+
+const KIMI_SESSION_ID = "22222222-3333-4444-9555-666666666666";
 
 test("buildKimiArgs: every Kimi profile enables thinking mode intentionally", () => {
   for (const profile of Object.values(MODE_PROFILES)) {
@@ -40,4 +42,39 @@ test("buildKimiArgs: resume keeps session id with thinking enabled", () => {
 
   assert.ok(args.includes("--thinking"));
   assert.equal(args[args.indexOf("--session") + 1], "00000000-0000-4000-8000-000000000000");
+});
+
+test("parseKimiResult: classifies raw max-step exhaustion before JSON parsing", () => {
+  const parsed = parseKimiResult(
+    "Max number of steps reached: 1\n",
+    `To resume this session: kimi -r ${KIMI_SESSION_ID}\n`,
+  );
+
+  assert.equal(parsed.ok, false);
+  assert.equal(parsed.reason, "step_limit_exceeded");
+  assert.equal(parsed.error, "Max number of steps reached: 1");
+  assert.equal(parsed.stepLimit, 1);
+  assert.equal(parsed.sessionId, KIMI_SESSION_ID);
+  assert.equal(parsed.raw, "Max number of steps reached: 1\n");
+});
+
+test("buildKimiArgs: review modes use safer max-step defaults and allow overrides", () => {
+  const reviewArgs = buildKimiArgs(resolveProfile("review"), {
+    model: "kimi-k2-turbo-preview",
+    includeDirPath: "/tmp/scoped-worktree",
+  });
+  assert.equal(reviewArgs[reviewArgs.indexOf("--max-steps-per-turn") + 1], "16");
+
+  const adversarialArgs = buildKimiArgs(resolveProfile("adversarial-review"), {
+    model: "kimi-k2-turbo-preview",
+    includeDirPath: "/tmp/scoped-worktree",
+  });
+  assert.equal(adversarialArgs[adversarialArgs.indexOf("--max-steps-per-turn") + 1], "32");
+
+  const customOverrideArgs = buildKimiArgs(resolveProfile("custom-review"), {
+    model: "kimi-k2-turbo-preview",
+    includeDirPath: "/tmp/scoped-worktree",
+    maxStepsPerTurn: 48,
+  });
+  assert.equal(customOverrideArgs[customOverrideArgs.indexOf("--max-steps-per-turn") + 1], "48");
 });

--- a/tests/unit/kimi-dispatcher.test.mjs
+++ b/tests/unit/kimi-dispatcher.test.mjs
@@ -58,6 +58,17 @@ test("parseKimiResult: classifies raw max-step exhaustion before JSON parsing", 
   assert.equal(parsed.raw, "Max number of steps reached: 1\n");
 });
 
+test("parseKimiResult: does not treat an embedded max-step line as the sole sentinel", () => {
+  const parsed = parseKimiResult(
+    `{"content":"partial","session_id":"${KIMI_SESSION_ID}"}\nMax number of steps reached: 8\n`,
+    "",
+  );
+
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.result, "partial");
+  assert.equal(parsed.sessionId, KIMI_SESSION_ID);
+});
+
 test("buildKimiArgs: review modes use safer max-step defaults and allow overrides", () => {
   const reviewArgs = buildKimiArgs(resolveProfile("review"), {
     model: "kimi-k2-turbo-preview",


### PR DESCRIPTION
## Summary

Fixes #52.

Kimi can emit the plain-text sentinel `Max number of steps reached: N` even when invoked with `--output-format stream-json`. The companion previously sent that through the generic JSON parse failure path, so operators saw parser/runtime flakiness instead of an actionable provider resource-limit condition.

This PR treats that sentinel as a first-class failure class:

- classifies raw Kimi max-step exhaustion before JSON parsing as `step_limit_exceeded`
- maps that parsed reason into a Kimi `JobRecord` diagnostic with retry guidance
- adds `--max-steps-per-turn` support for `run` and `continue`
- raises Kimi review defaults above the old hardcoded `8` while keeping ping/rescue at `8`
- preserves Kimi max-step runtime options through foreground, background worker, and continue flows via a private 0600 sidecar instead of the public `JobRecord`
- canonicalizes CLI companion `JobRecord` schema parity across Claude/Gemini/Kimi, including nullable `kimi_session_id`, and bumps the shared schema to v8
- adds schema-parity tests so provider-specific public JobRecord drift fails directly

## Validation

- RED targeted tests first failed for parser classification, JobRecord classification, argv/default behavior, schema parity, private runtime-option propagation, and background/continue max-step propagation.
- `npm test` — 618 pass, 6 skipped
- `npm run test:coverage` — 762 pass, 18 skipped, coverage target met
- commit pre-hook reran `npm test` — 618 pass, 6 skipped
- `git diff --check`