### PR TITLE
Add workflow-specific provider skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,13 @@ one without the others.
 
 After enabling the plugins, open Codex's skill picker or ask Codex what plugin
 skills are available. Current Codex builds expose plugin skills with their
-plugin namespace; the installed skill list should include
-`claude:claude-delegation`, `gemini:gemini-delegation`, and
-`kimi:kimi-delegation`. The API-backed reviewer plugin exposes
+plugin namespace. The discoverable UX is `<plugin>:<provider-workflow>` through
+workflow-specific skills such as `claude:claude-review`,
+`gemini:gemini-rescue`, `kimi:kimi-status`,
+`api-reviewers:deepseek-review`, and `api-reviewers:glm-setup`. The installed
+skill list should also include the broad fallback skills
+`claude:claude-delegation`, `gemini:gemini-delegation`,
+`kimi:kimi-delegation`, and
 `api-reviewers:api-reviewers-delegation`.
 
 For a non-interactive check against the current Codex profile, run:
@@ -142,39 +146,58 @@ future or compatible Codex builds, but plugin command files are not valid slash
 commands in this Codex build.
 
 Until Codex exposes plugin command files through the TUI, verify runtime behavior
-through the user-invocable skill fallback, the mock smoke tests, opt-in live E2E
-tests, or the companion scripts under `plugins/<target>/scripts/`.
+through user-invocable workflow-specific skills, the broad delegation skill
+fallbacks, the mock smoke tests, opt-in live E2E tests, or the companion scripts
+under `plugins/<target>/scripts/`.
 
-## Skill fallback
+## Workflow Skills
 
-Codex CLI 0.125.0 can load plugin skills, so each plugin exposes one
-user-invocable skill fallback:
+Codex CLI 0.125.0 can load plugin skills, so each provider workflow is exposed
+as a user-invocable skill. Current Codex builds list these skills with plugin
+namespaces. These are thin wrappers around the existing companion/API reviewer
+contracts:
 
-- **Claude delegation skill:** asks Claude Code to run setup checks, preflight,
-  review, adversarial review, custom-review, rescue, status, result, or cancel workflows through
-  `plugins/claude/scripts/claude-companion.mjs`.
-- **Gemini delegation skill:** asks Gemini CLI to run setup checks, preflight,
-  review, adversarial review, custom-review, rescue, status, result, or cancel workflows through
-  `plugins/gemini/scripts/gemini-companion.mjs`.
-- **Kimi delegation skill:** asks Kimi Code CLI to run setup checks, preflight,
-  review, adversarial review, custom-review, rescue, status, result, or cancel workflows through
-  `plugins/kimi/scripts/kimi-companion.mjs`.
-- **API reviewers delegation skill:** asks DeepSeek or GLM direct API to run
-  setup checks, review, adversarial review, or custom-review workflows through
-  `plugins/api-reviewers/scripts/api-reviewer.mjs`.
+- **Claude:** `claude:claude-review`,
+  `claude:claude-adversarial-review`, `claude:claude-rescue`,
+  `claude:claude-setup`, `claude:claude-status`, `claude:claude-result`,
+  `claude:claude-cancel`.
+- **Gemini:** `gemini:gemini-review`,
+  `gemini:gemini-adversarial-review`, `gemini:gemini-rescue`,
+  `gemini:gemini-setup`, `gemini:gemini-status`, `gemini:gemini-result`,
+  `gemini:gemini-cancel`.
+- **Kimi:** `kimi:kimi-review`, `kimi:kimi-adversarial-review`,
+  `kimi:kimi-rescue`, `kimi:kimi-setup`, `kimi:kimi-status`,
+  `kimi:kimi-result`, `kimi:kimi-cancel`.
+- **DeepSeek:** `api-reviewers:deepseek-review`,
+  `api-reviewers:deepseek-adversarial-review`,
+  `api-reviewers:deepseek-custom-review`, `api-reviewers:deepseek-setup`.
+- **GLM:** `api-reviewers:glm-review`,
+  `api-reviewers:glm-adversarial-review`,
+  `api-reviewers:glm-custom-review`, `api-reviewers:glm-setup`.
+
+The broad delegation skills remain available as fallback/overview entries:
+`claude:claude-delegation`, `gemini:gemini-delegation`,
+`kimi:kimi-delegation`, and `api-reviewers:api-reviewers-delegation`.
+
+The original user-invocable skill fallback remains available for users who
+prefer one overview entry per plugin. The Claude, Gemini, Kimi, and API
+reviewers delegation skills still route to their companion/API reviewer scripts
+as broad overview entries.
+For Claude, Gemini, and Kimi, advanced `custom-review` and `preflight` flows
+remain available through those broad delegation skills.
 
 Example prompts:
 
 ```text
-Use the Claude delegation skill to review the current diff for regressions.
-Use the Gemini delegation skill for an adversarial review of this design.
-Use the Kimi delegation skill to review this branch for missed edge cases.
-Use the API reviewers delegation skill to ask GLM to review selected files.
+Use claude:claude-review to review the current diff for regressions.
+Use gemini:gemini-adversarial-review for an adversarial review of this design.
+Use kimi:kimi-rescue to investigate this failing test in the background, then use kimi:kimi-status and kimi:kimi-result.
+Use api-reviewers:deepseek-custom-review to review selected files.
 ```
 
 ## Deferred command docs
 
-The plugin still packages command docs for the intended future slash-command
+The slash-command files remain packaged for the intended future slash-command
 surface, except diagnostic ping command docs are deferred until upstream Codex
 registers plugin command files. The ping follow-up is tracked in
 https://github.com/seungpyoson/codex-plugin-multi/issues/13. Example future

--- a/plugins/api-reviewers/commands/deepseek-adversarial-review.md
+++ b/plugins/api-reviewers/commands/deepseek-adversarial-review.md
@@ -1,12 +1,13 @@
 ---
 description: Ask DeepSeek direct API for an adversarial review.
-argument-hint: "[review prompt]"
+argument-hint: "[--scope-base REF] [review prompt]"
 ---
 
 Run:
 
 ```bash
-node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider deepseek --mode adversarial-review --scope branch-diff --foreground --prompt "$ARGUMENTS"
+node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider deepseek --mode adversarial-review --scope branch-diff --prompt "<prompt text>"
 ```
 
-Render the returned JobRecord. Do not print API-key values.
+`$ARGUMENTS` may include an optional `--scope-base REF` followed by prompt text. If present, pass `--scope-base REF` before `--prompt` and pass only the remaining prompt text to `--prompt`.
+Render the returned JobRecord. If `external_review` is present, render it before the review result. Do not print API-key values.

--- a/plugins/api-reviewers/commands/deepseek-custom-review.md
+++ b/plugins/api-reviewers/commands/deepseek-custom-review.md
@@ -6,7 +6,8 @@ argument-hint: "--scope-paths <files> [review prompt]"
 Run:
 
 ```bash
-node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider deepseek --mode custom-review --scope custom --scope-paths "$SCOPE_PATHS" --foreground --prompt "$ARGUMENTS"
+node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider deepseek --mode custom-review --scope custom --scope-paths "<file1>,<file2>" --prompt "<prompt text>"
 ```
 
-Render the returned JobRecord. Do not print API-key values.
+`$ARGUMENTS` may include `--scope-paths <files>` followed by prompt text. Pass the files to `--scope-paths`. Replace `<file1>,<file2>` with comma- or newline-separated concrete relative paths, expand globs before running, and pass only the remaining prompt text to `--prompt`.
+Render the returned JobRecord. If `external_review` is present, render it before the review result. Do not print API-key values.

--- a/plugins/api-reviewers/commands/deepseek-review.md
+++ b/plugins/api-reviewers/commands/deepseek-review.md
@@ -1,12 +1,13 @@
 ---
 description: Ask DeepSeek direct API to review the current diff.
-argument-hint: "[review prompt]"
+argument-hint: "[--scope-base REF] [review prompt]"
 ---
 
 Run:
 
 ```bash
-node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider deepseek --mode review --scope branch-diff --foreground --prompt "$ARGUMENTS"
+node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider deepseek --mode review --scope branch-diff --prompt "<prompt text>"
 ```
 
-Render the returned JobRecord. Do not print API-key values.
+`$ARGUMENTS` may include an optional `--scope-base REF` followed by prompt text. If present, pass `--scope-base REF` before `--prompt` and pass only the remaining prompt text to `--prompt`.
+Render the returned JobRecord. If `external_review` is present, render it before the review result. Do not print API-key values.

--- a/plugins/api-reviewers/commands/glm-adversarial-review.md
+++ b/plugins/api-reviewers/commands/glm-adversarial-review.md
@@ -1,12 +1,13 @@
 ---
 description: Ask GLM direct API for an adversarial review.
-argument-hint: "[review prompt]"
+argument-hint: "[--scope-base REF] [review prompt]"
 ---
 
 Run:
 
 ```bash
-node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider glm --mode adversarial-review --scope branch-diff --foreground --prompt "$ARGUMENTS"
+node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider glm --mode adversarial-review --scope branch-diff --prompt "<prompt text>"
 ```
 
-Render the returned JobRecord. Do not print API-key values.
+`$ARGUMENTS` may include an optional `--scope-base REF` followed by prompt text. If present, pass `--scope-base REF` before `--prompt` and pass only the remaining prompt text to `--prompt`.
+Render the returned JobRecord. If `external_review` is present, render it before the review result. Do not print API-key values.

--- a/plugins/api-reviewers/commands/glm-custom-review.md
+++ b/plugins/api-reviewers/commands/glm-custom-review.md
@@ -6,7 +6,8 @@ argument-hint: "--scope-paths <files> [review prompt]"
 Run:
 
 ```bash
-node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider glm --mode custom-review --scope custom --scope-paths "$SCOPE_PATHS" --foreground --prompt "$ARGUMENTS"
+node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider glm --mode custom-review --scope custom --scope-paths "<file1>,<file2>" --prompt "<prompt text>"
 ```
 
-Render the returned JobRecord. Do not print API-key values.
+`$ARGUMENTS` may include `--scope-paths <files>` followed by prompt text. Pass the files to `--scope-paths`. Replace `<file1>,<file2>` with comma- or newline-separated concrete relative paths, expand globs before running, and pass only the remaining prompt text to `--prompt`.
+Render the returned JobRecord. If `external_review` is present, render it before the review result. Do not print API-key values.

--- a/plugins/api-reviewers/commands/glm-review.md
+++ b/plugins/api-reviewers/commands/glm-review.md
@@ -1,12 +1,13 @@
 ---
 description: Ask GLM direct API to review the current diff.
-argument-hint: "[review prompt]"
+argument-hint: "[--scope-base REF] [review prompt]"
 ---
 
 Run:
 
 ```bash
-node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider glm --mode review --scope branch-diff --foreground --prompt "$ARGUMENTS"
+node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider glm --mode review --scope branch-diff --prompt "<prompt text>"
 ```
 
-Render the returned JobRecord. Do not print API-key values.
+`$ARGUMENTS` may include an optional `--scope-base REF` followed by prompt text. If present, pass `--scope-base REF` before `--prompt` and pass only the remaining prompt text to `--prompt`.
+Render the returned JobRecord. If `external_review` is present, render it before the review result. Do not print API-key values.

--- a/plugins/api-reviewers/skills/api-reviewers-delegation/SKILL.md
+++ b/plugins/api-reviewers/skills/api-reviewers-delegation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: api-reviewers-delegation
-description: Delegate review, adversarial review, custom review, setup checks, and result rendering to direct API-backed DeepSeek and GLM reviewers.
+description: Delegate review, adversarial review, custom review, and setup to DeepSeek/GLM.
 user-invocable: true
 ---
 
@@ -29,14 +29,16 @@ Render the JSON fields directly:
 
 ## Review
 
-Run foreground reviews with:
+Run reviews with:
 
 ```bash
-node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider deepseek --mode review --scope branch-diff --foreground --prompt "$PROMPT"
-node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider glm --mode adversarial-review --scope branch-diff --foreground --prompt "$PROMPT"
-node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider deepseek --mode custom-review --scope custom --scope-paths "$FILES" --foreground --prompt "$PROMPT"
+node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider deepseek --mode review --scope branch-diff --prompt "<focus>"
+node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider glm --mode adversarial-review --scope branch-diff --prompt "<focus>"
+node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider deepseek --mode custom-review --scope custom --scope-paths "<file1>,<file2>" --prompt "<focus>"
 ```
 
+For branch-diff review or adversarial-review, add `--scope-base REF` before `--prompt` when the user provides a base ref. Use `<focus>` as the user's review prompt or focus area.
+Replace `<file1>,<file2>` with comma- or newline-separated concrete relative paths for `--scope-paths`; expand globs before running.
 If the command fails, report `error_code`, `error_message`, and `suggested_action` from the JobRecord. Do not expose API keys.
 If `external_review` is present, render it before the review result.
 

--- a/plugins/api-reviewers/skills/deepseek-adversarial-review/SKILL.md
+++ b/plugins/api-reviewers/skills/deepseek-adversarial-review/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: deepseek-adversarial-review
+description: Use when asking DeepSeek direct API for an adversarial review.
+user-invocable: true
+---
+
+# DeepSeek Adversarial Review
+
+Use the API reviewer DeepSeek adversarial-review workflow. Current Codex builds expose it as `api-reviewers:deepseek-adversarial-review` in the skill picker; its skill frontmatter name is `deepseek-adversarial-review`; the command contract is `plugins/api-reviewers/commands/deepseek-adversarial-review.md`.
+
+Run from the repository root:
+
+```bash
+node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider deepseek --mode adversarial-review --scope branch-diff --prompt "<focus>"
+```
+
+If the user provides a base ref, add `--scope-base REF` before `--prompt`. `<focus>` is the user's review prompt or focus area.
+Render the returned JobRecord, render `external_review` before the review result when present, and never print API-key values.

--- a/plugins/api-reviewers/skills/deepseek-custom-review/SKILL.md
+++ b/plugins/api-reviewers/skills/deepseek-custom-review/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: deepseek-custom-review
+description: Use when asking DeepSeek direct API to review explicit files.
+user-invocable: true
+---
+
+# DeepSeek Custom Review
+
+Use the API reviewer DeepSeek custom-review workflow. Current Codex builds expose it as `api-reviewers:deepseek-custom-review` in the skill picker; its skill frontmatter name is `deepseek-custom-review`; the command contract is `plugins/api-reviewers/commands/deepseek-custom-review.md`.
+
+Run from the repository root:
+
+```bash
+node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider deepseek --mode custom-review --scope custom --scope-paths "<file1>,<file2>" --prompt "<focus>"
+```
+
+Replace `<file1>,<file2>` with comma- or newline-separated concrete relative `--scope-paths`; expand globs before running. `<focus>` is the user's review prompt or focus area. Render `external_review` before the review result when present. Never print API-key values.

--- a/plugins/api-reviewers/skills/deepseek-review/SKILL.md
+++ b/plugins/api-reviewers/skills/deepseek-review/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: deepseek-review
+description: Use when asking DeepSeek direct API to review the current branch diff.
+user-invocable: true
+---
+
+# DeepSeek Review
+
+Use the API reviewer DeepSeek review workflow. Current Codex builds expose it as `api-reviewers:deepseek-review` in the skill picker; its skill frontmatter name is `deepseek-review`; the command contract is `plugins/api-reviewers/commands/deepseek-review.md`.
+
+Run from the repository root:
+
+```bash
+node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider deepseek --mode review --scope branch-diff --prompt "<focus>"
+```
+
+If the user provides a base ref, add `--scope-base REF` before `--prompt`. `<focus>` is the user's review prompt or focus area.
+Render the returned JobRecord, render `external_review` before the review result when present, and never print API-key values.

--- a/plugins/api-reviewers/skills/deepseek-setup/SKILL.md
+++ b/plugins/api-reviewers/skills/deepseek-setup/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: deepseek-setup
+description: Use when checking DeepSeek direct API reviewer readiness.
+user-invocable: true
+---
+
+# DeepSeek Setup
+
+Use the API reviewer DeepSeek setup workflow. Current Codex builds expose it as `api-reviewers:deepseek-setup` in the skill picker; its skill frontmatter name is `deepseek-setup`; the command contract is `plugins/api-reviewers/commands/deepseek-setup.md`.
+
+Run from the repository root:
+
+```bash
+node plugins/api-reviewers/scripts/api-reviewer.mjs doctor --provider deepseek
+```
+
+Show `summary`, `ready`, `next_action`, and credential key names only.

--- a/plugins/api-reviewers/skills/glm-adversarial-review/SKILL.md
+++ b/plugins/api-reviewers/skills/glm-adversarial-review/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: glm-adversarial-review
+description: Use when asking GLM direct API for an adversarial review.
+user-invocable: true
+---
+
+# GLM Adversarial Review
+
+Use the API reviewer GLM adversarial-review workflow. Current Codex builds expose it as `api-reviewers:glm-adversarial-review` in the skill picker; its skill frontmatter name is `glm-adversarial-review`; the command contract is `plugins/api-reviewers/commands/glm-adversarial-review.md`.
+
+Run from the repository root:
+
+```bash
+node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider glm --mode adversarial-review --scope branch-diff --prompt "<focus>"
+```
+
+If the user provides a base ref, add `--scope-base REF` before `--prompt`. `<focus>` is the user's review prompt or focus area.
+Render the returned JobRecord, render `external_review` before the review result when present, and never print API-key values.

--- a/plugins/api-reviewers/skills/glm-custom-review/SKILL.md
+++ b/plugins/api-reviewers/skills/glm-custom-review/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: glm-custom-review
+description: Use when asking GLM direct API to review explicit files.
+user-invocable: true
+---
+
+# GLM Custom Review
+
+Use the API reviewer GLM custom-review workflow. Current Codex builds expose it as `api-reviewers:glm-custom-review` in the skill picker; its skill frontmatter name is `glm-custom-review`; the command contract is `plugins/api-reviewers/commands/glm-custom-review.md`.
+
+Run from the repository root:
+
+```bash
+node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider glm --mode custom-review --scope custom --scope-paths "<file1>,<file2>" --prompt "<focus>"
+```
+
+Replace `<file1>,<file2>` with comma- or newline-separated concrete relative `--scope-paths`; expand globs before running. `<focus>` is the user's review prompt or focus area. Render `external_review` before the review result when present. Never print API-key values.

--- a/plugins/api-reviewers/skills/glm-review/SKILL.md
+++ b/plugins/api-reviewers/skills/glm-review/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: glm-review
+description: Use when asking GLM direct API to review the current branch diff.
+user-invocable: true
+---
+
+# GLM Review
+
+Use the API reviewer GLM review workflow. Current Codex builds expose it as `api-reviewers:glm-review` in the skill picker; its skill frontmatter name is `glm-review`; the command contract is `plugins/api-reviewers/commands/glm-review.md`.
+
+Run from the repository root:
+
+```bash
+node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider glm --mode review --scope branch-diff --prompt "<focus>"
+```
+
+If the user provides a base ref, add `--scope-base REF` before `--prompt`. `<focus>` is the user's review prompt or focus area.
+Render the returned JobRecord, render `external_review` before the review result when present, and never print API-key values.

--- a/plugins/api-reviewers/skills/glm-setup/SKILL.md
+++ b/plugins/api-reviewers/skills/glm-setup/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: glm-setup
+description: Use when checking GLM direct API reviewer readiness.
+user-invocable: true
+---
+
+# GLM Setup
+
+Use the API reviewer GLM setup workflow. Current Codex builds expose it as `api-reviewers:glm-setup` in the skill picker; its skill frontmatter name is `glm-setup`; the command contract is `plugins/api-reviewers/commands/glm-setup.md`.
+
+Run from the repository root:
+
+```bash
+node plugins/api-reviewers/scripts/api-reviewer.mjs doctor --provider glm
+```
+
+Show `summary`, `ready`, `next_action`, and credential key names only.

--- a/plugins/claude/commands/claude-adversarial-review.md
+++ b/plugins/claude/commands/claude-adversarial-review.md
@@ -1,20 +1,20 @@
 ---
 description: Get Claude Code to adversarially challenge the current design. Not a linter — a "why will this break" pass.
-argument-hint: "[--scope-base <ref>] [focus area]"
+argument-hint: "[--scope-base REF] [focus area]"
 ---
 
 Adversarial review via Claude Code. Assumes the author is wrong; looks for failure modes, hidden assumptions, missing edge cases.
 
 ## Arguments
 
-`$ARGUMENTS` — optional `--scope-base <ref>` followed by focus text (e.g., "error handling", "concurrency"). If present, pass `--scope-base <ref>` before `--`; pass the remaining focus text after `--`.
+`$ARGUMENTS` — optional `--scope-base REF` followed by focus text (e.g., "error handling", "concurrency"). If present, pass `--scope-base REF` before `--`; pass the remaining focus text after `--`.
 
 ## Workflow
 
 1. Consult the `claude-prompting` skill for adversarial prompt framing.
 2. Run:
    ```
-   node "<plugin-root>/scripts/claude-companion.mjs" run --mode=adversarial-review --foreground [--scope-base <ref>] -- "<focus text>"
+   node "<plugin-root>/scripts/claude-companion.mjs" run --mode=adversarial-review --foreground -- "<focus text>"
    ```
    (Containment=worktree, scope=branch-diff, dispose=true all come from the profile — spec §21.4.)
    `branch-diff` is object-pure: checkout filters, replace refs, and grafts are ignored.

--- a/plugins/claude/commands/claude-cancel.md
+++ b/plugins/claude/commands/claude-cancel.md
@@ -8,8 +8,9 @@ argument-hint: "<job-id> [--force]"
 1. Confirm with the user before canceling unless they passed `--force` (SIGKILL).
 2. Parse `$ARGUMENTS` as `<job-id> [--force]`, then run:
    ```
-   node "<plugin-root>/scripts/claude-companion.mjs" cancel --job <job-id> [--force]
+   node "<plugin-root>/scripts/claude-companion.mjs" cancel --job "<job-id>"
    ```
+   Add `--force` only when the user passed `--force`.
 3. Report the response JSON. The exit code is the coarse-grained outcome; the JSON `status` field is the fine-grained reason.
 
 ### Statuses and exit codes

--- a/plugins/claude/commands/claude-review.md
+++ b/plugins/claude/commands/claude-review.md
@@ -1,20 +1,20 @@
 ---
 description: Get Claude Code's read-only review of the current diff, files, or focus area. Runs in a disposable worktree (default).
-argument-hint: "[--scope-base <ref>] [focus area]"
+argument-hint: "[--scope-base REF] [focus area]"
 ---
 
 Review via Claude Code. Read-only; changes detected post-hoc, never auto-reverted.
 
 ## Arguments
 
-`$ARGUMENTS` — optional `--scope-base <ref>` followed by focus text. If present, pass `--scope-base <ref>` before `--`; pass the remaining focus text after `--`.
+`$ARGUMENTS` — optional `--scope-base REF` followed by focus text. If present, pass `--scope-base REF` before `--`; pass the remaining focus text after `--`.
 
 ## Workflow
 
 1. Consult the `claude-prompting` skill for review-mode prompt framing and schema hints.
 2. Run:
    ```
-   node "<plugin-root>/scripts/claude-companion.mjs" run --mode=review --foreground [--scope-base <ref>] -- "<focus text>"
+   node "<plugin-root>/scripts/claude-companion.mjs" run --mode=review --foreground -- "<focus text>"
    ```
    (Containment + scope + dispose are all carried by the review profile — spec §21.4.)
    For a pinned review bundle or hand-picked files, first run `preflight`, then use

--- a/plugins/claude/skills/claude-adversarial-review/SKILL.md
+++ b/plugins/claude/skills/claude-adversarial-review/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: claude-adversarial-review
+description: Use when asking Claude Code to challenge a design or diff adversarially.
+user-invocable: true
+---
+
+# Claude Adversarial Review
+
+Use the Claude companion adversarial-review workflow. Current Codex builds expose it as `claude:claude-adversarial-review` in the skill picker; its skill frontmatter name is `claude-adversarial-review`; the command contract is `plugins/claude/commands/claude-adversarial-review.md`.
+
+`<plugin-root>` is `plugins/claude` or an absolute path to that plugin directory; `<workspace>` is the repository or bundle directory to review; `<focus>` is the user's review prompt or focus area. Run:
+
+```bash
+node "<plugin-root>/scripts/claude-companion.mjs" run --mode=adversarial-review --foreground --cwd "<workspace>" -- "<focus>"
+```
+
+If the user provides a base ref, add `--scope-base REF` before `--`.
+
+Render findings by severity, render `external_review` before normal prose when present, and surface any `mutations`. Do not claim `/claude-adversarial-review` is available in Codex builds that do not register plugin command files.

--- a/plugins/claude/skills/claude-cancel/SKILL.md
+++ b/plugins/claude/skills/claude-cancel/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: claude-cancel
+description: Use when cancelling a running Claude-plugin background job.
+user-invocable: true
+---
+
+# Claude Cancel
+
+Use the Claude companion cancel workflow. Current Codex builds expose it as `claude:claude-cancel` in the skill picker; its skill frontmatter name is `claude-cancel`; the command contract is `plugins/claude/commands/claude-cancel.md`.
+
+`<plugin-root>` is `plugins/claude` or an absolute path to that plugin directory; `<workspace>` is the workspace where the job was launched; `<job-id>` is the identifier returned by a background launch or listed by the status workflow. Run:
+
+```bash
+node "<plugin-root>/scripts/claude-companion.mjs" cancel --cwd "<workspace>" --job "<job-id>"
+```
+
+Confirm before cancelling unless the user already requested force. Foreground runs should be interrupted with Ctrl+C.

--- a/plugins/claude/skills/claude-delegation/SKILL.md
+++ b/plugins/claude/skills/claude-delegation/SKILL.md
@@ -25,8 +25,10 @@ In the repository checkout, it is `plugins/claude`.
 
 - Setup/OAuth check:
   ```bash
-  node "<plugin-root>/scripts/claude-companion.mjs" ping
+  node "<plugin-root>/scripts/claude-companion.mjs" doctor
   ```
+For review or adversarial-review, add `--scope-base REF` before `--` when the user provides a base ref.
+
 - Read-only review:
   ```bash
   node "<plugin-root>/scripts/claude-companion.mjs" run --mode=review --foreground --cwd "<workspace>" -- "<review focus>"

--- a/plugins/claude/skills/claude-rescue/SKILL.md
+++ b/plugins/claude/skills/claude-rescue/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: claude-rescue
+description: Use when delegating investigation, fixes, or follow-up rescue work to Claude Code.
+user-invocable: true
+---
+
+# Claude Rescue
+
+Use the Claude companion rescue workflow. Current Codex builds expose it as `claude:claude-rescue` in the skill picker; its skill frontmatter name is `claude-rescue`; the command contract is `plugins/claude/commands/claude-rescue.md`.
+
+`<plugin-root>` is `plugins/claude` or an absolute path to that plugin directory; `<workspace>` is the repository where the rescue task should run. Run:
+
+```bash
+node "<plugin-root>/scripts/claude-companion.mjs" run --mode=rescue --background --cwd "<workspace>" -- "<task>"
+```
+
+Rescue is write-capable by design. Prefer review skills for read-only critique. Do not claim `/claude-rescue` is available in Codex builds that do not register plugin command files.

--- a/plugins/claude/skills/claude-result/SKILL.md
+++ b/plugins/claude/skills/claude-result/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: claude-result
+description: Use when showing the stored result of a finished Claude-plugin job.
+user-invocable: true
+---
+
+# Claude Result
+
+Use the Claude companion result workflow. Current Codex builds expose it as `claude:claude-result` in the skill picker; its skill frontmatter name is `claude-result`; the command contract is `plugins/claude/commands/claude-result.md`.
+
+`<plugin-root>` is `plugins/claude` or an absolute path to that plugin directory; `<workspace>` is the workspace where the job was launched; `<job-id>` is the identifier returned by a background launch or listed by the status workflow. Run:
+
+```bash
+node "<plugin-root>/scripts/claude-companion.mjs" result --cwd "<workspace>" --job "<job-id>"
+```
+
+Render companion JSON according to `claude-result-handling`. Do not re-run the job.

--- a/plugins/claude/skills/claude-review/SKILL.md
+++ b/plugins/claude/skills/claude-review/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: claude-review
+description: Use when asking Claude Code to review the current diff, files, or focus area.
+user-invocable: true
+---
+
+# Claude Review
+
+Use the Claude companion review workflow. Current Codex builds expose it as `claude:claude-review` in the skill picker; its skill frontmatter name is `claude-review`; the command contract is `plugins/claude/commands/claude-review.md`.
+
+`<plugin-root>` is `plugins/claude` or an absolute path to that plugin directory; `<workspace>` is the repository or bundle directory to review; `<focus>` is the user's review prompt or focus area. Run:
+
+```bash
+node "<plugin-root>/scripts/claude-companion.mjs" run --mode=review --foreground --cwd "<workspace>" -- "<focus>"
+```
+
+If the user provides a base ref, add `--scope-base REF` before `--`.
+
+Render companion JSON according to `claude-result-handling`; render `external_review` before normal prose when present. Do not claim `/claude-review` is available in Codex builds that do not register plugin command files.

--- a/plugins/claude/skills/claude-setup/SKILL.md
+++ b/plugins/claude/skills/claude-setup/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: claude-setup
+description: Use when checking Claude Code installation and OAuth readiness for the Claude plugin.
+user-invocable: true
+---
+
+# Claude Setup
+
+Use the Claude companion setup workflow. Current Codex builds expose it as `claude:claude-setup` in the skill picker; its skill frontmatter name is `claude-setup`; the command contract is `plugins/claude/commands/claude-setup.md`.
+
+`<plugin-root>` is `plugins/claude` or an absolute path to that plugin directory. Run:
+
+```bash
+node "<plugin-root>/scripts/claude-companion.mjs" doctor
+```
+
+Show `summary`, `ready`, and `next_action` exactly. Never print secret values or suggest Claude API keys for subscription/OAuth setup.

--- a/plugins/claude/skills/claude-status/SKILL.md
+++ b/plugins/claude/skills/claude-status/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: claude-status
+description: Use when listing active or recent Claude-plugin jobs for the current workspace.
+user-invocable: true
+---
+
+# Claude Status
+
+Use the Claude companion status workflow. Current Codex builds expose it as `claude:claude-status` in the skill picker; its skill frontmatter name is `claude-status`; the command contract is `plugins/claude/commands/claude-status.md`.
+
+`<plugin-root>` is `plugins/claude` or an absolute path to that plugin directory; `<workspace>` is the workspace where the job was launched. Run:
+
+```bash
+node "<plugin-root>/scripts/claude-companion.mjs" status --cwd "<workspace>" --all
+```
+
+Render `job_id`, `status`, `mode`, `model`, `started_at`, and `ended_at`. Do not expose sidecar paths unless explicitly asked.

--- a/plugins/gemini/commands/gemini-adversarial-review.md
+++ b/plugins/gemini/commands/gemini-adversarial-review.md
@@ -1,19 +1,19 @@
 ---
 description: Get Gemini CLI to adversarially challenge the current design under read-only policy.
-argument-hint: "[--scope-base <ref>] [focus area]"
+argument-hint: "[--scope-base REF] [focus area]"
 ---
 
 Adversarial review via Gemini CLI. Assumes the author is wrong; looks for failure modes, hidden assumptions, and missing edge cases.
 
 ## Arguments
 
-`$ARGUMENTS` — optional `--scope-base <ref>` followed by focus text. If present, pass `--scope-base <ref>` before `--`; pass the remaining focus text after `--`.
+`$ARGUMENTS` — optional `--scope-base REF` followed by focus text. If present, pass `--scope-base REF` before `--`; pass the remaining focus text after `--`.
 
 ## Workflow
 
 Run:
 ```
-node "<plugin-root>/scripts/gemini-companion.mjs" run --mode=adversarial-review --foreground [--scope-base <ref>] -- "<focus text>"
+node "<plugin-root>/scripts/gemini-companion.mjs" run --mode=adversarial-review --foreground -- "<focus text>"
 ```
 `branch-diff` is object-pure: checkout filters, replace refs, and grafts are ignored.
 It reduces the selected review scope, but a successful run still sends those

--- a/plugins/gemini/commands/gemini-cancel.md
+++ b/plugins/gemini/commands/gemini-cancel.md
@@ -8,8 +8,9 @@ argument-hint: "<job-id> [--force]"
 1. Confirm with the user before canceling unless they passed `--force` (SIGKILL).
 2. Parse `$ARGUMENTS` as `<job-id> [--force]`, then run:
    ```
-   node "<plugin-root>/scripts/gemini-companion.mjs" cancel --job <job-id> [--force]
+   node "<plugin-root>/scripts/gemini-companion.mjs" cancel --job "<job-id>"
    ```
+   Add `--force` only when the user passed `--force`.
 3. Report the response JSON. The exit code is the coarse-grained outcome; the JSON `status` field is the fine-grained reason.
 
 ### Statuses and exit codes

--- a/plugins/gemini/commands/gemini-review.md
+++ b/plugins/gemini/commands/gemini-review.md
@@ -1,19 +1,19 @@
 ---
 description: Get Gemini CLI's read-only review of the current diff, files, or focus area. Runs with TOML policy enforcement.
-argument-hint: "[--scope-base <ref>] [focus area]"
+argument-hint: "[--scope-base REF] [focus area]"
 ---
 
 Review via Gemini CLI. Read-only policy is mandatory; changes detected post-hoc, never auto-reverted.
 
 ## Arguments
 
-`$ARGUMENTS` — optional `--scope-base <ref>` followed by focus text. If present, pass `--scope-base <ref>` before `--`; pass the remaining focus text after `--`.
+`$ARGUMENTS` — optional `--scope-base REF` followed by focus text. If present, pass `--scope-base REF` before `--`; pass the remaining focus text after `--`.
 
 ## Workflow
 
 Run:
 ```
-node "<plugin-root>/scripts/gemini-companion.mjs" run --mode=review --foreground [--scope-base <ref>] -- "<focus text>"
+node "<plugin-root>/scripts/gemini-companion.mjs" run --mode=review --foreground -- "<focus text>"
 ```
 
 For a pinned review bundle or selected files, first run `preflight`, then use

--- a/plugins/gemini/skills/gemini-adversarial-review/SKILL.md
+++ b/plugins/gemini/skills/gemini-adversarial-review/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: gemini-adversarial-review
+description: Use when asking Gemini CLI to challenge a design or diff adversarially.
+user-invocable: true
+---
+
+# Gemini Adversarial Review
+
+Use the Gemini companion adversarial-review workflow. Current Codex builds expose it as `gemini:gemini-adversarial-review` in the skill picker; its skill frontmatter name is `gemini-adversarial-review`; the command contract is `plugins/gemini/commands/gemini-adversarial-review.md`.
+
+`<plugin-root>` is `plugins/gemini` or an absolute path to that plugin directory; `<workspace>` is the repository or bundle directory to review; `<focus>` is the user's review prompt or focus area. Run:
+
+```bash
+node "<plugin-root>/scripts/gemini-companion.mjs" run --mode=adversarial-review --foreground --cwd "<workspace>" -- "<focus>"
+```
+
+If the user provides a base ref, add `--scope-base REF` before `--`.
+
+Render findings by severity, render `external_review` before normal prose when present, and surface any `mutations`. Do not claim `/gemini-adversarial-review` is available in Codex builds that do not register plugin command files.

--- a/plugins/gemini/skills/gemini-cancel/SKILL.md
+++ b/plugins/gemini/skills/gemini-cancel/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: gemini-cancel
+description: Use when cancelling a running Gemini-plugin background job.
+user-invocable: true
+---
+
+# Gemini Cancel
+
+Use the Gemini companion cancel workflow. Current Codex builds expose it as `gemini:gemini-cancel` in the skill picker; its skill frontmatter name is `gemini-cancel`; the command contract is `plugins/gemini/commands/gemini-cancel.md`.
+
+`<plugin-root>` is `plugins/gemini` or an absolute path to that plugin directory; `<workspace>` is the workspace where the job was launched; `<job-id>` is the identifier returned by a background launch or listed by the status workflow. Run:
+
+```bash
+node "<plugin-root>/scripts/gemini-companion.mjs" cancel --cwd "<workspace>" --job "<job-id>"
+```
+
+Confirm before cancelling unless the user already requested force. Foreground runs should be interrupted with Ctrl+C.

--- a/plugins/gemini/skills/gemini-delegation/SKILL.md
+++ b/plugins/gemini/skills/gemini-delegation/SKILL.md
@@ -25,8 +25,10 @@ In the repository checkout, it is `plugins/gemini`.
 
 - Setup/OAuth check:
   ```bash
-  node "<plugin-root>/scripts/gemini-companion.mjs" ping
+  node "<plugin-root>/scripts/gemini-companion.mjs" doctor
   ```
+For review or adversarial-review, add `--scope-base REF` before `--` when the user provides a base ref.
+
 - Read-only review:
   ```bash
   node "<plugin-root>/scripts/gemini-companion.mjs" run --mode=review --foreground --cwd "<workspace>" -- "<review focus>"

--- a/plugins/gemini/skills/gemini-rescue/SKILL.md
+++ b/plugins/gemini/skills/gemini-rescue/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: gemini-rescue
+description: Use when delegating investigation or fixes to Gemini CLI.
+user-invocable: true
+---
+
+# Gemini Rescue
+
+Use the Gemini companion rescue workflow. Current Codex builds expose it as `gemini:gemini-rescue` in the skill picker; its skill frontmatter name is `gemini-rescue`; the command contract is `plugins/gemini/commands/gemini-rescue.md`.
+
+`<plugin-root>` is `plugins/gemini` or an absolute path to that plugin directory; `<workspace>` is the repository where the rescue task should run. Run:
+
+```bash
+node "<plugin-root>/scripts/gemini-companion.mjs" run --mode=rescue --background --cwd "<workspace>" -- "<task>"
+```
+
+Rescue is write-capable by design. Prefer review skills for read-only critique. Do not claim `/gemini-rescue` is available in Codex builds that do not register plugin command files.

--- a/plugins/gemini/skills/gemini-result/SKILL.md
+++ b/plugins/gemini/skills/gemini-result/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: gemini-result
+description: Use when showing the persisted result for a Gemini-plugin job.
+user-invocable: true
+---
+
+# Gemini Result
+
+Use the Gemini companion result workflow. Current Codex builds expose it as `gemini:gemini-result` in the skill picker; its skill frontmatter name is `gemini-result`; the command contract is `plugins/gemini/commands/gemini-result.md`.
+
+`<plugin-root>` is `plugins/gemini` or an absolute path to that plugin directory; `<workspace>` is the workspace where the job was launched; `<job-id>` is the identifier returned by a background launch or listed by the status workflow. Run:
+
+```bash
+node "<plugin-root>/scripts/gemini-companion.mjs" result --cwd "<workspace>" --job "<job-id>"
+```
+
+Render the returned JobRecord. Do not expose sidecar paths unless explicitly asked.

--- a/plugins/gemini/skills/gemini-review/SKILL.md
+++ b/plugins/gemini/skills/gemini-review/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: gemini-review
+description: Use when asking Gemini CLI to review the current diff, files, or focus area.
+user-invocable: true
+---
+
+# Gemini Review
+
+Use the Gemini companion review workflow. Current Codex builds expose it as `gemini:gemini-review` in the skill picker; its skill frontmatter name is `gemini-review`; the command contract is `plugins/gemini/commands/gemini-review.md`.
+
+`<plugin-root>` is `plugins/gemini` or an absolute path to that plugin directory; `<workspace>` is the repository or bundle directory to review; `<focus>` is the user's review prompt or focus area. Run:
+
+```bash
+node "<plugin-root>/scripts/gemini-companion.mjs" run --mode=review --foreground --cwd "<workspace>" -- "<focus>"
+```
+
+If the user provides a base ref, add `--scope-base REF` before `--`.
+
+Render the returned JobRecord, render `external_review` before normal prose when present, and surface `mutations`. Do not claim `/gemini-review` is available in Codex builds that do not register plugin command files.

--- a/plugins/gemini/skills/gemini-setup/SKILL.md
+++ b/plugins/gemini/skills/gemini-setup/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: gemini-setup
+description: Use when checking Gemini CLI availability and OAuth readiness.
+user-invocable: true
+---
+
+# Gemini Setup
+
+Use the Gemini companion setup workflow. Current Codex builds expose it as `gemini:gemini-setup` in the skill picker; its skill frontmatter name is `gemini-setup`; the command contract is `plugins/gemini/commands/gemini-setup.md`.
+
+`<plugin-root>` is `plugins/gemini` or an absolute path to that plugin directory. Run:
+
+```bash
+node "<plugin-root>/scripts/gemini-companion.mjs" doctor
+```
+
+Show `summary`, `ready`, `next_action`, and any model fallback diagnostics. Never print secret values.

--- a/plugins/gemini/skills/gemini-status/SKILL.md
+++ b/plugins/gemini/skills/gemini-status/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: gemini-status
+description: Use when listing active or recent Gemini-plugin jobs for the current workspace.
+user-invocable: true
+---
+
+# Gemini Status
+
+Use the Gemini companion status workflow. Current Codex builds expose it as `gemini:gemini-status` in the skill picker; its skill frontmatter name is `gemini-status`; the command contract is `plugins/gemini/commands/gemini-status.md`.
+
+`<plugin-root>` is `plugins/gemini` or an absolute path to that plugin directory; `<workspace>` is the workspace where the job was launched. Run:
+
+```bash
+node "<plugin-root>/scripts/gemini-companion.mjs" status --cwd "<workspace>" --all
+```
+
+Render `job_id`, `status`, `mode`, `model`, `started_at`, and `ended_at`. Do not expose sidecar paths unless explicitly asked.

--- a/plugins/kimi/commands/kimi-adversarial-review.md
+++ b/plugins/kimi/commands/kimi-adversarial-review.md
@@ -1,19 +1,19 @@
 ---
 description: Get Kimi Code CLI to adversarially challenge the current design under read-only policy.
-argument-hint: "[--scope-base <ref>] [--max-steps-per-turn <n>] [focus area]"
+argument-hint: "[--scope-base REF] [--max-steps-per-turn N] [focus area]"
 ---
 
 Adversarial review via Kimi Code CLI. Assumes the author is wrong; looks for failure modes, hidden assumptions, and missing edge cases.
 
 ## Arguments
 
-`$ARGUMENTS` — optional `--scope-base <ref>` and `--max-steps-per-turn <n>` followed by focus text. If present, pass those flags before `--`; pass the remaining focus text after `--`.
+`$ARGUMENTS` — optional `--scope-base REF` and `--max-steps-per-turn N` followed by focus text. If present, pass those flags before `--`; pass the remaining focus text after `--`.
 
 ## Workflow
 
 Run:
 ```
-node "<plugin-root>/scripts/kimi-companion.mjs" run --mode=adversarial-review --foreground [--scope-base <ref>] [--max-steps-per-turn <n>] -- "<focus text>"
+node "<plugin-root>/scripts/kimi-companion.mjs" run --mode=adversarial-review --foreground -- "<focus text>"
 ```
 `branch-diff` is object-pure: checkout filters, replace refs, and grafts are ignored.
 It reduces the selected review scope, but a successful run still sends those

--- a/plugins/kimi/commands/kimi-cancel.md
+++ b/plugins/kimi/commands/kimi-cancel.md
@@ -8,8 +8,9 @@ argument-hint: "<job-id> [--force]"
 1. Confirm with the user before canceling unless they passed `--force` (SIGKILL).
 2. Parse `$ARGUMENTS` as `<job-id> [--force]`, then run:
    ```
-   node "<plugin-root>/scripts/kimi-companion.mjs" cancel --job <job-id> [--force]
+   node "<plugin-root>/scripts/kimi-companion.mjs" cancel --job "<job-id>"
    ```
+   Add `--force` only when the user passed `--force`.
 3. Report the response JSON. The exit code is the coarse-grained outcome; the JSON `status` field is the fine-grained reason.
 
 ### Statuses and exit codes

--- a/plugins/kimi/commands/kimi-review.md
+++ b/plugins/kimi/commands/kimi-review.md
@@ -1,19 +1,19 @@
 ---
 description: Get Kimi Code CLI's read-only review of the current diff, files, or focus area.
-argument-hint: "[--scope-base <ref>] [--max-steps-per-turn <n>] [focus area]"
+argument-hint: "[--scope-base REF] [--max-steps-per-turn N] [focus area]"
 ---
 
 Review via Kimi Code CLI. Runs in Kimi plan mode over disposable scoped input; changes are detected post-hoc and never auto-reverted.
 
 ## Arguments
 
-`$ARGUMENTS` — optional `--scope-base <ref>` and `--max-steps-per-turn <n>` followed by focus text. If present, pass those flags before `--`; pass the remaining focus text after `--`.
+`$ARGUMENTS` — optional `--scope-base REF` and `--max-steps-per-turn N` followed by focus text. If present, pass those flags before `--`; pass the remaining focus text after `--`.
 
 ## Workflow
 
 Run:
 ```
-node "<plugin-root>/scripts/kimi-companion.mjs" run --mode=review --foreground [--scope-base <ref>] [--max-steps-per-turn <n>] -- "<focus text>"
+node "<plugin-root>/scripts/kimi-companion.mjs" run --mode=review --foreground -- "<focus text>"
 ```
 
 For a pinned review bundle or selected files, first run `preflight`, then use

--- a/plugins/kimi/skills/kimi-adversarial-review/SKILL.md
+++ b/plugins/kimi/skills/kimi-adversarial-review/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: kimi-adversarial-review
+description: Use when asking Kimi Code CLI to challenge a design or diff adversarially.
+user-invocable: true
+---
+
+# Kimi Adversarial Review
+
+Use the Kimi companion adversarial-review workflow. Current Codex builds expose it as `kimi:kimi-adversarial-review` in the skill picker; its skill frontmatter name is `kimi-adversarial-review`; the command contract is `plugins/kimi/commands/kimi-adversarial-review.md`.
+
+`<plugin-root>` is `plugins/kimi` or an absolute path to that plugin directory; `<workspace>` is the repository or bundle directory to review; `<focus>` is the user's review prompt or focus area. Run:
+
+```bash
+node "<plugin-root>/scripts/kimi-companion.mjs" run --mode=adversarial-review --foreground --cwd "<workspace>" -- "<focus>"
+```
+
+If the user provides them, add `--scope-base REF` and/or
+`--max-steps-per-turn N` before `--`; `N` must be a positive integer.
+
+Render findings by severity, render `external_review` before normal prose when present, and surface any `mutations`. Do not claim `/kimi-adversarial-review` is available in Codex builds that do not register plugin command files.

--- a/plugins/kimi/skills/kimi-cancel/SKILL.md
+++ b/plugins/kimi/skills/kimi-cancel/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: kimi-cancel
+description: Use when cancelling a running Kimi-plugin background job.
+user-invocable: true
+---
+
+# Kimi Cancel
+
+Use the Kimi companion cancel workflow. Current Codex builds expose it as `kimi:kimi-cancel` in the skill picker; its skill frontmatter name is `kimi-cancel`; the command contract is `plugins/kimi/commands/kimi-cancel.md`.
+
+`<plugin-root>` is `plugins/kimi` or an absolute path to that plugin directory; `<workspace>` is the workspace where the job was launched; `<job-id>` is the identifier returned by a background launch or listed by the status workflow. Run:
+
+```bash
+node "<plugin-root>/scripts/kimi-companion.mjs" cancel --cwd "<workspace>" --job "<job-id>"
+```
+
+Confirm before cancelling unless the user already requested force. Foreground runs should be interrupted with Ctrl+C.

--- a/plugins/kimi/skills/kimi-delegation/SKILL.md
+++ b/plugins/kimi/skills/kimi-delegation/SKILL.md
@@ -25,15 +25,17 @@ In the repository checkout, it is `plugins/kimi`.
 
 - Setup/OAuth check:
   ```bash
-  node "<plugin-root>/scripts/kimi-companion.mjs" ping
+  node "<plugin-root>/scripts/kimi-companion.mjs" doctor
   ```
+For review or adversarial-review, add `--scope-base REF` before `--` when the user provides a base ref.
+
 - Read-only review:
   ```bash
-  node "<plugin-root>/scripts/kimi-companion.mjs" run --mode=review --foreground --cwd "<workspace>" [--max-steps-per-turn <n>] -- "<review focus>"
+  node "<plugin-root>/scripts/kimi-companion.mjs" run --mode=review --foreground --cwd "<workspace>" -- "<review focus>"
   ```
 - Adversarial review:
   ```bash
-  node "<plugin-root>/scripts/kimi-companion.mjs" run --mode=adversarial-review --foreground --cwd "<workspace>" [--max-steps-per-turn <n>] -- "<design or diff to challenge>"
+  node "<plugin-root>/scripts/kimi-companion.mjs" run --mode=adversarial-review --foreground --cwd "<workspace>" -- "<design or diff to challenge>"
   ```
 - Disclosure/scope preflight:
   ```bash
@@ -41,7 +43,7 @@ In the repository checkout, it is `plugins/kimi`.
   ```
 - Pinned bundle or selected-file review:
   ```bash
-  node "<plugin-root>/scripts/kimi-companion.mjs" run --mode=custom-review --foreground --cwd "<bundle-or-workspace>" --scope-paths "PR.diff,docs/*.md" [--max-steps-per-turn <n>] -- "<review focus using relative paths>"
+  node "<plugin-root>/scripts/kimi-companion.mjs" run --mode=custom-review --foreground --cwd "<bundle-or-workspace>" --scope-paths "PR.diff,docs/*.md" -- "<review focus using relative paths>"
   ```
 - Rescue/investigation:
   ```bash
@@ -60,6 +62,8 @@ In the repository checkout, it is `plugins/kimi`.
   ```bash
   node "<plugin-root>/scripts/kimi-companion.mjs" cancel --job "<job-id>" --cwd "<workspace>"
   ```
+
+For Kimi review, adversarial-review, custom-review, or rescue, add `--max-steps-per-turn N` before `--` when the user provides a positive integer step budget.
 
 ## Rendering
 

--- a/plugins/kimi/skills/kimi-rescue/SKILL.md
+++ b/plugins/kimi/skills/kimi-rescue/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: kimi-rescue
+description: Use when delegating investigation or fixes to Kimi Code CLI.
+user-invocable: true
+---
+
+# Kimi Rescue
+
+Use the Kimi companion rescue workflow. Current Codex builds expose it as `kimi:kimi-rescue` in the skill picker; its skill frontmatter name is `kimi-rescue`; the command contract is `plugins/kimi/commands/kimi-rescue.md`.
+
+`<plugin-root>` is `plugins/kimi` or an absolute path to that plugin directory; `<workspace>` is the repository where the rescue task should run. Run:
+
+```bash
+node "<plugin-root>/scripts/kimi-companion.mjs" run --mode=rescue --background --cwd "<workspace>" -- "<task>"
+```
+
+Rescue is write-capable by design. Prefer review skills for read-only critique. Do not claim `/kimi-rescue` is available in Codex builds that do not register plugin command files.
+If the user provides a step budget, add `--max-steps-per-turn N` before `--`; `N` must be a positive integer.

--- a/plugins/kimi/skills/kimi-result/SKILL.md
+++ b/plugins/kimi/skills/kimi-result/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: kimi-result
+description: Use when showing the persisted result for a Kimi-plugin job.
+user-invocable: true
+---
+
+# Kimi Result
+
+Use the Kimi companion result workflow. Current Codex builds expose it as `kimi:kimi-result` in the skill picker; its skill frontmatter name is `kimi-result`; the command contract is `plugins/kimi/commands/kimi-result.md`.
+
+`<plugin-root>` is `plugins/kimi` or an absolute path to that plugin directory; `<workspace>` is the workspace where the job was launched; `<job-id>` is the identifier returned by a background launch or listed by the status workflow. Run:
+
+```bash
+node "<plugin-root>/scripts/kimi-companion.mjs" result --cwd "<workspace>" --job "<job-id>"
+```
+
+Render the returned JobRecord. Do not expose sidecar paths unless explicitly asked.

--- a/plugins/kimi/skills/kimi-review/SKILL.md
+++ b/plugins/kimi/skills/kimi-review/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: kimi-review
+description: Use when asking Kimi Code CLI to review the current diff, files, or focus area.
+user-invocable: true
+---
+
+# Kimi Review
+
+Use the Kimi companion review workflow. Current Codex builds expose it as `kimi:kimi-review` in the skill picker; its skill frontmatter name is `kimi-review`; the command contract is `plugins/kimi/commands/kimi-review.md`.
+
+`<plugin-root>` is `plugins/kimi` or an absolute path to that plugin directory; `<workspace>` is the repository or bundle directory to review; `<focus>` is the user's review prompt or focus area. Run:
+
+```bash
+node "<plugin-root>/scripts/kimi-companion.mjs" run --mode=review --foreground --cwd "<workspace>" -- "<focus>"
+```
+
+If the user provides them, add `--scope-base REF` and/or
+`--max-steps-per-turn N` before `--`; `N` must be a positive integer.
+
+Render the returned JobRecord, render `external_review` before normal prose when present, and surface `mutations`. Do not claim `/kimi-review` is available in Codex builds that do not register plugin command files.

--- a/plugins/kimi/skills/kimi-setup/SKILL.md
+++ b/plugins/kimi/skills/kimi-setup/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: kimi-setup
+description: Use when checking Kimi Code CLI availability and OAuth readiness.
+user-invocable: true
+---
+
+# Kimi Setup
+
+Use the Kimi companion setup workflow. Current Codex builds expose it as `kimi:kimi-setup` in the skill picker; its skill frontmatter name is `kimi-setup`; the command contract is `plugins/kimi/commands/kimi-setup.md`.
+
+`<plugin-root>` is `plugins/kimi` or an absolute path to that plugin directory. Run:
+
+```bash
+node "<plugin-root>/scripts/kimi-companion.mjs" doctor
+```
+
+Show `summary`, `ready`, `next_action`, and any model fallback diagnostics. Never print secret values.

--- a/plugins/kimi/skills/kimi-status/SKILL.md
+++ b/plugins/kimi/skills/kimi-status/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: kimi-status
+description: Use when listing active or recent Kimi-plugin jobs for the current workspace.
+user-invocable: true
+---
+
+# Kimi Status
+
+Use the Kimi companion status workflow. Current Codex builds expose it as `kimi:kimi-status` in the skill picker; its skill frontmatter name is `kimi-status`; the command contract is `plugins/kimi/commands/kimi-status.md`.
+
+`<plugin-root>` is `plugins/kimi` or an absolute path to that plugin directory; `<workspace>` is the workspace where the job was launched. Run:
+
+```bash
+node "<plugin-root>/scripts/kimi-companion.mjs" status --cwd "<workspace>" --all
+```
+
+Render `job_id`, `status`, `mode`, `model`, `started_at`, and `ended_at`. Do not expose sidecar paths unless explicitly asked.

--- a/tests/unit/docs-contracts.test.mjs
+++ b/tests/unit/docs-contracts.test.mjs
@@ -254,8 +254,7 @@ test("README documents shipped install path, first commands, and safety posture"
   assert.match(readme, /codex plugin marketplace add seungpyoson\/codex-plugin-multi/);
   assert.match(readme, /\/plugins/);
   assert.match(readme, /user-invocable skill fallback/);
-  assert.match(readme, /Claude delegation skill/);
-  assert.match(readme, /Gemini delegation skill/);
+  assert.match(readme, /Claude, Gemini, Kimi, and API\s+reviewers delegation skills/);
   assert.doesNotMatch(readme, /Diagnostic plugin dispatch check/);
   assert.doesNotMatch(readme, /\/claude-ping/);
   assert.doesNotMatch(readme, /\/gemini-ping/);

--- a/tests/unit/docs-contracts.test.mjs
+++ b/tests/unit/docs-contracts.test.mjs
@@ -127,8 +127,8 @@ test("review command docs advertise --scope-base, not legacy --base", () => {
     readRepoFile("plugins/gemini/commands/gemini-adversarial-review.md"),
   ].join("\n");
 
-  assert.match(docs, /--scope-base <ref>/);
-  assert.doesNotMatch(docs, /--base <ref>/);
+  assert.match(docs, /--scope-base REF/);
+  assert.doesNotMatch(docs, /--base REF/);
 });
 
 test("review command docs route --scope-base as a companion flag", () => {
@@ -139,7 +139,7 @@ test("review command docs route --scope-base as a companion flag", () => {
     readRepoFile("plugins/gemini/commands/gemini-adversarial-review.md"),
   ].join("\n");
 
-  assert.match(docs, /pass `--scope-base <ref>` before `--`/i);
+  assert.match(docs, /pass `--scope-base REF` before `--`/i);
   assert.doesNotMatch(docs, /Passed as-is to the companion prompt/i);
 });
 

--- a/tests/unit/manifests.test.mjs
+++ b/tests/unit/manifests.test.mjs
@@ -23,7 +23,7 @@ function assertPickerDescription(skill, rel) {
 }
 
 function assertNoBracketedCliFlagsInBash(skill, rel) {
-  for (const [, block] of skill.matchAll(/```bash\n([\s\S]*?)```/g)) {
+  for (const [, block] of skill.matchAll(/(?:^|\n)[ \t]*```(?:bash)?\n([\s\S]*?)\n[ \t]*```/g)) {
     assert.doesNotMatch(block, /\[[^\]\n]*--[a-z0-9-]+[^\]\n]*\]/i, `${rel} has bracketed optional CLI syntax`);
   }
 }
@@ -95,6 +95,7 @@ function assertApiReviewerWorkflowInvocation(skill, provider, workflow, rel) {
 }
 
 function assertApiReviewerCommandDoc(command, workflow, rel) {
+  assertNoBracketedCliFlagsInBash(command, rel);
   assert.doesNotMatch(command, /--foreground\b/, `${rel} must not document ignored --foreground flag`);
   if (workflow !== "setup") {
     assert.match(command, /external_review.*before the review result/, `${rel} missing external_review rendering guidance`);
@@ -266,6 +267,8 @@ test("provider workflow skills are user-invocable and command-backed", () => {
       assertCompanionWorkflowInvocation(skill, plugin, workflow, rel);
       const commandRel = `plugins/${plugin}/commands/${skillName}.md`;
       assert.equal(existsSync(path.join(REPO_ROOT, commandRel)), true, `${commandRel} missing`);
+      const command = readFileSync(path.join(REPO_ROOT, commandRel), "utf8");
+      assertNoBracketedCliFlagsInBash(command, commandRel);
       assert.match(skill, new RegExp(commandRel.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
     }
   }

--- a/tests/unit/manifests.test.mjs
+++ b/tests/unit/manifests.test.mjs
@@ -5,10 +5,120 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const DESCRIPTION_MAX_LENGTH = 88;
+const DELEGATION_PLUGINS = ["claude", "gemini", "kimi"];
+const API_REVIEWER_PROVIDERS = ["deepseek", "glm"];
 
 function readJson(relPath) {
   return JSON.parse(readFileSync(path.join(REPO_ROOT, relPath), "utf8"));
 }
+
+function assertPickerDescription(skill, rel) {
+  const description = skill.match(/^description:\s*(.+)$/m)?.[1] ?? "";
+  assert.ok(description.length > 0, `${rel} missing description`);
+  assert.ok(
+    description.length <= DESCRIPTION_MAX_LENGTH,
+    `${rel} description too long for picker: ${description.length}`,
+  );
+}
+
+function assertNoBracketedCliFlagsInBash(skill, rel) {
+  for (const [, block] of skill.matchAll(/```bash\n([\s\S]*?)```/g)) {
+    assert.doesNotMatch(block, /\[[^\]\n]*--[a-z0-9-]+[^\]\n]*\]/i, `${rel} has bracketed optional CLI syntax`);
+  }
+}
+
+function assertCompanionWorkflowInvocation(skill, plugin, workflow, rel) {
+  assertNoBracketedCliFlagsInBash(skill, rel);
+  if (workflow === "setup") {
+    assert.match(skill, new RegExp(`${plugin}-companion\\.mjs"\\s+doctor\\b`), `${rel} missing doctor subcommand`);
+    return;
+  }
+
+  if (["status", "result", "cancel"].includes(workflow)) {
+    assert.match(skill, new RegExp(`${plugin}-companion\\.mjs"\\s+${workflow}\\b`), `${rel} missing ${workflow} subcommand`);
+    return;
+  }
+
+  assert.match(skill, new RegExp(`${plugin}-companion\\.mjs"\\s+run\\b`), `${rel} missing run subcommand`);
+  assert.match(skill, new RegExp(`--mode=${workflow}\\b`), `${rel} missing --mode=${workflow}`);
+  if (workflow === "rescue") {
+    assert.match(skill, /--background\b/, `${rel} missing --background`);
+    if (plugin === "kimi") {
+      assert.match(skill, /--max-steps-per-turn N/, `${rel} missing Kimi max-step option`);
+      assert.match(skill, /`N` must be a positive integer/, `${rel} must define Kimi max-step value`);
+    } else {
+      assert.doesNotMatch(skill, /--max-steps-per-turn\b/, `${rel} must not document Kimi-only max-step option`);
+    }
+  } else {
+    assert.match(skill, /--foreground\b/, `${rel} missing --foreground`);
+  }
+  if (["review", "adversarial-review"].includes(workflow)) {
+    assert.match(skill, /--scope-base REF/, `${rel} missing optional --scope-base`);
+    assert.match(skill, /`<focus>` is the user's review prompt or focus area/, `${rel} must define focus placeholder`);
+    assert.match(skill, /external_review|claude-result-handling/, `${rel} missing external review rendering guidance`);
+    if (plugin === "kimi") {
+      assert.match(skill, /--max-steps-per-turn N/, `${rel} missing Kimi max-step option`);
+      assert.match(skill, /`N` must be a positive integer/, `${rel} must define Kimi max-step value`);
+    } else {
+      assert.doesNotMatch(skill, /--max-steps-per-turn\b/, `${rel} must not document Kimi-only max-step option`);
+    }
+  }
+}
+
+function assertApiReviewerWorkflowInvocation(skill, provider, workflow, rel) {
+  assertNoBracketedCliFlagsInBash(skill, rel);
+  assert.match(skill, new RegExp(`api-reviewer\\.mjs\\s+${workflow === "setup" ? "doctor" : "run"}\\b`), `${rel} missing api-reviewer subcommand`);
+  assert.match(skill, new RegExp(`--provider\\s+${provider}\\b`), `${rel} missing --provider ${provider}`);
+  if (workflow === "setup") return;
+
+  assert.match(skill, new RegExp(`--mode\\s+${workflow}\\b`), `${rel} missing --mode ${workflow}`);
+  assert.doesNotMatch(skill, /--foreground\b/, `${rel} must not document ignored --foreground flag`);
+  assert.match(skill, /--prompt\s+"<focus>"/, `${rel} missing prompt placeholder`);
+  assert.match(skill, /`<focus>` is the user's review prompt or focus area/, `${rel} must define focus placeholder`);
+  if (workflow === "custom-review") {
+    assert.match(skill, /--scope\s+custom\b/, `${rel} missing custom scope`);
+    assert.match(skill, /--scope-paths\b/, `${rel} missing --scope-paths`);
+    const scopePaths = skill.match(/--scope-paths\s+"([^"]+)"/)?.[1] ?? "";
+    assert.ok(scopePaths.includes(","), `${rel} missing comma-separated scope-path placeholder`);
+    assert.doesNotMatch(scopePaths, /[*?]/, `${rel} must not use glob characters in scope-path placeholder`);
+    assert.doesNotMatch(scopePaths, /\s/, `${rel} scope-path placeholder must not use space-separated paths`);
+    assert.match(skill, /Replace `<file1>,<file2>`/, `${rel} must tell agents to replace scope-path placeholders`);
+    assert.match(skill, /comma- or newline-separated concrete relative `--scope-paths`/, `${rel} missing scope-path separator guidance`);
+    assert.match(skill, /expand globs before running/i, `${rel} missing glob expansion guidance`);
+    assert.match(skill, /external_review.*before the review result/, `${rel} missing external_review rendering guidance`);
+  } else {
+    assert.match(skill, /--scope\s+branch-diff\b/, `${rel} missing branch-diff scope`);
+    assert.match(skill, /--scope-base REF/, `${rel} missing optional --scope-base`);
+    assert.match(skill, /external_review.*before the review result/, `${rel} missing external_review rendering guidance`);
+  }
+}
+
+function assertApiReviewerCommandDoc(command, workflow, rel) {
+  assert.doesNotMatch(command, /--foreground\b/, `${rel} must not document ignored --foreground flag`);
+  if (workflow !== "setup") {
+    assert.match(command, /external_review.*before the review result/, `${rel} missing external_review rendering guidance`);
+  }
+  if (["review", "adversarial-review"].includes(workflow)) {
+    assert.match(command, /argument-hint:\s*"\[--scope-base REF\] \[review prompt\]"/, `${rel} missing scope-base argument hint`);
+    assert.match(command, /`--scope-base REF` before `--prompt`/, `${rel} must route scope-base before prompt`);
+    assert.match(command, /remaining prompt text to `--prompt`/, `${rel} must exclude scope-base from prompt text`);
+    assert.doesNotMatch(command, /--prompt\s+"\$ARGUMENTS"/, `${rel} must not pass all arguments as prompt`);
+  }
+  if (workflow === "custom-review") {
+    assert.match(command, /--scope\s+custom\b/, `${rel} missing custom scope`);
+    assert.match(command, /--scope-paths\s+"<file1>,<file2>"/, `${rel} missing scope-path placeholder`);
+    assert.match(command, /\$ARGUMENTS/, `${rel} must describe argument handling`);
+    assert.match(command, /--scope-paths <files>/, `${rel} must map scope paths from arguments`);
+    assert.match(command, /remaining prompt text to `--prompt`/, `${rel} must exclude scope paths from prompt text`);
+    assert.match(command, /Replace `<file1>,<file2>`/, `${rel} must tell agents to replace scope-path placeholders`);
+    assert.match(command, /comma- or newline-separated concrete relative paths/, `${rel} missing scope-path separator guidance`);
+    assert.match(command, /expand globs before running/i, `${rel} missing glob expansion guidance`);
+  }
+}
+
+const DELEGATION_WORKFLOWS = ["review", "adversarial-review", "rescue", "setup", "status", "result", "cancel"];
+const API_REVIEWER_WORKFLOWS = ["review", "adversarial-review", "custom-review", "setup"];
 
 test("marketplace.json: valid schema", () => {
   const m = readJson(".agents/plugins/marketplace.json");
@@ -71,7 +181,7 @@ test("claude, gemini, and kimi package non-ping command docs until upstream slas
     "review", "adversarial-review", "rescue",
     "setup", "status", "result", "cancel",
   ];
-  for (const plugin of ["claude", "gemini", "kimi"]) {
+  for (const plugin of DELEGATION_PLUGINS) {
     for (const command of commands) {
       const rel = `plugins/${plugin}/commands/${plugin}-${command}.md`;
       assert.equal(existsSync(path.join(REPO_ROOT, rel)), true, `${rel} missing`);
@@ -82,15 +192,104 @@ test("claude, gemini, and kimi package non-ping command docs until upstream slas
 });
 
 test("claude, gemini, and kimi expose user-invocable skill fallbacks", () => {
-  for (const plugin of ["claude", "gemini", "kimi"]) {
+  for (const plugin of DELEGATION_PLUGINS) {
     const rel = `plugins/${plugin}/skills/${plugin}-delegation/SKILL.md`;
     const skill = readFileSync(path.join(REPO_ROOT, rel), "utf8");
     assert.match(skill, new RegExp(`name: ${plugin}-delegation`));
     assert.match(skill, /user-invocable: true/);
     assert.match(skill, new RegExp(`${plugin}-companion\\.mjs`));
-    const description = skill.match(/^description:\s*(.+)$/m)?.[1] ?? "";
-    assert.ok(description.length > 0, `${rel} missing description`);
-    assert.ok(description.length <= 88, `${rel} description too long for picker: ${description.length}`);
+    assert.match(skill, new RegExp(`${plugin}-companion\\.mjs"\\s+doctor\\b`));
+    assertNoBracketedCliFlagsInBash(skill, rel);
+    assert.match(skill, /--scope-base REF/, `${rel} missing branch-diff base-ref guidance`);
+    if (plugin === "kimi") {
+      assert.match(skill, /rescue[\s\S]*--max-steps-per-turn N/, `${rel} must document Kimi rescue step budget`);
+    } else {
+      assert.doesNotMatch(skill, /--max-steps-per-turn\b/, `${rel} must not document Kimi-only max-step option`);
+    }
+    assertPickerDescription(skill, rel);
+  }
+});
+
+test("api-reviewers exposes a user-invocable skill fallback", () => {
+  const rel = "plugins/api-reviewers/skills/api-reviewers-delegation/SKILL.md";
+  const skill = readFileSync(path.join(REPO_ROOT, rel), "utf8");
+
+  assert.match(skill, /^name:\s*api-reviewers-delegation$/m);
+  assert.match(skill, /^user-invocable:\s*true$/m);
+  assert.match(skill, /api-reviewer\.mjs/);
+  assert.match(skill, /--provider\s+deepseek\b/);
+  assert.match(skill, /--provider\s+glm\b/);
+  assert.match(skill.match(/^description:\s*(.+)$/m)?.[1] ?? "", /adversarial review/);
+  assertNoBracketedCliFlagsInBash(skill, rel);
+  assert.doesNotMatch(skill, /--foreground\b/, `${rel} must not document ignored --foreground flag`);
+  assert.match(skill, /api-reviewer\.mjs\s+doctor\b/);
+  assert.match(skill, /api-reviewer\.mjs\s+run\b/);
+  assert.match(skill, /--mode\s+review\b/);
+  assert.match(skill, /--mode\s+adversarial-review\b/);
+  assert.match(skill, /--mode\s+custom-review\b/);
+  assert.match(skill, /--scope-base REF/);
+  assert.match(skill, /Replace `<file1>,<file2>`/, `${rel} must tell agents to replace scope-path placeholders`);
+  assert.match(skill, /comma- or newline-separated concrete relative paths/, `${rel} missing scope-path separator guidance`);
+  assert.match(skill, /external_review.*before the review result/);
+  assertPickerDescription(skill, rel);
+});
+
+test("provider workflow skills are user-invocable and command-backed", () => {
+  for (const plugin of DELEGATION_PLUGINS) {
+    for (const workflow of DELEGATION_WORKFLOWS) {
+      const skillName = `${plugin}-${workflow}`;
+      const rel = `plugins/${plugin}/skills/${skillName}/SKILL.md`;
+      const skillPath = path.join(REPO_ROOT, rel);
+      assert.equal(existsSync(skillPath), true, `${rel} missing`);
+      const skill = readFileSync(skillPath, "utf8");
+
+      assert.match(skill, new RegExp(`^name:\\s*${skillName}$`, "m"));
+      assert.match(skill, /^user-invocable:\s*true$/m);
+      assertPickerDescription(skill, rel);
+      assert.match(skill, new RegExp(`${plugin}-companion\\.mjs`));
+      assert.match(skill, new RegExp(`${plugin}:${skillName}`));
+      assert.match(skill, new RegExp("`<plugin-root>` is `plugins/" + plugin + "`"));
+      if (skill.includes("--cwd")) {
+        assert.match(skill, /`<workspace>` is /);
+        if (["status", "result", "cancel"].includes(workflow)) {
+          assert.match(skill, /`<workspace>` is the workspace where the job was launched/);
+          if (["result", "cancel"].includes(workflow)) {
+            assert.match(skill, /`<job-id>` is the identifier returned by a background launch or listed by the status workflow/);
+          }
+        } else if (workflow === "rescue") {
+          assert.match(skill, /`<workspace>` is the repository where the rescue task should run/);
+        } else {
+          assert.match(skill, /`<workspace>` is the repository or bundle directory to review/);
+        }
+      }
+      assert.doesNotMatch(skill, /frontmatter name remains/);
+      assertCompanionWorkflowInvocation(skill, plugin, workflow, rel);
+      const commandRel = `plugins/${plugin}/commands/${skillName}.md`;
+      assert.equal(existsSync(path.join(REPO_ROOT, commandRel)), true, `${commandRel} missing`);
+      assert.match(skill, new RegExp(commandRel.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    }
+  }
+
+  for (const provider of API_REVIEWER_PROVIDERS) {
+    for (const workflow of API_REVIEWER_WORKFLOWS) {
+      const skillName = `${provider}-${workflow}`;
+      const rel = `plugins/api-reviewers/skills/${skillName}/SKILL.md`;
+      const skillPath = path.join(REPO_ROOT, rel);
+      assert.equal(existsSync(skillPath), true, `${rel} missing`);
+      const skill = readFileSync(skillPath, "utf8");
+
+      assert.match(skill, new RegExp(`^name:\\s*${skillName}$`, "m"));
+      assert.match(skill, /^user-invocable:\s*true$/m);
+      assertPickerDescription(skill, rel);
+      assert.match(skill, /api-reviewer\.mjs/);
+      assert.match(skill, new RegExp(`api-reviewers:${skillName}`));
+      assertApiReviewerWorkflowInvocation(skill, provider, workflow, rel);
+      const commandRel = `plugins/api-reviewers/commands/${skillName}.md`;
+      assert.equal(existsSync(path.join(REPO_ROOT, commandRel)), true, `${commandRel} missing`);
+      const command = readFileSync(path.join(REPO_ROOT, commandRel), "utf8");
+      assertApiReviewerCommandDoc(command, workflow, commandRel);
+      assert.match(skill, new RegExp(commandRel.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    }
   }
 });
 
@@ -103,6 +302,28 @@ test("README documents install verification for discoverable delegation skills",
   assert.match(readme, /kimi:kimi-delegation/);
   assert.match(readme, /api-reviewers:api-reviewers-delegation/);
   assert.match(readme, /CODEX_HOME/);
+});
+
+test("README documents workflow-specific skill picker UX", () => {
+  const readme = readFileSync(path.join(REPO_ROOT, "README.md"), "utf8");
+
+  assert.match(readme, /<plugin>:<provider-workflow>/);
+  assert.match(readme, /workflow-specific skills/);
+  assert.match(readme, /slash-command files remain packaged/i);
+  assert.match(readme, /advanced `custom-review` and `preflight` flows/);
+  assert.match(readme, /remain available through those broad delegation skills/);
+  for (const plugin of DELEGATION_PLUGINS) {
+    for (const workflow of DELEGATION_WORKFLOWS) {
+      const skill = `${plugin}:${plugin}-${workflow}`;
+      assert.match(readme, new RegExp(`\\b${skill}\\b`), `README missing ${skill}`);
+    }
+  }
+  for (const provider of API_REVIEWER_PROVIDERS) {
+    for (const workflow of API_REVIEWER_WORKFLOWS) {
+      const skill = `api-reviewers:${provider}-${workflow}`;
+      assert.match(readme, new RegExp(`\\b${skill}\\b`), `README missing ${skill}`);
+    }
+  }
 });
 
 test("release docs disclose current Codex slash-command limitation", () => {


### PR DESCRIPTION
## Summary

Adds workflow-specific, user-invocable skills for the provider review flows so Codex skill discovery exposes direct entries like `claude:claude-review`, `gemini:gemini-status`, `kimi:kimi-rescue`, and `api-reviewers:deepseek-custom-review` instead of relying only on broad delegation fallback skills.

The change covers Claude, Gemini, and Kimi review/adversarial-review/rescue/setup/status/result/cancel workflows, plus DeepSeek and GLM review/adversarial-review/custom-review/setup workflows for the direct API reviewer plugin. It also updates README guidance for the namespaced picker UX and documents that companion-only advanced flows such as `custom-review` and `preflight` remain available through the broad delegation skills.

## Review-feedback fixes included

- Validates concrete workflow invocation contracts in `tests/unit/manifests.test.mjs` instead of only checking that files exist.
- Removes bracketed optional CLI flags from copyable skill bash snippets and rejects bracketed `--flag` syntax in bash blocks.
- Clarifies `<plugin-root>` and workflow-specific `<workspace>` placeholder meanings.
- Documents `--scope-base <ref>` where branch-diff review workflows support it.
- Keeps Kimi-only `--max-steps-per-turn <n>` scoped to valid Kimi workflows and defines `<n>` as a positive integer.
- Replaces unsupported API reviewer glob examples with concrete comma-separated path examples and tells agents to expand globs before running.
- Removes ignored API reviewer `--foreground` from skills and deferred API command docs.
- Tightens the API reviewers fallback description and assertions around supported workflows.

## Verification

- `node --test --test-reporter=spec tests/unit/manifests.test.mjs`
- `node --test --test-reporter=spec tests/unit/docs-contracts.test.mjs`
- `npm test` (793 passed, 0 failed, 6 skipped)

## Notes

This PR is scoped to the committed issue #69 branch diff. Unrelated local working-tree changes were intentionally left unstaged and are not part of this PR.