### PR TITLE
Fix stale review artifact cleanup

### DIFF
--- a/docs/artifact-cleanup-inventory.md
+++ b/docs/artifact-cleanup-inventory.md
@@ -1,0 +1,47 @@
+# Artifact Cleanup Inventory
+
+Issue #61 requires cleanup to be rooted in an explicit artifact and ownership map.
+
+## Companion Providers
+
+Applies to Claude, Gemini, and Kimi `review`, `adversarial-review`, `custom-review`, and `rescue`, in foreground, background, and continue flows.
+
+| Artifact | Root | Contents | Needed for | Safe deletion point | Owner |
+| --- | --- | --- | --- | --- | --- |
+| `state.json` | `<stateRoot>/<workspaceSlug-hash>/` | Retained job summaries, config | `status`, retained history | Never as per-job cleanup | `state.mjs` |
+| `<jobId>.json` | `<stateDir>/jobs/` | Canonical JobRecord, result metadata, target/session IDs | `status --job`, `result --job`, `continue`, history | When terminal job is pruned from retained history | `state.mjs` |
+| `<jobId>.json.*.tmp` | `<stateDir>/jobs/` | Partial atomic write for JobRecord | Nothing after interrupted write | When matching terminal job is pruned | `state.mjs` |
+| `<jobId>.log` | `<stateDir>/jobs/` | Legacy/safe log path if present in state | Debugging only | When terminal job is pruned, if path is inside jobs root | `state.mjs` |
+| `<jobId>/prompt.txt` | `<stateDir>/jobs/` | Full background prompt handoff | Background worker startup | Worker consumes it; any leftover is deleted with pruned terminal job | companion + `state.mjs` |
+| `<jobId>/runtime-options.json` | `<stateDir>/jobs/` | Kimi private runtime options, for example max step budget | Kimi background/continue | With containing sidecar directory when terminal job is pruned | Kimi companion + `state.mjs` |
+| `<jobId>/cancel-requested.flag` | `<stateDir>/jobs/` | Cancel intent marker | Running/queued cancellation finalization | Consumed by worker; leftover is deleted with pruned terminal job | cancel marker + `state.mjs` |
+| `<jobId>/git-status-before.txt` and `git-status-after.txt` | `<stateDir>/jobs/` | Mutation-detection snapshots | Operator diagnostics/result interpretation | With containing sidecar directory when terminal job is pruned | companion + `state.mjs` |
+| `<jobId>/stdout.log` and `stderr.log` | `<stateDir>/jobs/` | Target CLI diagnostics and raw output | Debugging only; JobRecord remains canonical | With containing sidecar directory when terminal job is pruned | companion + `state.mjs` |
+| Containment worktree | `os.tmpdir()/<provider>-worktree-*` | Scoped copied review material and target writes | Target execution only | End of foreground/background worker execution, including scope/spawn/finalization failures | `containment.mjs` caller |
+| Neutral cwd | `os.tmpdir()/gemini-neutral-cwd-*`, `kimi-neutral-cwd-*` | Empty target cwd for policy isolation | Target execution only | End of execution/failure path | companion |
+
+Safety proof for deletion: derive paths only from `assertSafeJobId(job.id)` and provider-owned roots. Active `queued` and `running` jobs are retained and their sidecar directories are not pruned. State-provided arbitrary paths are ignored except `logFile`, which is deleted only after containment under the provider jobs root is verified.
+
+Process policy: retained-history pruning does not signal processes. Companion process termination remains owned by `cancel`, which requires `pid_info` verification through `starttime` and `argv0`. Orphan reconciliation only marks active records `stale` when PID proof says the process is gone/reused, or when old queued/running records lack usable ownership proof; it does not kill.
+
+## API Reviewers
+
+Applies to DeepSeek and GLM `review`, `adversarial-review`, and `custom-review` direct API runs.
+
+| Artifact | Root | Contents | Needed for | Safe deletion point | Owner |
+| --- | --- | --- | --- | --- | --- |
+| `state.json` | `API_REVIEWERS_PLUGIN_DATA` or `.codex-plugin-data/api-reviewers` | Retained API reviewer job summaries | Retained history/pruning | Never as per-job cleanup | `api-reviewer.mjs` |
+| `jobs/<jobId>/meta.json` | API reviewer data root | Canonical direct API JobRecord | Returned result and retained diagnostics | When terminal API reviewer job is pruned from retained history | `api-reviewer.mjs` |
+| `jobs/<jobId>/meta.json.*.tmp` | API reviewer job dir | Partial atomic write | Nothing after interrupted write | Removed on write failure; containing job dir removed on prune | `api-reviewer.mjs` |
+
+API reviewer cleanup backfills the retained-history index by discovering existing safe `jobs/<jobId>/meta.json` directories before pruning. This covers installs that created per-job API reviewer records before `state.json` existed, while malformed metadata and unsafe directory names remain ignored for deletion. Direct API reviewer `meta.json` writes are per-job atomic writes that complete before the retained-history index lock is acquired, so the canonical JobRecord remains durable even if `state.json` indexing times out. Direct API reviewer `state.json` updates are serialized by a per-data-root advisory lock so parallel DeepSeek/GLM runs cannot publish stale retained-history snapshots over each other. Lock acquisition uses a gate directory while reclaiming or creating the main lock, so no third writer can enter during orphan restore. Lock release verifies the on-disk owner token before removing the lock, and stale reclaim refuses to steal cross-host locks, unreadable-owner locks, or same-host locks while the recorded owner PID is still alive.
+
+DeepSeek/GLM branch-diff and custom-review material is read from the workspace into memory and sent in the HTTP request body. The API reviewer path does not persist prompt sidecars, copied review bundles, branch-diff files, stdout/stderr logs, PID records, cancel markers, or subprocess state. Git scope discovery uses synchronous child processes that complete before the JobRecord is built; provider execution uses `fetch` in the current process. There is no live provider-owned subprocess to terminate on prune.
+
+Safety proof for deletion: API reviewer pruning only removes directories derived from validated safe job IDs under the API reviewer `jobs/` root. Tampered unsafe state entries are ignored for deletion. Active-looking records are retained and not pruned.
+
+## Failure Paths
+
+- Bad args, unsupported provider/mode, malformed provider config, missing keys, auth failure, scope failure, HTTP failure, timeout, and malformed provider response all produce terminal JobRecords and enter the same retained-history cleanup path.
+- Companion scope/spawn/finalization failures clean execution temp roots best-effort at the execution site; any retained per-job sidecars are removed later when terminal history is pruned.
+- Sidecar write failures remain diagnostic warnings and do not change the canonical terminal JobRecord.

--- a/plugins/api-reviewers/scripts/api-reviewer.mjs
+++ b/plugins/api-reviewers/scripts/api-reviewer.mjs
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { lstat, mkdir, readFile, readdir, rename, rm, unlink, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { dirname, isAbsolute, resolve, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import { randomUUID } from "node:crypto";
+import { hostname } from "node:os";
 
 import { cleanGitEnv } from "./lib/git-env.mjs";
 import {
@@ -18,6 +19,14 @@ const PROVIDERS_PATH = resolve(PLUGIN_ROOT, "config/providers.json");
 const VALID_MODES = new Set(["review", "adversarial-review", "custom-review"]);
 const VALID_AUTH_MODES = new Set(["api_key", "auto"]);
 const SCHEMA_VERSION = 9;
+const API_REVIEWER_STATE_VERSION = 1;
+const MAX_RETAINED_API_REVIEWER_JOBS = 50;
+const ACTIVE_JOB_STATUSES = new Set(["queued", "running"]);
+const API_REVIEWER_STATE_LOCK_DIR = ".state.lock";
+const API_REVIEWER_STATE_LOCK_GATE_DIR = ".state.lock.gate";
+const API_REVIEWER_STATE_LOCK_POLL_MS = 25;
+const API_REVIEWER_STATE_LOCK_TIMEOUT_MS = 5000;
+const API_REVIEWER_STATE_LOCK_STALE_MS = 30000;
 const API_REVIEWER_EXPECTED_KEYS = Object.freeze([
   "id",
   "job_id",
@@ -72,6 +81,408 @@ const MIN_SECRET_REDACTION_LENGTH = 8;
 
 function printJson(obj) {
   process.stdout.write(`${JSON.stringify(obj, null, 2)}\n`);
+}
+
+function isActiveJob(job) {
+  return ACTIVE_JOB_STATUSES.has(job?.status);
+}
+
+const SAFE_JOB_ID = /^(?:[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}|[A-Za-z0-9][A-Za-z0-9._-]{0,127})$/;
+
+function assertSafeJobId(jobId) {
+  if (typeof jobId !== "string" || !SAFE_JOB_ID.test(jobId)) {
+    throw new Error(`Unsafe jobId: ${JSON.stringify(jobId)}`);
+  }
+}
+
+function apiReviewerDataRoot(env = process.env) {
+  return resolve(env.API_REVIEWERS_PLUGIN_DATA ?? ".codex-plugin-data/api-reviewers");
+}
+
+function apiReviewerJobsDir(root) {
+  return resolve(root, "jobs");
+}
+
+function apiReviewerStateFile(root) {
+  return resolve(root, "state.json");
+}
+
+function sleep(ms) {
+  return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
+}
+
+function isProcessAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return e?.code === "EPERM";
+  }
+}
+
+function pruneJobs(jobs) {
+  const withIndex = jobs.map((job, originalIndex) => ({ job, originalIndex }));
+  withIndex.sort((left, right) => {
+    const lt = String(left.job.updatedAt ?? left.job.ended_at ?? left.job.endedAt ?? "");
+    const rt = String(right.job.updatedAt ?? right.job.ended_at ?? right.job.endedAt ?? "");
+    if (lt === rt) return left.originalIndex - right.originalIndex;
+    return rt.localeCompare(lt);
+  });
+  let terminalCount = 0;
+  return withIndex
+    .filter(({ job }) => {
+      if (isActiveJob(job)) return true;
+      if (terminalCount >= MAX_RETAINED_API_REVIEWER_JOBS) return false;
+      terminalCount += 1;
+      return true;
+    })
+    .map(({ job }) => job);
+}
+
+async function loadApiReviewerState(root) {
+  let stateJobs = [];
+  try {
+    const parsed = JSON.parse(await readFile(apiReviewerStateFile(root), "utf8"));
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      stateJobs = [];
+    } else {
+      stateJobs = Array.isArray(parsed.jobs) ? parsed.jobs : [];
+    }
+  } catch {
+    stateJobs = [];
+  }
+  return {
+    version: API_REVIEWER_STATE_VERSION,
+    jobs: mergeApiReviewerJobs(stateJobs, await discoverApiReviewerDiskJobs(root)),
+  };
+}
+
+function summarizeApiReviewerJobRecord(record, fallbackJobId = null) {
+  if (!record || typeof record !== "object" || Array.isArray(record)) return null;
+  const jobId = record.job_id ?? record.id ?? fallbackJobId;
+  try {
+    assertSafeJobId(jobId);
+  } catch {
+    return null;
+  }
+  if (fallbackJobId !== null && jobId !== fallbackJobId) return null;
+  return {
+    id: jobId,
+    job_id: jobId,
+    target: record.target,
+    provider: record.provider,
+    status: record.status,
+    mode: record.mode,
+    scope: record.scope,
+    scope_base: record.scope_base ?? null,
+    scope_paths: record.scope_paths ?? null,
+    updatedAt: record.updatedAt ?? record.ended_at ?? record.endedAt ?? record.started_at ?? record.startedAt ?? new Date(0).toISOString(),
+  };
+}
+
+function mergeApiReviewerJobs(stateJobs, diskJobs) {
+  const merged = [];
+  const seen = new Set();
+  for (const job of [...stateJobs, ...diskJobs]) {
+    const summary = summarizeApiReviewerJobRecord(job);
+    if (!summary) continue;
+    const jobId = summary.id;
+    if (seen.has(jobId)) continue;
+    seen.add(jobId);
+    merged.push(summary);
+  }
+  return merged;
+}
+
+async function discoverApiReviewerDiskJobs(root) {
+  let entries;
+  try {
+    entries = await readdir(apiReviewerJobsDir(root), { withFileTypes: true });
+  } catch (e) {
+    if (e.code === "ENOENT") return [];
+    throw e;
+  }
+  const jobs = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const jobId = entry.name;
+    try {
+      assertSafeJobId(jobId);
+    } catch {
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(await readFile(resolve(apiReviewerJobsDir(root), jobId, "meta.json"), "utf8"));
+      const summary = summarizeApiReviewerJobRecord(parsed, jobId);
+      if (summary) jobs.push(summary);
+    } catch {
+      // Ignore malformed legacy artifacts; cleanup only acts on validated job records.
+    }
+  }
+  return jobs;
+}
+
+async function writeApiReviewerState(root, state) {
+  await mkdir(root, { recursive: true });
+  const stateFile = apiReviewerStateFile(root);
+  const tmpFile = `${stateFile}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    await writeFile(tmpFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+    await rename(tmpFile, stateFile);
+  } catch (e) {
+    try { await unlink(tmpFile); } catch { /* already gone */ }
+    throw e;
+  }
+}
+
+async function writeApiReviewerMetaRecord(root, record) {
+  assertSafeJobId(record.job_id);
+  const dir = resolve(root, "jobs", record.job_id);
+  await mkdir(dir, { recursive: true });
+  const metaFile = resolve(dir, "meta.json");
+  const tmpFile = `${metaFile}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`;
+  try {
+    await writeFile(tmpFile, `${JSON.stringify(record, null, 2)}\n`, { mode: 0o600 });
+    await rename(tmpFile, metaFile);
+  } catch (e) {
+    try { await unlink(tmpFile); } catch { /* already gone */ }
+    throw e;
+  }
+}
+
+async function readApiReviewerLockOwnerRaw(lockOwnerFile) {
+  try {
+    return await readFile(lockOwnerFile, "utf8");
+  } catch (e) {
+    if (e.code === "ENOENT") return null;
+    return undefined;
+  }
+}
+
+async function readApiReviewerLockOwner(lockOwnerFile) {
+  try {
+    const parsed = JSON.parse(await readFile(lockOwnerFile, "utf8"));
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function apiReviewerLockAgeMs(lockStat, owner) {
+  const startedAt = owner?.startedAt ? Date.parse(owner.startedAt) : NaN;
+  if (Number.isFinite(startedAt)) return Date.now() - startedAt;
+  return Date.now() - lockStat.mtimeMs;
+}
+
+function apiReviewerStateLockTimeoutMs(env = process.env) {
+  const parsed = parsePositiveIntegerEnv(env, "API_REVIEWERS_STATE_LOCK_TIMEOUT_MS", "milliseconds");
+  return parsed.ok && parsed.value !== null ? parsed.value : API_REVIEWER_STATE_LOCK_TIMEOUT_MS;
+}
+
+function apiReviewerStateLockStaleMs(env = process.env) {
+  const parsed = parsePositiveIntegerEnv(env, "API_REVIEWERS_STATE_LOCK_STALE_MS", "milliseconds");
+  return parsed.ok && parsed.value !== null ? parsed.value : API_REVIEWER_STATE_LOCK_STALE_MS;
+}
+
+async function tryReclaimStaleApiReviewerStateLock(lockDir) {
+  const lockOwnerFile = resolve(lockDir, "owner.json");
+  let lockStat;
+  try {
+    lockStat = await lstat(lockDir);
+  } catch (e) {
+    if (e.code === "ENOENT") return true;
+    return false;
+  }
+  const ownerRaw = await readApiReviewerLockOwnerRaw(lockOwnerFile);
+  if (ownerRaw === undefined) return false;
+  const owner = await readApiReviewerLockOwner(lockOwnerFile);
+  if (owner?.hostname && owner.hostname !== hostname()) return false;
+  const sameHost = owner?.hostname === hostname();
+  const ownerPidValid = Number.isInteger(owner?.pid) && owner.pid > 0;
+  const sameHostAlive = sameHost && ownerPidValid && isProcessAlive(owner.pid);
+  if (sameHostAlive) return false;
+
+  const ownerDead = sameHost && ownerPidValid && !isProcessAlive(owner.pid);
+  const ageMs = apiReviewerLockAgeMs(lockStat, owner);
+  if (!ownerDead && ageMs <= apiReviewerStateLockStaleMs()) return false;
+
+  const orphanDir = `${lockDir}.orphaned-${process.pid}-${Date.now()}-${randomUUID()}`;
+  try {
+    await rename(lockDir, orphanDir);
+    const orphanOwnerRaw = await readApiReviewerLockOwnerRaw(resolve(orphanDir, "owner.json"));
+    if (orphanOwnerRaw !== ownerRaw) {
+      try { await rename(orphanDir, lockDir); } catch { /* leave orphan for manual cleanup */ }
+      return false;
+    }
+    await rm(orphanDir, { recursive: true, force: true });
+    return true;
+  } catch (e) {
+    if (e.code === "ENOENT") return true;
+    return false;
+  }
+}
+
+async function releaseApiReviewerStateLock(lockDir, token) {
+  const owner = await readApiReviewerLockOwner(resolve(lockDir, "owner.json"));
+  if (owner?.token === token && owner?.pid === process.pid && owner?.hostname === hostname()) {
+    await rm(lockDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+async function acquireApiReviewerStateLockGate(root, deadline) {
+  const gateDir = resolve(root, API_REVIEWER_STATE_LOCK_GATE_DIR);
+  const gateOwnerFile = resolve(gateDir, "owner.json");
+  while (true) {
+    try {
+      await mkdir(gateDir);
+      const token = randomUUID();
+      try {
+        await writeFile(gateOwnerFile, `${JSON.stringify({
+          pid: process.pid,
+          hostname: hostname(),
+          startedAt: new Date().toISOString(),
+          token,
+        })}\n`, "utf8");
+      } catch (e) {
+        await rm(gateDir, { recursive: true, force: true }).catch(() => {});
+        throw e;
+      }
+      return () => releaseApiReviewerStateLock(gateDir, token);
+    } catch (e) {
+      if (e.code !== "EEXIST") {
+        throw new Error(`api_reviewer_state_lock_error: could not acquire ${gateDir}: ${e.message}`);
+      }
+      if (await tryReclaimStaleApiReviewerStateLock(gateDir)) continue;
+      if (Date.now() >= deadline) {
+        throw new Error(`api_reviewer_state_lock_timeout: could not acquire ${gateDir}`);
+      }
+      await sleep(API_REVIEWER_STATE_LOCK_POLL_MS);
+    }
+  }
+}
+
+async function withApiReviewerStateLock(root, fn) {
+  await mkdir(root, { recursive: true });
+  const lockDir = resolve(root, API_REVIEWER_STATE_LOCK_DIR);
+  const lockOwnerFile = resolve(lockDir, "owner.json");
+  const deadline = Date.now() + apiReviewerStateLockTimeoutMs();
+  while (true) {
+    let releaseGate = null;
+    let token = null;
+    let lockDirCreated = false;
+    try {
+      releaseGate = await acquireApiReviewerStateLockGate(root, deadline);
+      try {
+        await mkdir(lockDir);
+        lockDirCreated = true;
+      } catch (e) {
+        if (e.code !== "EEXIST") {
+          throw new Error(`api_reviewer_state_lock_error: could not acquire ${lockDir}: ${e.message}`);
+        }
+        const reclaimed = await tryReclaimStaleApiReviewerStateLock(lockDir);
+        if (!reclaimed) {
+          await releaseGate();
+          releaseGate = null;
+          if (Date.now() >= deadline) {
+            throw new Error(`api_reviewer_state_lock_timeout: could not acquire ${lockDir}`);
+          }
+          await sleep(API_REVIEWER_STATE_LOCK_POLL_MS);
+          continue;
+        }
+        // Reclaim succeeded; recreate lockDir while still holding the gate so
+        // no third writer can acquire during the orphan put-back window.
+        await mkdir(lockDir);
+        lockDirCreated = true;
+      }
+      token = randomUUID();
+      await writeFile(lockOwnerFile, `${JSON.stringify({
+        pid: process.pid,
+        hostname: hostname(),
+        startedAt: new Date().toISOString(),
+        token,
+      })}\n`, "utf8");
+      await releaseGate();
+      releaseGate = null;
+    } catch (e) {
+      if (String(e.message ?? "").startsWith("api_reviewer_state_lock_")) throw e;
+      if (lockDirCreated) {
+        await rm(lockDir, { recursive: true, force: true }).catch(() => {});
+      }
+      throw new Error(`api_reviewer_state_lock_error: could not acquire ${lockDir}: ${e.message}`);
+    } finally {
+      if (releaseGate) await releaseGate();
+    }
+    try {
+      return await fn();
+    } finally {
+      await releaseApiReviewerStateLock(lockDir, token);
+    }
+  }
+}
+
+async function removeApiReviewerJobDir(root, jobId) {
+  assertSafeJobId(jobId);
+  const jobsDir = apiReviewerJobsDir(root);
+  const jobDir = resolve(jobsDir, jobId);
+  const rel = relative(jobsDir, jobDir);
+  if (!rel || rel.startsWith("..") || isAbsolute(rel)) return;
+  try {
+    const stat = await lstat(jobDir);
+    if (stat.isDirectory()) {
+      await rm(jobDir, { recursive: true, force: true });
+      return;
+    }
+    await unlink(jobDir);
+  } catch (e) {
+    if (e.code === "ENOENT") return;
+    throw e;
+  }
+}
+
+async function removeApiReviewerJobTmpFiles(root, jobId) {
+  assertSafeJobId(jobId);
+  const jobDir = resolve(apiReviewerJobsDir(root), jobId);
+  try {
+    const stat = await lstat(jobDir);
+    if (!stat.isDirectory()) return;
+  } catch (e) {
+    if (e.code === "ENOENT") return;
+    throw e;
+  }
+  let names;
+  try {
+    names = await readdir(jobDir);
+  } catch (e) {
+    if (e.code === "ENOENT") return;
+    throw e;
+  }
+  const prefix = "meta.json.";
+  for (const name of names) {
+    if (!name.startsWith(prefix) || !name.endsWith(".tmp")) continue;
+    try { await unlink(resolve(jobDir, name)); }
+    catch (e) { if (e.code !== "ENOENT") throw e; }
+  }
+}
+
+async function updateApiReviewerStateForRecord(root, record) {
+  const previousJobs = (await loadApiReviewerState(root)).jobs;
+  const summary = summarizeApiReviewerJobRecord(record);
+  if (!summary) return;
+  const merged = [summary, ...previousJobs.filter((job) => (job.id ?? job.job_id) !== record.id)];
+  const nextJobs = pruneJobs(merged);
+  const retainedIds = new Set(nextJobs.map((job) => job.id ?? job.job_id));
+  for (const job of previousJobs) {
+    const jobId = job.id ?? job.job_id;
+    if (retainedIds.has(jobId) || isActiveJob(job)) continue;
+    try { await removeApiReviewerJobTmpFiles(root, jobId); }
+    catch { /* best-effort cleanup must not hide the current review result */ }
+    try { await removeApiReviewerJobDir(root, jobId); }
+    catch { /* best-effort cleanup must not hide the current review result */ }
+  }
+  await writeApiReviewerState(root, {
+    version: API_REVIEWER_STATE_VERSION,
+    jobs: nextJobs,
+  });
 }
 
 function parseArgs(argv) {
@@ -733,10 +1144,12 @@ function buildRecord({ provider, cfg, mode, options, scopeInfo, execution, start
 }
 
 async function persistRecord(record, env = process.env) {
-  const root = resolve(env.API_REVIEWERS_PLUGIN_DATA ?? ".codex-plugin-data/api-reviewers");
-  const dir = resolve(root, "jobs", record.job_id);
-  await mkdir(dir, { recursive: true });
-  await writeFile(resolve(dir, "meta.json"), `${JSON.stringify(record, null, 2)}\n`, { mode: 0o600 });
+  const root = apiReviewerDataRoot(env);
+  await writeApiReviewerMetaRecord(root, record);
+  await withApiReviewerStateLock(root, async () => {
+    await writeApiReviewerMetaRecord(root, record);
+    await updateApiReviewerStateForRecord(root, record);
+  });
 }
 
 async function persistRecordBestEffort(record, env = process.env) {

--- a/plugins/claude/scripts/lib/state.mjs
+++ b/plugins/claude/scripts/lib/state.mjs
@@ -209,6 +209,54 @@ function removeJobLogFileIfSafe(cwd, filePath) {
   removeFileIfExists(filePath);
 }
 
+function removeJobSidecarDir(cwd, jobId) {
+  const sidecarDir = path.join(resolveJobsDir(cwd), jobId);
+  if (!isPathWithin(resolveJobsDir(cwd), sidecarDir)) return;
+  try {
+    const stat = fs.lstatSync(sidecarDir);
+    if (stat.isDirectory()) {
+      fs.rmSync(sidecarDir, { recursive: true, force: true });
+      return;
+    }
+    fs.unlinkSync(sidecarDir);
+  } catch (e) {
+    if (e.code === "ENOENT") return;
+    throw e;
+  }
+}
+
+function removeJobTmpFiles(cwd, jobId) {
+  const jobsDir = resolveJobsDir(cwd);
+  let names;
+  try {
+    names = fs.readdirSync(jobsDir);
+  } catch (e) {
+    if (e.code === "ENOENT") return;
+    throw e;
+  }
+  const prefix = `${jobId}.json.`;
+  for (const name of names) {
+    if (!name.startsWith(prefix) || !name.endsWith(".tmp")) continue;
+    removeFileIfExists(path.join(jobsDir, name));
+  }
+}
+
+function removeJobArtifacts(cwd, job) {
+  assertSafeJobId(job.id);
+  for (const cleanup of [
+    () => removeJobFile(resolveJobFile(cwd, job.id)),
+    () => removeJobLogFileIfSafe(cwd, job.logFile),
+    () => removeJobSidecarDir(cwd, job.id),
+    () => removeJobTmpFiles(cwd, job.id),
+  ]) {
+    try {
+      cleanup();
+    } catch {
+      // Retained-history cleanup is best-effort; state persistence is canonical.
+    }
+  }
+}
+
 export function saveState(cwd, state) {
   return withStateLock(cwd, () => saveStateUnlocked(cwd, state));
 }
@@ -502,8 +550,7 @@ function saveStateUnlocked(cwd, state) {
     } catch {
       continue;
     }
-    removeJobFile(resolveJobFile(cwd, job.id));
-    removeJobLogFileIfSafe(cwd, job.logFile);
+    removeJobArtifacts(cwd, job);
   }
 
   // Atomic write: write to a sibling tmp file, then rename. Rename is atomic

--- a/plugins/gemini/scripts/lib/state.mjs
+++ b/plugins/gemini/scripts/lib/state.mjs
@@ -208,6 +208,54 @@ function removeJobLogFileIfSafe(cwd, filePath) {
   removeFileIfExists(filePath);
 }
 
+function removeJobSidecarDir(cwd, jobId) {
+  const sidecarDir = path.join(resolveJobsDir(cwd), jobId);
+  if (!isPathWithin(resolveJobsDir(cwd), sidecarDir)) return;
+  try {
+    const stat = fs.lstatSync(sidecarDir);
+    if (stat.isDirectory()) {
+      fs.rmSync(sidecarDir, { recursive: true, force: true });
+      return;
+    }
+    fs.unlinkSync(sidecarDir);
+  } catch (e) {
+    if (e.code === "ENOENT") return;
+    throw e;
+  }
+}
+
+function removeJobTmpFiles(cwd, jobId) {
+  const jobsDir = resolveJobsDir(cwd);
+  let names;
+  try {
+    names = fs.readdirSync(jobsDir);
+  } catch (e) {
+    if (e.code === "ENOENT") return;
+    throw e;
+  }
+  const prefix = `${jobId}.json.`;
+  for (const name of names) {
+    if (!name.startsWith(prefix) || !name.endsWith(".tmp")) continue;
+    removeFileIfExists(path.join(jobsDir, name));
+  }
+}
+
+function removeJobArtifacts(cwd, job) {
+  assertSafeJobId(job.id);
+  for (const cleanup of [
+    () => removeJobFile(resolveJobFile(cwd, job.id)),
+    () => removeJobLogFileIfSafe(cwd, job.logFile),
+    () => removeJobSidecarDir(cwd, job.id),
+    () => removeJobTmpFiles(cwd, job.id),
+  ]) {
+    try {
+      cleanup();
+    } catch {
+      // Retained-history cleanup is best-effort; state persistence is canonical.
+    }
+  }
+}
+
 export function saveState(cwd, state) {
   return withStateLock(cwd, () => saveStateUnlocked(cwd, state));
 }
@@ -501,8 +549,7 @@ function saveStateUnlocked(cwd, state) {
     } catch {
       continue;
     }
-    removeJobFile(resolveJobFile(cwd, job.id));
-    removeJobLogFileIfSafe(cwd, job.logFile);
+    removeJobArtifacts(cwd, job);
   }
 
   // Atomic write: write to a sibling tmp file, then rename. Rename is atomic

--- a/plugins/kimi/scripts/lib/state.mjs
+++ b/plugins/kimi/scripts/lib/state.mjs
@@ -208,6 +208,54 @@ function removeJobLogFileIfSafe(cwd, filePath) {
   removeFileIfExists(filePath);
 }
 
+function removeJobSidecarDir(cwd, jobId) {
+  const sidecarDir = path.join(resolveJobsDir(cwd), jobId);
+  if (!isPathWithin(resolveJobsDir(cwd), sidecarDir)) return;
+  try {
+    const stat = fs.lstatSync(sidecarDir);
+    if (stat.isDirectory()) {
+      fs.rmSync(sidecarDir, { recursive: true, force: true });
+      return;
+    }
+    fs.unlinkSync(sidecarDir);
+  } catch (e) {
+    if (e.code === "ENOENT") return;
+    throw e;
+  }
+}
+
+function removeJobTmpFiles(cwd, jobId) {
+  const jobsDir = resolveJobsDir(cwd);
+  let names;
+  try {
+    names = fs.readdirSync(jobsDir);
+  } catch (e) {
+    if (e.code === "ENOENT") return;
+    throw e;
+  }
+  const prefix = `${jobId}.json.`;
+  for (const name of names) {
+    if (!name.startsWith(prefix) || !name.endsWith(".tmp")) continue;
+    removeFileIfExists(path.join(jobsDir, name));
+  }
+}
+
+function removeJobArtifacts(cwd, job) {
+  assertSafeJobId(job.id);
+  for (const cleanup of [
+    () => removeJobFile(resolveJobFile(cwd, job.id)),
+    () => removeJobLogFileIfSafe(cwd, job.logFile),
+    () => removeJobSidecarDir(cwd, job.id),
+    () => removeJobTmpFiles(cwd, job.id),
+  ]) {
+    try {
+      cleanup();
+    } catch {
+      // Retained-history cleanup is best-effort; state persistence is canonical.
+    }
+  }
+}
+
 export function saveState(cwd, state) {
   return withStateLock(cwd, () => saveStateUnlocked(cwd, state));
 }
@@ -501,8 +549,7 @@ function saveStateUnlocked(cwd, state) {
     } catch {
       continue;
     }
-    removeJobFile(resolveJobFile(cwd, job.id));
-    removeJobLogFileIfSafe(cwd, job.logFile);
+    removeJobArtifacts(cwd, job);
   }
 
   // Atomic write: write to a sibling tmp file, then rename. Rename is atomic

--- a/tests/smoke/api-reviewers.smoke.test.mjs
+++ b/tests/smoke/api-reviewers.smoke.test.mjs
@@ -1,9 +1,9 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { execFile, execFileSync } from "node:child_process";
-import { cpSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, symlinkSync, utimesSync, writeFileSync } from "node:fs";
 import { createServer } from "node:http";
-import { tmpdir } from "node:os";
+import { hostname, tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -72,6 +72,16 @@ function run(args, { cwd = REPO_ROOT, env = {}, companion = COMPANION } = {}) {
 
 function parseJson(stdout) {
   return JSON.parse(stdout);
+}
+
+async function waitForValue(fn, { timeoutMs = 2000, intervalMs = 25 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const value = fn();
+    if (value) return value;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  assert.fail("timed out waiting for expected value");
 }
 
 function mockResponse(model, id = "chatcmpl-test", content = `Verdict: APPROVE\nProvider model: ${model}`) {
@@ -276,6 +286,491 @@ test("API_REVIEWERS_MAX_TOKENS overrides provider request defaults", async () =>
   assert.equal(record.status, "completed");
   assert.equal(record.provider, "glm");
   assert.doesNotMatch(result.stdout, /secret-test-value/);
+});
+
+test("direct API reviewer persistence prunes old terminal job directories without touching active or unsafe entries", async () => {
+  const cwd = makeWorkspace();
+  const dataDir = mkdtempSync(path.join(tmpdir(), "api-reviewers-data-"));
+  const jobsDir = path.join(dataDir, "jobs");
+  mkdirSync(jobsDir, { recursive: true });
+
+  const oldJobs = Array.from({ length: 51 }, (_, index) => {
+    const id = `job_old_${String(index).padStart(2, "0")}`;
+    const dir = path.join(jobsDir, id);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, "meta.json"), JSON.stringify({ id, job_id: id, status: "completed" }) + "\n");
+    writeFileSync(path.join(dir, "prompt.txt"), "stale prompt material\n");
+    return {
+      id,
+      job_id: id,
+      status: "completed",
+      updatedAt: `2000-01-01T00:00:${String(index).padStart(2, "0")}.000Z`,
+    };
+  });
+  mkdirSync(path.join(jobsDir, "active_job"), { recursive: true });
+  writeFileSync(path.join(jobsDir, "active_job", "prompt.txt"), "active prompt material\n");
+  mkdirSync(path.join(jobsDir, "..unsafe"), { recursive: true });
+  writeFileSync(path.join(jobsDir, "..unsafe", "prompt.txt"), "unsafe should remain\n");
+  writeFileSync(path.join(dataDir, "state.json"), JSON.stringify({
+    version: 1,
+    jobs: [
+      ...oldJobs,
+      { id: "active_job", job_id: "active_job", status: "running", updatedAt: "1999-01-01T00:00:00.000Z" },
+      { id: "../unsafe", job_id: "../unsafe", status: "completed", updatedAt: "1998-01-01T00:00:00.000Z" },
+    ],
+  }, null, 2) + "\n");
+
+  const result = await run([
+    "run",
+    "--provider", "deepseek",
+    "--mode", "custom-review",
+    "--scope", "custom",
+    "--scope-paths", "seed.txt",
+    "--foreground",
+    "--prompt", "Check this file.",
+  ], {
+    cwd,
+    env: {
+      API_REVIEWERS_PLUGIN_DATA: dataDir,
+      API_REVIEWERS_MOCK_RESPONSE: mockResponse("deepseek-v4-pro"),
+      DEEPSEEK_API_KEY: "secret-test-value",
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const record = parseJson(result.stdout);
+  const state = JSON.parse(readFileSync(path.join(dataDir, "state.json"), "utf8"));
+  const retainedIds = state.jobs.map((job) => job.id);
+  assert.equal(retainedIds.includes(record.id), true);
+  assert.equal(retainedIds.includes("active_job"), true);
+  assert.equal(existsSync(path.join(dataDir, "jobs", record.id, "meta.json")), true);
+  assert.equal(existsSync(path.join(jobsDir, "active_job", "prompt.txt")), true);
+  assert.equal(existsSync(path.join(jobsDir, "..unsafe", "prompt.txt")), true);
+  assert.equal(existsSync(path.join(jobsDir, "job_old_00")), false);
+  assert.ok(readdirSync(jobsDir).length <= 52, "prune should not retain all seeded terminal job directories");
+});
+
+test("direct API reviewer persistence discovers and prunes pre-state job directories", async () => {
+  const cwd = makeWorkspace();
+  const dataDir = mkdtempSync(path.join(tmpdir(), "api-reviewers-data-"));
+  const jobsDir = path.join(dataDir, "jobs");
+  mkdirSync(jobsDir, { recursive: true });
+
+  for (let index = 0; index < 51; index += 1) {
+    const id = `job_disk_${String(index).padStart(2, "0")}`;
+    const dir = path.join(jobsDir, id);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, "meta.json"), JSON.stringify({
+      id,
+      job_id: id,
+      status: "completed",
+      provider: "deepseek",
+      mode: "custom-review",
+      ended_at: `2001-01-01T00:00:${String(index).padStart(2, "0")}.000Z`,
+    }) + "\n");
+    writeFileSync(path.join(dir, "prompt.txt"), "stale prompt material\n");
+  }
+  mkdirSync(path.join(jobsDir, "active_disk"), { recursive: true });
+  writeFileSync(path.join(jobsDir, "active_disk", "meta.json"), JSON.stringify({
+    id: "active_disk",
+    job_id: "active_disk",
+    status: "running",
+    provider: "deepseek",
+    mode: "custom-review",
+    updatedAt: "2000-01-01T00:00:00.000Z",
+  }) + "\n");
+  mkdirSync(path.join(jobsDir, "..unsafe"), { recursive: true });
+  writeFileSync(path.join(jobsDir, "..unsafe", "meta.json"), JSON.stringify({
+    id: "../unsafe",
+    job_id: "../unsafe",
+    status: "completed",
+  }) + "\n");
+
+  const result = await run([
+    "run",
+    "--provider", "deepseek",
+    "--mode", "custom-review",
+    "--scope", "custom",
+    "--scope-paths", "seed.txt",
+    "--foreground",
+    "--prompt", "Check this file.",
+  ], {
+    cwd,
+    env: {
+      API_REVIEWERS_PLUGIN_DATA: dataDir,
+      API_REVIEWERS_MOCK_RESPONSE: mockResponse("deepseek-v4-pro"),
+      DEEPSEEK_API_KEY: "secret-test-value",
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const record = parseJson(result.stdout);
+  const state = JSON.parse(readFileSync(path.join(dataDir, "state.json"), "utf8"));
+  const retainedIds = state.jobs.map((job) => job.id);
+  assert.equal(retainedIds.includes(record.id), true);
+  assert.equal(retainedIds.includes("active_disk"), true);
+  assert.equal(existsSync(path.join(jobsDir, record.id, "meta.json")), true);
+  assert.equal(existsSync(path.join(jobsDir, "active_disk", "meta.json")), true);
+  assert.equal(existsSync(path.join(jobsDir, "..unsafe", "meta.json")), true);
+  assert.equal(existsSync(path.join(jobsDir, "job_disk_00")), false);
+  assert.ok(readdirSync(jobsDir).length <= 52, "migration prune should not retain all directory-only jobs");
+});
+
+test("direct API reviewer pruning does not follow symlinked job dirs during tmp cleanup", async () => {
+  const cwd = makeWorkspace();
+  const dataDir = mkdtempSync(path.join(tmpdir(), "api-reviewers-data-"));
+  const jobsDir = path.join(dataDir, "jobs");
+  mkdirSync(jobsDir, { recursive: true });
+  const outsideDir = mkdtempSync(path.join(tmpdir(), "api-reviewers-outside-"));
+  const outsideTmp = path.join(outsideDir, "meta.json.outside.tmp");
+  writeFileSync(outsideTmp, "must not be deleted\n");
+
+  const symlinkJobId = "job_symlink_tmp";
+  symlinkSync(outsideDir, path.join(jobsDir, symlinkJobId), "dir");
+
+  const oldJobs = Array.from({ length: 50 }, (_, index) => {
+    const id = `job_keep_${String(index).padStart(2, "0")}`;
+    const dir = path.join(jobsDir, id);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, "meta.json"), JSON.stringify({ id, job_id: id, status: "completed" }) + "\n");
+    return {
+      id,
+      job_id: id,
+      status: "completed",
+      updatedAt: `2002-01-01T00:00:${String(index).padStart(2, "0")}.000Z`,
+    };
+  });
+  writeFileSync(path.join(dataDir, "state.json"), JSON.stringify({
+    version: 1,
+    jobs: [
+      ...oldJobs,
+      { id: symlinkJobId, job_id: symlinkJobId, status: "completed", updatedAt: "1999-01-01T00:00:00.000Z" },
+    ],
+  }, null, 2) + "\n");
+
+  const result = await run([
+    "run",
+    "--provider", "deepseek",
+    "--mode", "custom-review",
+    "--scope", "custom",
+    "--scope-paths", "seed.txt",
+    "--foreground",
+    "--prompt", "Check this file.",
+  ], {
+    cwd,
+    env: {
+      API_REVIEWERS_PLUGIN_DATA: dataDir,
+      API_REVIEWERS_MOCK_RESPONSE: mockResponse("deepseek-v4-pro"),
+      DEEPSEEK_API_KEY: "secret-test-value",
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.equal(existsSync(outsideTmp), true, "tmp cleanup must not follow a symlinked job dir");
+  assert.equal(existsSync(path.join(jobsDir, symlinkJobId)), false, "pruning should remove only the symlink node");
+});
+
+test("direct API reviewer concurrent runs retain every completed job in state", async () => {
+  const cwd = makeWorkspace();
+  const dataDir = mkdtempSync(path.join(tmpdir(), "api-reviewers-data-"));
+  const runCount = 8;
+
+  const results = await Promise.all(Array.from({ length: runCount }, (_, index) => run([
+    "run",
+    "--provider", index % 2 === 0 ? "deepseek" : "glm",
+    "--mode", "custom-review",
+    "--scope", "custom",
+    "--scope-paths", "seed.txt",
+    "--foreground",
+    "--prompt", `Check this file ${index}.`,
+  ], {
+    cwd,
+    env: {
+      API_REVIEWERS_PLUGIN_DATA: dataDir,
+      API_REVIEWERS_MOCK_RESPONSE: mockResponse(index % 2 === 0 ? "deepseek-v4-pro" : "glm-5.1", `mock-${index}`),
+      DEEPSEEK_API_KEY: "secret-test-value",
+      ZAI_API_KEY: "secret-test-value",
+    },
+  })));
+
+  for (const result of results) {
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+  }
+  const records = results.map((result) => parseJson(result.stdout));
+  const state = JSON.parse(readFileSync(path.join(dataDir, "state.json"), "utf8"));
+  const retainedIds = new Set(state.jobs.map((job) => job.id));
+  for (const record of records) {
+    assert.equal(existsSync(path.join(dataDir, "jobs", record.id, "meta.json")), true);
+    assert.equal(retainedIds.has(record.id), true, `missing ${record.id} from state.json`);
+  }
+});
+
+test("direct API reviewer lock does not reclaim a live old owner", async () => {
+  const cwd = makeWorkspace();
+  const dataDir = mkdtempSync(path.join(tmpdir(), "api-reviewers-data-"));
+  const lockDir = path.join(dataDir, ".state.lock");
+  mkdirSync(lockDir, { recursive: true });
+  writeFileSync(path.join(lockDir, "owner.json"), JSON.stringify({
+    pid: process.pid,
+    hostname: hostname(),
+    startedAt: new Date(Date.now() - 120000).toISOString(),
+    token: "live-test-owner",
+  }) + "\n");
+  const oldTime = new Date(Date.now() - 120000);
+  utimesSync(lockDir, oldTime, oldTime);
+
+  const result = await run([
+    "run",
+    "--provider", "deepseek",
+    "--mode", "custom-review",
+    "--scope", "custom",
+    "--scope-paths", "seed.txt",
+    "--foreground",
+    "--prompt", "Check this file.",
+  ], {
+    cwd,
+    env: {
+      API_REVIEWERS_PLUGIN_DATA: dataDir,
+      API_REVIEWERS_MOCK_RESPONSE: mockResponse("deepseek-v4-pro"),
+      API_REVIEWERS_STATE_LOCK_TIMEOUT_MS: "150",
+      DEEPSEEK_API_KEY: "secret-test-value",
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const record = parseJson(result.stdout);
+  assert.equal(record.status, "completed");
+  assert.match(record.disclosure_note, /JobRecord persistence failed: api_reviewer_state_lock_timeout/);
+  assert.equal(existsSync(path.join(lockDir, "owner.json")), true);
+  assert.equal(existsSync(path.join(dataDir, "jobs", record.id, "meta.json")), true);
+  assert.equal(existsSync(path.join(dataDir, "state.json")), false);
+});
+
+test("direct API reviewer lock reclaims a dead same-host owner", async () => {
+  const cwd = makeWorkspace();
+  const dataDir = mkdtempSync(path.join(tmpdir(), "api-reviewers-data-"));
+  const lockDir = path.join(dataDir, ".state.lock");
+  mkdirSync(lockDir, { recursive: true });
+  writeFileSync(path.join(lockDir, "owner.json"), JSON.stringify({
+    pid: 999999999,
+    hostname: hostname(),
+    startedAt: new Date(Date.now() - 120000).toISOString(),
+    token: "dead-test-owner",
+  }) + "\n");
+  const oldTime = new Date(Date.now() - 120000);
+  utimesSync(lockDir, oldTime, oldTime);
+
+  const result = await run([
+    "run",
+    "--provider", "deepseek",
+    "--mode", "custom-review",
+    "--scope", "custom",
+    "--scope-paths", "seed.txt",
+    "--foreground",
+    "--prompt", "Check this file.",
+  ], {
+    cwd,
+    env: {
+      API_REVIEWERS_PLUGIN_DATA: dataDir,
+      API_REVIEWERS_MOCK_RESPONSE: mockResponse("deepseek-v4-pro"),
+      DEEPSEEK_API_KEY: "secret-test-value",
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const record = parseJson(result.stdout);
+  assert.equal(record.status, "completed");
+  const state = JSON.parse(readFileSync(path.join(dataDir, "state.json"), "utf8"));
+  assert.equal(state.jobs.some((job) => job.id === record.id), true);
+  assert.equal(existsSync(path.join(dataDir, "jobs", record.id, "meta.json")), true);
+  assert.equal(existsSync(lockDir), false);
+});
+
+test("direct API reviewer lock does not reclaim a cross-host owner", async () => {
+  const cwd = makeWorkspace();
+  const dataDir = mkdtempSync(path.join(tmpdir(), "api-reviewers-data-"));
+  const lockDir = path.join(dataDir, ".state.lock");
+  mkdirSync(lockDir, { recursive: true });
+  writeFileSync(path.join(lockDir, "owner.json"), JSON.stringify({
+    pid: 999999999,
+    hostname: "remote-host.invalid",
+    startedAt: new Date(Date.now() - 120000).toISOString(),
+    token: "remote-test-owner",
+  }) + "\n");
+  const oldTime = new Date(Date.now() - 120000);
+  utimesSync(lockDir, oldTime, oldTime);
+
+  const result = await run([
+    "run",
+    "--provider", "deepseek",
+    "--mode", "custom-review",
+    "--scope", "custom",
+    "--scope-paths", "seed.txt",
+    "--foreground",
+    "--prompt", "Check this file.",
+  ], {
+    cwd,
+    env: {
+      API_REVIEWERS_PLUGIN_DATA: dataDir,
+      API_REVIEWERS_MOCK_RESPONSE: mockResponse("deepseek-v4-pro"),
+      API_REVIEWERS_STATE_LOCK_TIMEOUT_MS: "150",
+      DEEPSEEK_API_KEY: "secret-test-value",
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const record = parseJson(result.stdout);
+  assert.equal(record.status, "completed");
+  assert.match(record.disclosure_note, /JobRecord persistence failed: api_reviewer_state_lock_timeout/);
+  assert.equal(existsSync(path.join(lockDir, "owner.json")), true);
+  assert.equal(existsSync(path.join(dataDir, "jobs", record.id, "meta.json")), true);
+  assert.equal(existsSync(path.join(dataDir, "state.json")), false);
+});
+
+test("direct API reviewer lock does not reclaim unreadable owner metadata", async () => {
+  const cwd = makeWorkspace();
+  const dataDir = mkdtempSync(path.join(tmpdir(), "api-reviewers-data-"));
+  const lockDir = path.join(dataDir, ".state.lock");
+  mkdirSync(path.join(lockDir, "owner.json"), { recursive: true });
+  const oldTime = new Date(Date.now() - 120000);
+  utimesSync(lockDir, oldTime, oldTime);
+
+  const result = await run([
+    "run",
+    "--provider", "deepseek",
+    "--mode", "custom-review",
+    "--scope", "custom",
+    "--scope-paths", "seed.txt",
+    "--foreground",
+    "--prompt", "Check this file.",
+  ], {
+    cwd,
+    env: {
+      API_REVIEWERS_PLUGIN_DATA: dataDir,
+      API_REVIEWERS_MOCK_RESPONSE: mockResponse("deepseek-v4-pro"),
+      API_REVIEWERS_STATE_LOCK_TIMEOUT_MS: "150",
+      DEEPSEEK_API_KEY: "secret-test-value",
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const record = parseJson(result.stdout);
+  assert.equal(record.status, "completed");
+  assert.match(record.disclosure_note, /JobRecord persistence failed: api_reviewer_state_lock_timeout/);
+  assert.equal(existsSync(path.join(lockDir, "owner.json")), true);
+  assert.equal(existsSync(path.join(dataDir, "jobs", record.id, "meta.json")), true);
+  assert.equal(existsSync(path.join(dataDir, "state.json")), false);
+});
+
+test("direct API reviewer lock waits behind a live gate owner", async () => {
+  const cwd = makeWorkspace();
+  const dataDir = mkdtempSync(path.join(tmpdir(), "api-reviewers-data-"));
+  const gateDir = path.join(dataDir, ".state.lock.gate");
+  mkdirSync(gateDir, { recursive: true });
+  writeFileSync(path.join(gateDir, "owner.json"), JSON.stringify({
+    pid: process.pid,
+    hostname: hostname(),
+    startedAt: new Date(Date.now() - 120000).toISOString(),
+    token: "live-gate-owner",
+  }) + "\n");
+  const oldTime = new Date(Date.now() - 120000);
+  utimesSync(gateDir, oldTime, oldTime);
+
+  const result = await run([
+    "run",
+    "--provider", "deepseek",
+    "--mode", "custom-review",
+    "--scope", "custom",
+    "--scope-paths", "seed.txt",
+    "--foreground",
+    "--prompt", "Check this file.",
+  ], {
+    cwd,
+    env: {
+      API_REVIEWERS_PLUGIN_DATA: dataDir,
+      API_REVIEWERS_MOCK_RESPONSE: mockResponse("deepseek-v4-pro"),
+      API_REVIEWERS_STATE_LOCK_TIMEOUT_MS: "150",
+      DEEPSEEK_API_KEY: "secret-test-value",
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const record = parseJson(result.stdout);
+  assert.equal(record.status, "completed");
+  assert.match(record.disclosure_note, /JobRecord persistence failed: api_reviewer_state_lock_timeout/);
+  assert.equal(existsSync(path.join(gateDir, "owner.json")), true);
+  assert.equal(existsSync(path.join(dataDir, "jobs", record.id, "meta.json")), true);
+  assert.equal(existsSync(path.join(dataDir, "state.json")), false);
+});
+
+test("direct API reviewer restores current meta if pre-index artifact is pruned", async () => {
+  const cwd = makeWorkspace();
+  const dataDir = mkdtempSync(path.join(tmpdir(), "api-reviewers-data-"));
+  const jobsDir = path.join(dataDir, "jobs");
+  const gateDir = path.join(dataDir, ".state.lock.gate");
+  mkdirSync(gateDir, { recursive: true });
+  writeFileSync(path.join(gateDir, "owner.json"), JSON.stringify({
+    pid: process.pid,
+    hostname: hostname(),
+    startedAt: new Date().toISOString(),
+    token: "test-held-gate",
+  }) + "\n");
+
+  const child = execFile(process.execPath, [
+    COMPANION,
+    "run",
+    "--provider", "deepseek",
+    "--mode", "custom-review",
+    "--scope", "custom",
+    "--scope-paths", "seed.txt",
+    "--foreground",
+    "--prompt", "Check this file.",
+  ], {
+    cwd,
+    env: {
+      ...process.env,
+      API_REVIEWERS_PLUGIN_DATA: dataDir,
+      API_REVIEWERS_MOCK_RESPONSE: mockResponse("deepseek-v4-pro"),
+      API_REVIEWERS_STATE_LOCK_TIMEOUT_MS: "5000",
+      DEEPSEEK_API_KEY: "secret-test-value",
+    },
+    timeout: 10000,
+  });
+
+  let stdout = "";
+  let stderr = "";
+  child.stdout?.setEncoding("utf8");
+  child.stderr?.setEncoding("utf8");
+  child.stdout?.on("data", (chunk) => { stdout += chunk; });
+  child.stderr?.on("data", (chunk) => { stderr += chunk; });
+  const childResult = new Promise((resolve) => {
+    child.on("close", (code) => {
+      resolve({
+        status: code ?? 0,
+        stdout,
+        stderr,
+      });
+    });
+  });
+
+  const jobId = await waitForValue(() => {
+    try {
+      return readdirSync(jobsDir).find((name) => existsSync(path.join(jobsDir, name, "meta.json")));
+    } catch {
+      return null;
+    }
+  });
+
+  rmSync(path.join(jobsDir, jobId), { recursive: true, force: true });
+  rmSync(gateDir, { recursive: true, force: true });
+
+  const result = await childResult;
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const record = parseJson(result.stdout);
+  const state = JSON.parse(readFileSync(path.join(dataDir, "state.json"), "utf8"));
+  assert.equal(record.id, jobId);
+  assert.equal(state.jobs.some((job) => job.id === record.id), true);
+  assert.equal(existsSync(path.join(jobsDir, record.id, "meta.json")), true);
 });
 
 test("mock request-body assertion failures are marked not sent", async () => {

--- a/tests/unit/docs-contracts.test.mjs
+++ b/tests/unit/docs-contracts.test.mjs
@@ -75,6 +75,39 @@ test("cancel command docs enumerate the runtime status and error contracts", () 
   }
 });
 
+test("artifact cleanup inventory covers every provider, review mode, and owned artifact class", () => {
+  const doc = readRepoFile("docs/artifact-cleanup-inventory.md");
+
+  for (const provider of ["Claude", "Gemini", "Kimi", "DeepSeek", "GLM"]) {
+    assert.match(doc, new RegExp(`\\b${provider}\\b`), `missing provider ${provider}`);
+  }
+  for (const mode of ["review", "adversarial-review", "custom-review", "rescue", "foreground", "background", "continue"]) {
+    assert.match(doc, new RegExp(`\\b${mode}\\b`), `missing mode ${mode}`);
+  }
+  for (const artifact of [
+    "state.json",
+    "<jobId>.json",
+    "<jobId>.json.*.tmp",
+    "<jobId>.log",
+    "prompt.txt",
+    "runtime-options.json",
+    "cancel-requested.flag",
+    "git-status-before.txt",
+    "git-status-after.txt",
+    "stdout.log",
+    "stderr.log",
+    "Containment worktree",
+    "Neutral cwd",
+    "jobs/<jobId>/meta.json",
+    "jobs/<jobId>/meta.json.*.tmp",
+  ]) {
+    assert.match(doc, new RegExp(artifact.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `missing artifact ${artifact}`);
+  }
+  assert.match(doc, /does not persist prompt sidecars, copied review bundles, branch-diff files, stdout\/stderr logs, PID records, cancel markers, or subprocess state/);
+  assert.match(doc, /retained-history pruning does not signal processes/);
+  assert.match(doc, /starttime.*argv0/s);
+});
+
 test("claude review command docs use current mutation schema fields", () => {
   const docs = [
     readRepoFile("plugins/claude/commands/claude-review.md"),

--- a/tests/unit/state.test.mjs
+++ b/tests/unit/state.test.mjs
@@ -24,6 +24,7 @@ import {
   generateJobId,
 } from "../../plugins/claude/scripts/lib/state.mjs";
 import * as GeminiState from "../../plugins/gemini/scripts/lib/state.mjs";
+import * as KimiState from "../../plugins/kimi/scripts/lib/state.mjs";
 
 // Node's test runner executes tests WITHIN a single file serially by default
 // (subtests only run concurrently under an explicit `test.describe` with
@@ -33,13 +34,16 @@ import * as GeminiState from "../../plugins/gemini/scripts/lib/state.mjs";
 
 let INITIAL_CONFIG;
 let INITIAL_GEMINI_CONFIG;
+let INITIAL_KIMI_CONFIG;
 before(() => {
   INITIAL_CONFIG = { ...getStateConfig() };
   INITIAL_GEMINI_CONFIG = { ...GeminiState.getStateConfig() };
+  INITIAL_KIMI_CONFIG = { ...KimiState.getStateConfig() };
 });
 afterEach(() => {
   configureState(INITIAL_CONFIG);
   GeminiState.configureState(INITIAL_GEMINI_CONFIG);
+  KimiState.configureState(INITIAL_KIMI_CONFIG);
 });
 
 function freshStateDir() {
@@ -69,6 +73,21 @@ function freshGeminiStateDir() {
 
 function cleanupGemini(dir) {
   delete process.env["GEMINI_STATE_TEST_DATA"];
+  rmSync(dir, { recursive: true, force: true });
+}
+
+function freshKimiStateDir() {
+  const dir = mkdtempSync(path.join(tmpdir(), "kimi-state-test-"));
+  process.env["KIMI_STATE_TEST_DATA"] = dir;
+  KimiState.configureState({
+    pluginDataEnv: "KIMI_STATE_TEST_DATA",
+    fallbackStateRootDir: path.join(dir, "fallback"),
+  });
+  return dir;
+}
+
+function cleanupKimi(dir) {
+  delete process.env["KIMI_STATE_TEST_DATA"];
   rmSync(dir, { recursive: true, force: true });
 }
 
@@ -522,7 +541,105 @@ for (const [target, state, fresh, cleanupTarget] of [
     readJobFileById,
   }, freshStateDir, cleanup],
   ["gemini", GeminiState, freshGeminiStateDir, cleanupGemini],
+  ["kimi", KimiState, freshKimiStateDir, cleanupKimi],
 ]) {
+  test(`${target} state: pruning a terminal job removes owned sidecar directory and sibling tmp files`, () => {
+    const dir = fresh();
+    try {
+      const logFile = state.resolveJobLogFile(dir, "drop-job");
+      const jobFile = state.resolveJobFile(dir, "drop-job");
+      const sidecarDir = path.join(path.dirname(jobFile), "drop-job");
+      const siblingTmp = `${jobFile}.${process.pid}.stale.tmp`;
+      state.writeJobFile(dir, "drop-job", { id: "drop-job", status: "completed" });
+      fs.writeFileSync(logFile, "old log", "utf8");
+      fs.mkdirSync(sidecarDir, { recursive: true });
+      fs.writeFileSync(path.join(sidecarDir, "prompt.txt"), "prompt text", "utf8");
+      fs.writeFileSync(path.join(sidecarDir, "runtime-options.json"), "{\"max_steps_per_turn\":32}\n", "utf8");
+      fs.writeFileSync(path.join(sidecarDir, "git-status-before.txt.tmp"), "partial sidecar", "utf8");
+      fs.writeFileSync(siblingTmp, "partial meta", "utf8");
+
+      state.saveState(dir, {
+        jobs: [{ id: "drop-job", updatedAt: "2000-01-01T00:00:00.000Z", logFile }],
+      });
+      state.saveState(dir, { jobs: [] });
+
+      assert.equal(fs.existsSync(jobFile), false);
+      assert.equal(fs.existsSync(logFile), false);
+      assert.equal(fs.existsSync(sidecarDir), false);
+      assert.equal(fs.existsSync(siblingTmp), false);
+    } finally {
+      cleanupTarget(dir);
+    }
+  });
+
+  test(`${target} state: pruning preserves sidecar directory for still-active jobs`, () => {
+    const dir = fresh();
+    try {
+      const jobFile = state.resolveJobFile(dir, "active-job");
+      const sidecarDir = path.join(path.dirname(jobFile), "active-job");
+      state.writeJobFile(dir, "active-job", { id: "active-job", status: "running" });
+      fs.mkdirSync(sidecarDir, { recursive: true });
+      fs.writeFileSync(path.join(sidecarDir, "prompt.txt"), "still needed", "utf8");
+      state.saveState(dir, {
+        jobs: [{ id: "active-job", status: "running", updatedAt: "2000-01-01T00:00:00.000Z" }],
+      });
+
+      state.saveState(dir, { jobs: [] });
+
+      assert.equal(fs.existsSync(jobFile), true);
+      assert.equal(fs.existsSync(path.join(sidecarDir, "prompt.txt")), true);
+      assert.equal(state.listJobs(dir).some((job) => job.id === "active-job" && job.status === "running"), true);
+    } finally {
+      cleanupTarget(dir);
+    }
+  });
+
+  test(`${target} state: artifact cleanup failures do not block state save`, () => {
+    const dir = fresh();
+    try {
+      state.saveState(dir, {
+        jobs: [
+          { id: "drop-dir-json", status: "completed", updatedAt: "2000-01-01T00:00:00.000Z" },
+        ],
+      });
+      fs.mkdirSync(state.resolveJobFile(dir, "drop-dir-json"), { recursive: true });
+
+      assert.doesNotThrow(() => state.saveState(dir, { jobs: [] }));
+      assert.deepEqual(state.listJobs(dir), []);
+      assert.equal(fs.existsSync(state.resolveJobFile(dir, "drop-dir-json")), true);
+    } finally {
+      cleanupTarget(dir);
+    }
+  });
+
+  test(`${target} state: pruning handles file sidecars and directory-shaped tmp files`, () => {
+    const dir = fresh();
+    try {
+      const jobFile = state.resolveJobFile(dir, "drop-file-sidecar");
+      const jobsDir = path.dirname(jobFile);
+      const sidecarPath = path.join(jobsDir, "drop-file-sidecar");
+      const tmpDir = `${jobFile}.${process.pid}.tmp`;
+      const ignoredTmpLikeFile = path.join(jobsDir, "drop-file-sidecar.json.not-tmp");
+      state.saveState(dir, {
+        jobs: [
+          { id: "drop-file-sidecar", status: "completed", updatedAt: "2000-01-01T00:00:00.000Z" },
+        ],
+      });
+      fs.writeFileSync(sidecarPath, "legacy non-directory sidecar", "utf8");
+      fs.mkdirSync(tmpDir);
+      fs.writeFileSync(ignoredTmpLikeFile, "not a tmp suffix", "utf8");
+
+      state.saveState(dir, { jobs: [] });
+
+      assert.deepEqual(state.listJobs(dir), []);
+      assert.equal(fs.existsSync(sidecarPath), false);
+      assert.equal(fs.existsSync(tmpDir), true);
+      assert.equal(fs.existsSync(ignoredTmpLikeFile), true);
+    } finally {
+      cleanupTarget(dir);
+    }
+  });
+
   test(`${target} state: retained jobs, same timestamps, missing stale files, and null jobs`, () => {
     const dir = fresh();
     try {


### PR DESCRIPTION
## Summary

Fixes #61.

- Adds a provider/mode artifact cleanup inventory covering companion and API reviewer paths.
- Removes pruned terminal companion job artifacts beyond the retained job JSON: safe logs, per-job sidecar directories, and sibling tmp files.
- Adds API reviewer retained-history state, safe job-id constrained pruning, atomic meta writes, and migration/backfill from pre-existing `jobs/<jobId>/meta.json` directories before pruning.
- Documents that retained-history pruning does not signal live processes; process termination remains owned by cancel/reconcile ownership checks.

## Root Cause

Companion pruning only removed the main job JSON and safe log path, leaving owned per-job helper directories behind. API reviewer cleanup also had no retained-history pruning path, and the first implementation needed a migration guard because previous API reviewer runs could have directory-only `jobs/<jobId>/meta.json` artifacts without a `state.json` index.

## Verification

- `node --test --test-reporter=spec tests/smoke/api-reviewers.smoke.test.mjs`: 53 pass
- `node --test --test-reporter=spec tests/unit/state.test.mjs`: 88 pass
- `CODEX_PLUGIN_SKIP_SMOKE=1 npm run test:coverage`: 710 tests, 697 pass, 13 skipped, 0 failures; coverage target met
- `npm run lint`: pass
- `git diff --check`: clean
- `npm test`: 755 tests, 749 pass, 6 skipped, 0 failures
- pre-commit `npm test`: 755 tests, 749 pass, 6 skipped, 0 failures