### PR TITLE
fix: harden Kimi step-limit classification

### DIFF
--- a/plugins/kimi/scripts/kimi-companion.mjs
+++ b/plugins/kimi/scripts/kimi-companion.mjs
@@ -727,12 +727,13 @@ async function cmdRunWorker(rest) {
     fail("bad_state", `_run-worker refuses terminal job ${options.job}`);
   }
 
+  const runtimeOptions = readRuntimeOptionsSidecar(workspaceRoot, options.job);
+
   // Honor a cancel that arrived while we were queued. The worker MUST check
   // this before spawning the target — otherwise the run completes (model
   // call, side effects) and only the post-run consumer at executeRun would
   // convert "completed" → "cancelled".
   if (consumeCancelMarker(workspaceRoot, options.job)) {
-    const runtimeOptions = readRuntimeOptionsSidecar(workspaceRoot, options.job);
     const cancelledRecord = buildJobRecord(invocationFromRecord(meta, runtimeOptions), {
       status: "cancelled",
       exitCode: null, parsed: null, pidInfo: null, kimiSessionId: null,
@@ -744,7 +745,7 @@ async function cmdRunWorker(rest) {
 
   const prompt = consumePromptSidecar(workspaceRoot, options.job);
   if (!prompt) {
-    const errorRecord = buildJobRecord(invocationFromRecord(meta), {
+    const errorRecord = buildJobRecord(invocationFromRecord(meta, runtimeOptions), {
       exitCode: null, parsed: null, pidInfo: null, kimiSessionId: null,
       errorMessage: "worker: prompt sidecar missing; job cannot resume",
     }, []);
@@ -753,7 +754,6 @@ async function cmdRunWorker(rest) {
     fail("bad_state", "prompt sidecar missing for job " + options.job);
   }
 
-  const runtimeOptions = readRuntimeOptionsSidecar(workspaceRoot, options.job);
   const invocation = invocationFromRecord(meta, runtimeOptions);
   await executeRun(invocation, prompt, { foreground: false });
 }

--- a/plugins/kimi/scripts/lib/kimi.mjs
+++ b/plugins/kimi/scripts/lib/kimi.mjs
@@ -67,7 +67,47 @@ function parseResumeSessionId(text) {
   return /\bTo resume this session:\s+kimi\s+-r\s+([0-9a-fA-F-]+)/.exec(text)?.[1] ?? null;
 }
 
-export function parseKimiResult(stdout, stderr = "") {
+const STEP_LIMIT_RE = /^Max number of steps reached:\s*(\d+)\s*$/;
+
+function parseJsonLineSessionId(text) {
+  for (const line of String(text ?? "").split("\n").reverse()) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("{")) continue;
+    try {
+      const parsed = JSON.parse(trimmed);
+      const sessionId = parsed.session_id ?? parsed.sessionId ?? null;
+      if (sessionId) return sessionId;
+    } catch {
+      // Keep scanning older stream-json lines.
+    }
+  }
+  return null;
+}
+
+function findStepLimitLine(stdout) {
+  for (const line of String(stdout ?? "").split("\n").reverse()) {
+    const match = STEP_LIMIT_RE.exec(line.trim());
+    if (match) return match;
+  }
+  return null;
+}
+
+function stepLimitResult(match, stdout, stderr) {
+  const error = match[0].trim();
+  return {
+    ok: false,
+    reason: "step_limit_exceeded",
+    error,
+    stepLimit: Number(match[1]),
+    sessionId:
+      parseResumeSessionId(`${stdout}\n${stderr}`) ??
+      parseJsonLineSessionId(stdout) ??
+      parseJsonLineSessionId(stderr),
+    raw: stdout,
+  };
+}
+
+export function parseKimiResult(stdout, stderr = "", options = {}) {
   const trimmed = stdout.trim();
   if (!trimmed) {
     const stderrSummary = summarizeStderr(stderr);
@@ -76,17 +116,17 @@ export function parseKimiResult(stdout, stderr = "") {
     }
     return { ok: false, reason: "empty_stdout", raw: stdout };
   }
-  const stepLimitMatch = /^Max number of steps reached:\s*(\d+)\s*$/.exec(trimmed);
+  const stepLimitMatch = STEP_LIMIT_RE.exec(trimmed);
   if (stepLimitMatch) {
-    const error = stepLimitMatch[0].trim();
-    return {
-      ok: false,
-      reason: "step_limit_exceeded",
-      error,
-      stepLimit: Number(stepLimitMatch[1]),
-      sessionId: parseResumeSessionId(`${stdout}\n${stderr}`),
-      raw: stdout,
-    };
+    return stepLimitResult(stepLimitMatch, stdout, stderr);
+  }
+  // Signal-killed runs have exitCode null; mixed sentinels are ignored so crash/timeout
+  // classification is not masked, while sole sentinels are still caught above.
+  if (Number.isInteger(options?.exitCode) && options.exitCode !== 0) {
+    const failedStepLimitMatch = findStepLimitLine(stdout);
+    if (failedStepLimitMatch) {
+      return stepLimitResult(failedStepLimitMatch, stdout, stderr);
+    }
   }
   let parsed;
   const resumeMatch = parseResumeSessionId(`${stdout}\n${stderr}`);
@@ -175,7 +215,7 @@ export async function spawnKimi(profile, runtimeInputs = {}) {
       finishReject(Object.assign(new Error(`spawn ${binary} failed: ${e.message}`), { code: e.code }));
     });
     child.on("close", (exitCode, signal) => {
-      const parsed = parseKimiResult(stdout, stderr);
+      const parsed = parseKimiResult(stdout, stderr, { exitCode });
       finishResolve({
         exitCode,
         signal,

--- a/tests/smoke/kimi-companion.smoke.test.mjs
+++ b/tests/smoke/kimi-companion.smoke.test.mjs
@@ -12,6 +12,7 @@ const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..
 const COMPANION = path.join(REPO_ROOT, "plugins/kimi/scripts/kimi-companion.mjs");
 const MOCK = path.join(REPO_ROOT, "tests/smoke/kimi-mock.mjs");
 const KIMI_SESSION_ID = "22222222-3333-4444-9555-666666666666";
+const KIMI_RESUMED_SESSION_ID = "77777777-8888-4999-aaaa-bbbbbbbbbbbb";
 
 function runCompanion(args, { cwd, env = {}, dataDir = mkdtempSync(path.join(tmpdir(), "kimi-smoke-data-")) } = {}) {
   const res = spawnSync("node", [COMPANION, ...args], {
@@ -280,6 +281,7 @@ test("kimi foreground review step-limit exhaustion returns actionable JobRecord"
     env: {
       KIMI_MOCK_ASSERT_MAX_STEPS_PER_TURN: "48",
       KIMI_MOCK_STEP_LIMIT: "1",
+      KIMI_MOCK_STEP_LIMIT_PREFIX_JSON: "1",
     },
   });
   assert.equal(result.status, 2);
@@ -288,6 +290,7 @@ test("kimi foreground review step-limit exhaustion returns actionable JobRecord"
   assert.equal(record.mode, "custom-review");
   assert.equal(record.status, "failed");
   assert.equal(record.error_code, "step_limit_exceeded");
+  assert.equal(record.kimi_session_id, KIMI_SESSION_ID);
   assert.match(record.error_message, /Max number of steps reached: 1/);
   assert.match(record.suggested_action, /higher step budget/i);
   assert.match(record.suggested_action, /narrower scope/i);
@@ -350,6 +353,41 @@ test("kimi background review preserves configured max-step budget outside public
   assert.equal(existsSync(paths.runtimeOptionsPath), true);
 }));
 
+test("kimi background review step-limit exhaustion preserves private max-step budget", () => withRepo((cwd) => {
+  const dataDir = mkdtempSync(path.join(tmpdir(), "kimi-background-step-limit-data-"));
+  const launched = runCompanion([
+    "run",
+    "--mode",
+    "custom-review",
+    "--cwd",
+    cwd,
+    "--scope-paths",
+    "seed.txt",
+    "--background",
+    "--max-steps-per-turn",
+    "48",
+    "--",
+    "Review this scope.",
+  ], {
+    cwd,
+    dataDir,
+    env: {
+      KIMI_MOCK_ASSERT_MAX_STEPS_PER_TURN: "48",
+      KIMI_MOCK_STEP_LIMIT: "1",
+      KIMI_MOCK_STEP_LIMIT_PREFIX_JSON: "1",
+    },
+  });
+  assert.equal(launched.status, 0, launched.stderr);
+  const payload = parseJson(launched.stdout);
+  assert.equal(payload.event, "launched");
+
+  const record = waitForTerminalRecord(dataDir, payload.job_id);
+  assert.equal(record.status, "failed");
+  assert.equal(record.error_code, "step_limit_exceeded");
+  assert.equal(record.kimi_session_id, KIMI_SESSION_ID);
+  assert.equal("max_steps_per_turn" in record, false);
+}));
+
 test("kimi continue reuses prior private max-step budget without JobRecord drift", () => withRepo((cwd) => {
   const dataDir = mkdtempSync(path.join(tmpdir(), "kimi-continue-max-steps-data-"));
   const first = runCompanion([
@@ -393,6 +431,122 @@ test("kimi continue reuses prior private max-step budget without JobRecord drift
   const continuedRecord = parseJson(continued.stdout);
   assert.equal(continuedRecord.status, "completed");
   assert.equal(continuedRecord.parent_job_id, firstRecord.job_id);
+  assert.equal("max_steps_per_turn" in continuedRecord, false);
+}));
+
+test("kimi continue resumes from step-limit failure and reuses private max-step budget", () => withRepo((cwd) => {
+  const dataDir = mkdtempSync(path.join(tmpdir(), "kimi-continue-step-limit-data-"));
+  const first = runCompanion([
+    "run",
+    "--mode",
+    "custom-review",
+    "--cwd",
+    cwd,
+    "--scope-paths",
+    "seed.txt",
+    "--foreground",
+    "--max-steps-per-turn",
+    "48",
+    "--",
+    "Review this scope.",
+  ], {
+    cwd,
+    dataDir,
+    env: {
+      KIMI_MOCK_ASSERT_MAX_STEPS_PER_TURN: "48",
+      KIMI_MOCK_STEP_LIMIT: "1",
+      KIMI_MOCK_STEP_LIMIT_PREFIX_JSON: "1",
+      KIMI_MOCK_STEP_LIMIT_RESUME_ON_STDOUT: "1",
+    },
+  });
+  assert.equal(first.status, 2, first.stderr);
+  const firstRecord = parseJson(first.stdout);
+  assert.equal(firstRecord.status, "failed");
+  assert.equal(firstRecord.error_code, "step_limit_exceeded");
+  assert.equal(firstRecord.kimi_session_id, KIMI_SESSION_ID);
+  assert.equal("max_steps_per_turn" in firstRecord, false);
+
+  const continued = runCompanion([
+    "continue",
+    "--job",
+    firstRecord.job_id,
+    "--cwd",
+    cwd,
+    "--foreground",
+    "--",
+    "Continue this review.",
+  ], {
+    cwd,
+    dataDir,
+    env: {
+      KIMI_MOCK_ASSERT_MAX_STEPS_PER_TURN: "48",
+      KIMI_MOCK_ASSERT_RESUME_ID: KIMI_SESSION_ID,
+    },
+  });
+  assert.equal(continued.status, 0, continued.stderr);
+  const continuedRecord = parseJson(continued.stdout);
+  assert.equal(continuedRecord.status, "completed");
+  assert.equal(continuedRecord.parent_job_id, firstRecord.job_id);
+  assert.equal(continuedRecord.resume_chain[0], KIMI_SESSION_ID);
+  assert.equal(continuedRecord.kimi_session_id, KIMI_RESUMED_SESSION_ID);
+  assert.equal("max_steps_per_turn" in continuedRecord, false);
+}));
+
+test("kimi background continue resumes from step-limit failure", () => withRepo((cwd) => {
+  const dataDir = mkdtempSync(path.join(tmpdir(), "kimi-background-continue-step-limit-data-"));
+  const first = runCompanion([
+    "run",
+    "--mode",
+    "custom-review",
+    "--cwd",
+    cwd,
+    "--scope-paths",
+    "seed.txt",
+    "--foreground",
+    "--max-steps-per-turn",
+    "48",
+    "--",
+    "Review this scope.",
+  ], {
+    cwd,
+    dataDir,
+    env: {
+      KIMI_MOCK_ASSERT_MAX_STEPS_PER_TURN: "48",
+      KIMI_MOCK_STEP_LIMIT: "1",
+      KIMI_MOCK_STEP_LIMIT_PREFIX_JSON: "1",
+    },
+  });
+  assert.equal(first.status, 2, first.stderr);
+  const firstRecord = parseJson(first.stdout);
+  assert.equal(firstRecord.error_code, "step_limit_exceeded");
+  assert.equal(firstRecord.kimi_session_id, KIMI_SESSION_ID);
+
+  const launched = runCompanion([
+    "continue",
+    "--job",
+    firstRecord.job_id,
+    "--cwd",
+    cwd,
+    "--background",
+    "--",
+    "Continue this review.",
+  ], {
+    cwd,
+    dataDir,
+    env: {
+      KIMI_MOCK_ASSERT_MAX_STEPS_PER_TURN: "48",
+      KIMI_MOCK_ASSERT_RESUME_ID: KIMI_SESSION_ID,
+    },
+  });
+  assert.equal(launched.status, 0, launched.stderr);
+  const payload = parseJson(launched.stdout);
+  assert.equal(payload.event, "launched");
+
+  const continuedRecord = waitForTerminalRecord(dataDir, payload.job_id);
+  assert.equal(continuedRecord.status, "completed");
+  assert.equal(continuedRecord.parent_job_id, firstRecord.job_id);
+  assert.equal(continuedRecord.resume_chain[0], KIMI_SESSION_ID);
+  assert.equal(continuedRecord.kimi_session_id, KIMI_RESUMED_SESSION_ID);
   assert.equal("max_steps_per_turn" in continuedRecord, false);
 }));
 

--- a/tests/smoke/kimi-mock.mjs
+++ b/tests/smoke/kimi-mock.mjs
@@ -59,6 +59,15 @@ if (expectedMaxSteps && String(parsed.flags["--max-steps-per-turn"] ?? "") !== e
   process.exit(1);
 }
 
+const expectedResumeId = process.env.KIMI_MOCK_ASSERT_RESUME_ID;
+const actualResumeId = parsed.flags["--session"] ?? parsed.flags["--resume"] ?? "";
+if (expectedResumeId && actualResumeId !== expectedResumeId) {
+  process.stderr.write(
+    `kimi-mock: resume id mismatch: expected ${expectedResumeId}, got ${actualResumeId || "<missing>"}\n`,
+  );
+  process.exit(1);
+}
+
 if (process.env.KIMI_MOCK_CAPACITY_MODEL === model) {
   process.stderr.write(JSON.stringify({
     error: {
@@ -76,8 +85,16 @@ if (process.env.KIMI_MOCK_CAPACITY_MODEL === model) {
 
 if (process.env.KIMI_MOCK_STEP_LIMIT) {
   const limit = process.env.KIMI_MOCK_STEP_LIMIT;
+  if (process.env.KIMI_MOCK_STEP_LIMIT_PREFIX_JSON === "1") {
+    process.stdout.write(JSON.stringify({ content: "Partial Kimi response.", session_id: sessionId }) + "\n");
+  }
   process.stdout.write(`Max number of steps reached: ${limit}\n`);
-  process.stderr.write(`To resume this session: kimi -r ${sessionId}\n`);
+  const resumeHint = `To resume this session: kimi -r ${sessionId}\n`;
+  if (process.env.KIMI_MOCK_STEP_LIMIT_RESUME_ON_STDOUT === "1") {
+    process.stdout.write(resumeHint);
+  } else {
+    process.stderr.write(resumeHint);
+  }
   process.exit(1);
 }
 

--- a/tests/unit/kimi-dispatcher.test.mjs
+++ b/tests/unit/kimi-dispatcher.test.mjs
@@ -16,6 +16,17 @@ test("buildKimiArgs: every Kimi profile enables thinking mode intentionally", ()
   }
 });
 
+test("MODE_PROFILES: every Kimi profile declares a positive max-step budget", () => {
+  for (const [name, profile] of Object.entries(MODE_PROFILES)) {
+    assert.ok(
+      Object.prototype.hasOwnProperty.call(profile, "max_steps_per_turn"),
+      `${name} must declare max_steps_per_turn`,
+    );
+    assert.equal(Number.isInteger(profile.max_steps_per_turn), true, `${name} max_steps_per_turn must be an integer`);
+    assert.ok(profile.max_steps_per_turn > 0, `${name} max_steps_per_turn must be positive`);
+  }
+});
+
 test("buildKimiArgs: review keeps model and plan mode with thinking", () => {
   const args = buildKimiArgs(resolveProfile("review"), {
     model: "kimi-code/kimi-for-coding",
@@ -58,10 +69,102 @@ test("parseKimiResult: classifies raw max-step exhaustion before JSON parsing", 
   assert.equal(parsed.raw, "Max number of steps reached: 1\n");
 });
 
-test("parseKimiResult: does not treat an embedded max-step line as the sole sentinel", () => {
+test("parseKimiResult: treats sole max-step sentinel as failure regardless of exit-code metadata", () => {
+  for (const options of [undefined, { exitCode: null }, { exitCode: 0 }]) {
+    const parsed = parseKimiResult(
+      "Max number of steps reached: 1\n",
+      `To resume this session: kimi -r ${KIMI_SESSION_ID}\n`,
+      options,
+    );
+
+    assert.equal(parsed.ok, false);
+    assert.equal(parsed.reason, "step_limit_exceeded");
+    assert.equal(parsed.sessionId, KIMI_SESSION_ID);
+  }
+});
+
+test("parseKimiResult: classifies mixed JSON plus sentinel when Kimi exits nonzero", () => {
   const parsed = parseKimiResult(
     `{"content":"partial","session_id":"${KIMI_SESSION_ID}"}\nMax number of steps reached: 8\n`,
     "",
+    { exitCode: 1 },
+  );
+
+  assert.equal(parsed.ok, false);
+  assert.equal(parsed.reason, "step_limit_exceeded");
+  assert.equal(parsed.error, "Max number of steps reached: 8");
+  assert.equal(parsed.stepLimit, 8);
+  assert.equal(parsed.sessionId, KIMI_SESSION_ID);
+});
+
+test("parseKimiResult: keeps scanning stream-json lines for session id on step limit", () => {
+  const parsed = parseKimiResult(
+    `{"content":"partial","session_id":"${KIMI_SESSION_ID}"}\n{"stats":{"tokens":{"total":12}}}\nMax number of steps reached: 8\n`,
+    "",
+    { exitCode: 1 },
+  );
+
+  assert.equal(parsed.ok, false);
+  assert.equal(parsed.reason, "step_limit_exceeded");
+  assert.equal(parsed.sessionId, KIMI_SESSION_ID);
+});
+
+test("parseKimiResult: recovers JSON session id from stderr when no resume hint exists", () => {
+  const parsed = parseKimiResult(
+    "Max number of steps reached: 8\n",
+    `{"content":"partial","session_id":"${KIMI_SESSION_ID}"}\n`,
+    { exitCode: 1 },
+  );
+
+  assert.equal(parsed.ok, false);
+  assert.equal(parsed.reason, "step_limit_exceeded");
+  assert.equal(parsed.sessionId, KIMI_SESSION_ID);
+});
+
+test("parseKimiResult: prefers stdout JSON session id over stderr fallback", () => {
+  const stderrSessionId = "99999999-aaaa-4bbb-8ccc-dddddddddddd";
+  const parsed = parseKimiResult(
+    `{"content":"partial","session_id":"${KIMI_SESSION_ID}"}\nMax number of steps reached: 8\n`,
+    `{"content":"stderr","session_id":"${stderrSessionId}"}\n`,
+    { exitCode: 1 },
+  );
+
+  assert.equal(parsed.ok, false);
+  assert.equal(parsed.reason, "step_limit_exceeded");
+  assert.equal(parsed.sessionId, KIMI_SESSION_ID);
+});
+
+test("parseKimiResult: accepts stdout resume hints after a failed max-step sentinel", () => {
+  const parsed = parseKimiResult(
+    `Max number of steps reached: 8\nTo resume this session: kimi -r ${KIMI_SESSION_ID}\n`,
+    "",
+    { exitCode: 1 },
+  );
+
+  assert.equal(parsed.ok, false);
+  assert.equal(parsed.reason, "step_limit_exceeded");
+  assert.equal(parsed.error, "Max number of steps reached: 8");
+  assert.equal(parsed.stepLimit, 8);
+  assert.equal(parsed.sessionId, KIMI_SESSION_ID);
+});
+
+test("parseKimiResult: preserves embedded max-step text in successful JSON output", () => {
+  const parsed = parseKimiResult(
+    `{"content":"partial","session_id":"${KIMI_SESSION_ID}"}\nMax number of steps reached: 8\n`,
+    "",
+    { exitCode: 0 },
+  );
+
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.result, "partial");
+  assert.equal(parsed.sessionId, KIMI_SESSION_ID);
+});
+
+test("parseKimiResult: tolerates null options argument", () => {
+  const parsed = parseKimiResult(
+    `{"content":"partial","session_id":"${KIMI_SESSION_ID}"}\nMax number of steps reached: 8\n`,
+    "",
+    null,
   );
 
   assert.equal(parsed.ok, true);
@@ -88,4 +191,16 @@ test("buildKimiArgs: review modes use safer max-step defaults and allow override
     maxStepsPerTurn: 48,
   });
   assert.equal(customOverrideArgs[customOverrideArgs.indexOf("--max-steps-per-turn") + 1], "48");
+});
+
+test("buildKimiArgs: rejects invalid max-step budgets", () => {
+  for (const maxStepsPerTurn of [0, -1, 1.5, Number.NaN]) {
+    assert.throws(
+      () => buildKimiArgs(resolveProfile("review"), {
+        model: "kimi-k2-turbo-preview",
+        maxStepsPerTurn,
+      }),
+      /maxStepsPerTurn must be a positive integer/,
+    );
+  }
 });


### PR DESCRIPTION
## Summary

Follow-up to the merged PR #57 Kimi step-limit work. This hardens classification and coverage around mixed stream-json output followed by Kimi's raw max-step sentinel.

Changes:
- classify mixed stream-json + `Max number of steps reached: N` as `step_limit_exceeded` when Kimi exits nonzero
- preserve successful JSON output that merely contains sentinel-like text when Kimi exits 0
- recover Kimi session ids from stdout/stderr resume hints and earlier stdout/stderr stream-json events, preferring stdout stream-json before stderr fallback
- cover foreground, background, foreground-continue, and background-continue step-limit companion paths
- assert private `max_steps_per_turn` remains outside public JobRecords
- add Kimi profile, argument validation, exit metadata, null-options, and stream precedence coverage
- pass runtime options consistently through the `_run-worker` prompt-missing error path
- document the deliberate signal-kill behavior at the mixed-sentinel exit-code gate

## Review Evidence

Internal adversarial review found two issues; both were addressed before this PR was opened:
- session id fallback now keeps scanning older stream-json lines when newer JSON events lack session ids
- smoke coverage now exercises mixed JSON + sentinel paths and stdout resume hints

External reviews:
- Kimi: PASS, no blocking findings
- DeepSeek: PASS, no blocking findings
- Claude: PASS, no blocking findings
- Gemini: PASS, no blocking findings

GitHub review comments addressed:
- Gemini Code Assist reverse-scan suggestion is implemented and thread resolved
- Gemini Code Assist optional-chaining suggestion is implemented with null-options unit coverage and thread resolved
- Greptile misleading-test-name concern is addressed by broader omitted/null/zero exit-code coverage
- Greptile signal-kill concern is documented at the classifier gate

Final follow-up on current head `0c0be09`:
- stdout JSON session-id fallback now wins over stderr fallback when both streams contain session ids
- added explicit unit coverage for conflicting stdout/stderr JSON session IDs
- left sidecar cleanup and large-output reverse-array allocation as documented non-blocking follow-ups in the PR comments

Schema note: reviewers re-checked the previous `api-reviewers` schema-drift claim. It is out of scope for this branch; current `main` has `plugins/api-reviewers/scripts/api-reviewer.mjs` on its own schema version, and this branch does not touch that path.

## Verification

- `node --test tests/unit/kimi-dispatcher.test.mjs` — 16 passed
- `node --test tests/smoke/kimi-companion.smoke.test.mjs` — 23 passed
- `npm test` — 667 passed, 0 failed, 6 skipped
- `git diff --check` — passed
- pre-commit reran `npm test` successfully
- branch pushed with `--force-with-lease`