### PR TITLE
Fix reviewer runtime diagnostics and cache drift visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,42 @@ running the same command. If the namespaced skills are missing, the plugin is
 either not enabled in that Codex profile or the manifests are not exposing the
 bundled `skills/` roots correctly.
 
+## Repair stale plugin skill discovery
+
+`npm install` only refreshes this repository's Node dependencies. It does not
+refresh Codex's marketplace clone, runtime plugin cache, enabled plugin config,
+or an already-open TUI session's in-memory skill inventory.
+
+Run the read-only cache doctor before manually copying files:
+
+```bash
+npm run doctor:cache
+```
+
+For `second-codex`, inspect both profiles:
+
+```bash
+npm run doctor:cache -- --second-codex-home "$HOME/.codex-second"
+```
+
+The report compares marketplace/plugin skill files against
+`plugins/cache/codex-plugin-multi/<plugin>/0.1.0`, checks whether each plugin is
+enabled in `config.toml`, and prints next actions. For Git marketplace installs,
+start with:
+
+```bash
+codex plugin marketplace upgrade codex-plugin-multi
+```
+
+If Codex reports that the marketplace is not configured as Git, remove and
+re-add it from GitHub. After marketplace/cache or enablement changes, restart
+the relevant Codex or `second-codex` TUI session; existing sessions do not
+reliably hot-reload plugin skill inventory. Verify the target profile with:
+
+```bash
+codex debug prompt-input 'list skills'
+```
+
 ## Current Codex 0.125.0 TUI limitation
 
 Codex CLI 0.125.0 does not currently expose plugin `commands/*.md` files as TUI slash commands.

--- a/docs/grok-subscription-tunnel.md
+++ b/docs/grok-subscription-tunnel.md
@@ -123,7 +123,17 @@ Expected readiness:
 - `auth_mode: "subscription_web"`
 - `ready: true`
 - `reachable: true`
+- `chat_ready: true`
 - `probe_endpoint` ending in `/models`
+- `chat_probe_endpoint` ending in `/chat/completions`
+
+The doctor uses `GROK_WEB_DOCTOR_TIMEOUT_MS` for the cheap `/models` probe and
+`GROK_WEB_CHAT_DOCTOR_TIMEOUT_MS` for the chat-readiness probe. The chat
+timeout defaults to 10000 ms so a healthy but slow local tunnel is not reported
+as unavailable just because the model listing endpoint is fast. If `/models`
+works but `/chat/completions` rejects the configured model, the doctor reports
+`grok_chat_model_rejected` and points at `GROK_WEB_MODEL` instead of session
+refresh guidance.
 
 Live E2E:
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test": "node scripts/ci/run-tests.mjs",
     "test:full": "CODEX_PLUGIN_FULL_TESTS=1 node scripts/ci/run-tests.mjs",
     "test:coverage": "node scripts/ci/check-coverage.mjs",
+    "doctor:cache": "node scripts/codex-plugin-cache-doctor.mjs",
     "smoke:claude": "node --test --test-reporter=spec tests/smoke/claude-companion.smoke.test.mjs tests/smoke/identity-resume-chain.smoke.test.mjs",
     "smoke:gemini": "node --test --test-reporter=spec tests/smoke/gemini-companion.smoke.test.mjs",
     "smoke:kimi": "node --test --test-reporter=spec tests/smoke/kimi-companion.smoke.test.mjs",

--- a/plugins/api-reviewers/scripts/api-reviewer.mjs
+++ b/plugins/api-reviewers/scripts/api-reviewer.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
-import { lstat, mkdir, readFile, readdir, rename, rm, unlink, writeFile } from "node:fs/promises";
+import { lstat, mkdir, readFile, readdir, realpath, rename, rm, stat, unlink, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { dirname, isAbsolute, resolve, relative } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -9,7 +9,7 @@ import { hostname } from "node:os";
 
 import { cleanGitEnv } from "./lib/git-env.mjs";
 import { isCodexSandbox } from "./lib/codex-env.mjs";
-import { REVIEW_PROMPT_CONTRACT_VERSION, buildReviewPrompt } from "./lib/review-prompt.mjs";
+import { REVIEW_PROMPT_CONTRACT_VERSION, buildReviewAuditManifest, buildReviewPrompt, scopeResolutionReason } from "./lib/review-prompt.mjs";
 import {
   EXTERNAL_REVIEW_KEYS,
   SOURCE_CONTENT_TRANSMISSION,
@@ -29,6 +29,8 @@ const API_REVIEWER_STATE_LOCK_GATE_DIR = ".state.lock.gate";
 const API_REVIEWER_STATE_LOCK_POLL_MS = 25;
 const API_REVIEWER_STATE_LOCK_TIMEOUT_MS = 5000;
 const API_REVIEWER_STATE_LOCK_STALE_MS = 30000;
+const GIT_BINARY = "/usr/bin/git";
+const GIT_SAFE_PATH = "/usr/bin:/bin";
 const API_REVIEWER_EXPECTED_KEYS = Object.freeze([
   "id",
   "job_id",
@@ -65,6 +67,7 @@ const API_REVIEWER_EXPECTED_KEYS = Object.freeze([
   "suggested_action",
   "external_review",
   "disclosure_note",
+  "runtime_diagnostics",
   "result",
   "structured_output",
   "permission_denials",
@@ -489,7 +492,8 @@ async function updateApiReviewerStateForRecord(root, record) {
 }
 
 function parseArgs(argv) {
-  const out = { _: [] };
+  const out = Object.create(null);
+  out._ = [];
   for (let i = 0; i < argv.length; i += 1) {
     const token = argv[i];
     if (!token.startsWith("--")) {
@@ -498,10 +502,13 @@ function parseArgs(argv) {
     }
     const eq = token.indexOf("=");
     if (eq !== -1) {
-      out[token.slice(2, eq)] = token.slice(eq + 1);
+      const key = token.slice(2, eq);
+      assertSafeOptionKey(key, token);
+      out[key] = token.slice(eq + 1);
       continue;
     }
     const key = token.slice(2);
+    assertSafeOptionKey(key, token);
     const next = argv[i + 1];
     if (next == null || next.startsWith("--")) out[key] = true;
     else {
@@ -510,6 +517,12 @@ function parseArgs(argv) {
     }
   }
   return out;
+}
+
+function assertSafeOptionKey(key, token) {
+  if (!key || key === "__proto__" || key === "prototype" || key === "constructor") {
+    throw new Error(`unsupported option ${token}`);
+  }
 }
 
 async function loadProviders() {
@@ -611,9 +624,11 @@ function redactor(env = process.env, configuredSecretNames = []) {
   const configured = new Set(configuredSecretNames);
   const secrets = Object.entries(env)
     .filter(([name, value]) => (
-      (configured.has(name) || /(?:^|_)(?:API_KEY|TOKEN|ACCESS_KEY|SECRET|ADMIN_KEY)$/.test(name)) &&
       typeof value === "string" &&
-      (configured.has(name) ? value.length > 0 : value.length >= MIN_SECRET_REDACTION_LENGTH)
+      (
+        (configured.has(name) && value.length >= 4) ||
+        (/(?:^|_)(?:API_KEY|TOKEN|ACCESS_KEY|SECRET|ADMIN_KEY)$/.test(name) && value.length >= MIN_SECRET_REDACTION_LENGTH)
+      )
     ))
     .map(([, value]) => value);
   return (text) => {
@@ -709,7 +724,7 @@ function runCommand(command, args = [], options = {}) {
 }
 
 function git(args, cwd, options = {}) {
-  const res = runCommand("git", args, { cwd, env: cleanGitEnv() });
+  const res = runCommand(GIT_BINARY, args, { cwd, env: { ...cleanGitEnv(), PATH: GIT_SAFE_PATH } });
   if (res.error) throw new Error(`git_failed:${res.error.message}`);
   if (res.signal) throw new Error(`git_failed:signal:${res.signal}`);
   if (res.status !== 0) {
@@ -718,6 +733,22 @@ function git(args, cwd, options = {}) {
     throw new Error(`git_failed:${detail}`);
   }
   return res.stdout.trim();
+}
+
+function gitRaw(args, cwd, options = {}) {
+  const res = runCommand(GIT_BINARY, args, {
+    cwd,
+    env: { ...cleanGitEnv(), PATH: GIT_SAFE_PATH },
+    maxBuffer: options.maxBuffer,
+  });
+  if (res.error) throw new Error(`git_failed:${res.error.message}`);
+  if (res.signal) throw new Error(`git_failed:signal:${res.signal}`);
+  if (res.status !== 0) {
+    if (options.allowFailure) return null;
+    const detail = String(res.stderr || res.stdout || `git exited with status ${res.status}`).trim();
+    throw new Error(`git_failed:${detail}`);
+  }
+  return res.stdout;
 }
 
 function bestEffortWorkspaceRoot(cwd) {
@@ -733,6 +764,30 @@ function splitScopePaths(value) {
   return String(value).split(/[,\n]/).map((s) => s.trim()).filter(Boolean);
 }
 
+function splitGitPathList(output) {
+  return output ? output.split("\0").filter(Boolean) : [];
+}
+
+function matchGlob(rel, pattern) {
+  let re = "^";
+  for (let i = 0; i < pattern.length; i += 1) {
+    const c = pattern[i];
+    if (c === "*") {
+      if (pattern[i + 1] === "*") {
+        re += ".*";
+        i += 1;
+        if (pattern[i + 1] === "/") i += 1;
+      } else {
+        re += "[^/]*";
+      }
+    } else if (c === "?") re += "[^/]";
+    else if (".^$+(){}|\\[]".includes(c)) re += `\\${c}`;
+    else re += c;
+  }
+  re += "$";
+  return new RegExp(re).test(rel);
+}
+
 function scopeName(options) {
   return options.scope ?? (options.mode === "custom-review" ? "custom" : "branch-diff");
 }
@@ -745,27 +800,59 @@ function selectedScopePaths(scope, options, cwd) {
   }
   if (scope === "branch-diff") {
     const base = options["scope-base"] ?? "main";
-    const changed = git(["diff", "--name-only", base, "--"], cwd);
-    const relPaths = changed ? changed.split("\n").filter(Boolean) : [];
+    const changed = gitRaw(["diff", "-z", "--name-only", `${base}...HEAD`, "--"], cwd);
+    const requested = splitScopePaths(options["scope-paths"]);
+    const changedPaths = splitGitPathList(changed);
+    const relPaths = requested.length > 0
+      ? changedPaths.filter((relPath) => requested.some((pattern) => matchGlob(relPath, pattern)))
+      : changedPaths;
     if (relPaths.length === 0) throw new Error("scope_empty: branch-diff selected no files");
     return relPaths;
   }
   throw new Error(`unsupported_scope:${scope}`);
 }
 
-async function readScopeFiles(workspaceRoot, relPaths) {
+function validateScopePath(workspaceRoot, relPath) {
+  if (relPath.includes("..") || isAbsolute(relPath) || relPath.includes("\\")) {
+    throw new Error(`unsafe_scope_path:${relPath}`);
+  }
+  const abs = resolve(workspaceRoot, relPath);
+  const normalizedRel = relative(workspaceRoot, abs);
+  if (normalizedRel.startsWith("..") || normalizedRel === "") {
+    throw new Error(`unsafe_scope_path:${relPath}`);
+  }
+  return { abs, normalizedRel };
+}
+
+async function readGitScopeFiles(gitCwd, workspaceRoot, relPaths) {
   const files = [];
   for (const relPath of relPaths) {
-    if (relPath.includes("..") || isAbsolute(relPath) || relPath.includes("\\")) {
-      throw new Error(`unsafe_scope_path:${relPath}`);
-    }
-    const abs = resolve(workspaceRoot, relPath);
-    const normalizedRel = relative(workspaceRoot, abs);
-    if (normalizedRel.startsWith("..") || normalizedRel === "") {
-      throw new Error(`unsafe_scope_path:${relPath}`);
-    }
+    const { normalizedRel } = validateScopePath(workspaceRoot, relPath);
+    const text = gitRaw(["show", `HEAD:${relPath}`], gitCwd, {
+      allowFailure: true,
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    if (text === null || text.length === 0) continue;
+    files.push({ path: normalizedRel, text });
+  }
+  if (files.length === 0) throw new Error("scope_empty: selected files are missing or empty");
+  return files;
+}
+
+async function readFilesystemScopeFiles(workspaceRoot, relPaths) {
+  const files = [];
+  const realWorkspaceRoot = await realpath(workspaceRoot);
+  for (const relPath of relPaths) {
+    const { abs, normalizedRel } = validateScopePath(workspaceRoot, relPath);
     if (!existsSync(abs)) continue;
-    const text = await readFile(abs, "utf8");
+    const realAbs = await realpath(abs);
+    const realRel = relative(realWorkspaceRoot, realAbs);
+    if (realRel.startsWith("..") || realRel === "") {
+      throw new Error(`unsafe_scope_path:${relPath}`);
+    }
+    const info = await stat(realAbs);
+    if (!info.isFile()) continue;
+    const text = await readFile(realAbs, "utf8");
     if (text.length === 0) continue;
     files.push({ path: normalizedRel, text });
   }
@@ -779,14 +866,18 @@ async function collectScope(options) {
   const scope = scopeName(options);
   const scopeBase = scope === "branch-diff" ? options["scope-base"] ?? "main" : null;
   const relPaths = selectedScopePaths(scope, options, cwd);
-  const files = await readScopeFiles(workspaceRoot, relPaths);
+  const files = scope === "branch-diff"
+    ? await readGitScopeFiles(cwd, workspaceRoot, relPaths)
+    : await readFilesystemScopeFiles(workspaceRoot, relPaths);
   return {
     cwd,
     workspaceRoot,
     scope,
     scope_base: scopeBase,
     scope_paths: relPaths,
-    base_commit: gitCommitForPrompt(cwd, scopeBase),
+    repository: repositoryIdentity(cwd, workspaceRoot),
+    base_commit: scopeBase ? gitCommitForPrompt(cwd, scopeBase) : null,
+    head_ref: git(["branch", "--show-current"], cwd, { allowFailure: true }) || "HEAD",
     head_commit: gitCommitForPrompt(cwd, "HEAD"),
     files,
   };
@@ -799,6 +890,13 @@ function gitCommitForPrompt(cwd, ref) {
   } catch {
     return null;
   }
+}
+
+function repositoryIdentity(cwd, workspaceRoot) {
+  const remote = git(["remote", "get-url", "origin"], cwd, { allowFailure: true });
+  if (!remote) return workspaceRoot;
+  const match = /[:/]([^/:]+\/[^/]+?)(?:\.git)?$/.exec(remote);
+  return match ? match[1] : remote;
 }
 
 function promptFor(mode, userPrompt, scopeInfo, providerName = "Direct API reviewer") {
@@ -820,10 +918,10 @@ function promptFor(mode, userPrompt, scopeInfo, providerName = "Direct API revie
   return buildReviewPrompt({
     provider: providerName,
     mode,
-    repository: scopeInfo.workspaceRoot ?? null,
+    repository: scopeInfo.repository,
     baseRef: scopeInfo.scope_base ?? null,
     baseCommit: scopeInfo.base_commit ?? null,
-    headRef: "HEAD",
+    headRef: scopeInfo.head_ref ?? "HEAD",
     headCommit: scopeInfo.head_commit ?? null,
     scope: scopeInfo.scope,
     scopePaths: scopeInfo.scope_paths,
@@ -896,6 +994,13 @@ function mockProviderExecution(cfg, prompt, credential, env, requestBody) {
     http_status: 200,
     credential_ref: credential.keyName,
     endpoint: baseUrlFor(cfg),
+    diagnostics: {
+      configured_timeout_ms: parseProviderTimeoutMs(env).value,
+      prompt_chars: prompt.length,
+      request_defaults: summarizeRequestDefaults(cfg.request_defaults),
+      max_tokens: requestBody.max_tokens ?? null,
+      temperature: requestBody.temperature ?? null,
+    },
   };
 }
 
@@ -933,6 +1038,7 @@ async function callProvider(provider, cfg, prompt, env = process.env) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs.value);
   const redact = redactor(env, cfg.env_keys);
+  const started = Date.now();
   try {
     const response = await fetch(endpoint, {
       method: "POST",
@@ -967,13 +1073,42 @@ async function callProvider(provider, cfg, prompt, env = process.env) {
       http_status: response.status,
       credential_ref: credential.keyName,
       endpoint: baseUrlFor(cfg),
+      diagnostics: {
+        configured_timeout_ms: timeoutMs.value,
+        prompt_chars: prompt.length,
+        request_defaults: summarizeRequestDefaults(cfg.request_defaults),
+        max_tokens: requestBody.max_tokens ?? null,
+        temperature: requestBody.temperature ?? null,
+      },
     };
   } catch (e) {
     const reason = e?.name === "AbortError" ? "timeout" : "provider_unavailable";
-    return providerFailure(reason, redact(e?.message ?? String(e)), null, null, payloadSentForProviderException(e));
+    return providerFailureWithDiagnostics(
+      reason,
+      redact(e?.message ?? String(e)),
+      null,
+      null,
+      payloadSentForProviderException(e),
+      {
+        configured_timeout_ms: timeoutMs.value,
+        elapsed_ms: Date.now() - started,
+        prompt_chars: prompt.length,
+        request_defaults: summarizeRequestDefaults(cfg.request_defaults),
+        max_tokens: requestBody.max_tokens ?? null,
+        temperature: requestBody.temperature ?? null,
+      },
+    );
   } finally {
     clearTimeout(timer);
   }
+}
+
+function summarizeRequestDefaults(defaults = {}) {
+  const summary = {};
+  for (const key of ["thinking", "reasoning_effort", "max_tokens", "top_p"]) {
+    if (Object.hasOwn(defaults, key)) summary[key] = defaults[key];
+  }
+  return summary;
 }
 
 function safeProviderSessionId(value) {
@@ -1028,6 +1163,13 @@ function providerFailure(reason, message, httpStatus, raw = null, payloadSent = 
     },
     http_status: httpStatus,
     payload_sent: payloadSent,
+  };
+}
+
+function providerFailureWithDiagnostics(reason, message, httpStatus, raw = null, payloadSent = null, diagnostics = null) {
+  return {
+    ...providerFailure(reason, message, httpStatus, raw, payloadSent),
+    diagnostics,
   };
 }
 
@@ -1097,6 +1239,93 @@ function errorCauseFor(errorCode) {
   return "direct_api_provider";
 }
 
+function scopeDiagnostics(scopeInfo) {
+  const files = Array.isArray(scopeInfo.files) ? scopeInfo.files : [];
+  const selectedChars = files.reduce((sum, file) => sum + String(file.text ?? "").length, 0);
+  const selectedBytes = files.reduce((sum, file) => sum + Buffer.byteLength(String(file.text ?? ""), "utf8"), 0);
+  return {
+    selected_files: files.length,
+    selected_bytes: selectedBytes,
+    selected_chars: selectedChars,
+  };
+}
+
+function diagnosticErrorSummary(errorCode, errorMessage, scopeInfo, execution) {
+  if (errorCode !== "timeout") return errorMessage || errorCode;
+  const scope = scopeDiagnostics(scopeInfo);
+  const diagnostics = execution.diagnostics ?? {};
+  const promptChars = diagnostics.prompt_chars ?? 0;
+  const estimatedTokens = Math.ceil(promptChars / 4);
+  return [
+    `timeout after ${diagnostics.elapsed_ms ?? "unknown"}ms`,
+    `configured_timeout_ms=${diagnostics.configured_timeout_ms ?? "unknown"}`,
+    `selected_files=${scope.selected_files}`,
+    `selected_bytes=${scope.selected_bytes}`,
+    `selected_chars=${scope.selected_chars}`,
+    `prompt_chars=${promptChars}`,
+    `estimated_tokens=${estimatedTokens}`,
+    `max_tokens=${diagnostics.max_tokens ?? "unknown"}`,
+  ].join(" ");
+}
+
+function buildReviewMetadata(cfg, scopeInfo, execution = null) {
+  const auditManifest = execution?.prompt ? buildReviewAuditManifest({
+    prompt: execution.prompt,
+    sourceFiles: scopeInfo.files,
+    git: {
+      remote: scopeInfo.repository ?? null,
+      branch: scopeInfo.head_ref ?? null,
+      baseRef: scopeInfo.scope_base ?? null,
+      baseCommit: scopeInfo.base_commit ?? null,
+      headRef: scopeInfo.head_ref ?? null,
+      headCommit: scopeInfo.head_commit ?? null,
+    },
+    promptBuilder: {
+      contractVersion: REVIEW_PROMPT_CONTRACT_VERSION,
+      pluginVersion: "0.1.0",
+      pluginCommit: gitCommitForPrompt(PLUGIN_ROOT, "HEAD"),
+    },
+    request: {
+      provider: cfg.display_name,
+      model: cfg.model,
+      timeoutMs: execution.diagnostics?.configured_timeout_ms ?? null,
+      maxTokens: execution.diagnostics?.max_tokens ?? null,
+      temperature: execution.diagnostics?.temperature ?? null,
+    },
+    truncation: {
+      prompt: false,
+      source: false,
+      output: false,
+    },
+    providerIds: {
+      sessionId: execution.session_id ?? null,
+    },
+    scope: {
+      name: scopeInfo.scope,
+      base: scopeInfo.scope_base ?? null,
+      paths: scopeInfo.scope_paths ?? null,
+      reason: scopeResolutionReason(scopeInfo),
+    },
+    result: execution.parsed?.result ?? "",
+    status: execution.exitCode === 0 && execution.parsed?.ok === true ? "completed" : "failed",
+    errorCode: execution.parsed?.reason ?? null,
+  }) : null;
+  return {
+    prompt_contract_version: REVIEW_PROMPT_CONTRACT_VERSION,
+    prompt_provider: cfg.display_name,
+    scope: scopeInfo.scope,
+    scope_base: scopeInfo.scope_base ?? null,
+    scope_paths: scopeInfo.scope_paths ?? null,
+    raw_output: execution ? {
+      http_status: execution.http_status ?? null,
+      raw_model: execution.parsed?.raw_model ?? null,
+      parsed_ok: execution.parsed?.ok ?? null,
+      result_chars: typeof execution.parsed?.result === "string" ? execution.parsed.result.length : null,
+    } : null,
+    audit_manifest: auditManifest,
+  };
+}
+
 function buildRecord({ provider, cfg, mode, options, scopeInfo, execution, startedAt, endedAt }) {
   const completed = execution.exitCode === 0 && execution.parsed?.ok === true;
   const redact = redactor(process.env, cfg.env_keys);
@@ -1142,19 +1371,7 @@ function buildRecord({ provider, cfg, mode, options, scopeInfo, execution, start
     scope_base: scopeInfo.scope_base ?? null,
     scope_paths: scopeInfo.scope_paths ?? null,
     prompt_head: String(options.prompt ?? "").slice(0, 200),
-    review_metadata: Object.freeze({
-      prompt_contract_version: REVIEW_PROMPT_CONTRACT_VERSION,
-      prompt_provider: cfg.display_name,
-      scope: scopeInfo.scope,
-      scope_base: scopeInfo.scope_base ?? null,
-      scope_paths: scopeInfo.scope_paths ?? null,
-      raw_output: Object.freeze({
-        http_status: execution.http_status ?? null,
-        raw_model: execution.parsed?.raw_model ?? null,
-        parsed_ok: execution.parsed?.ok ?? null,
-        result_chars: typeof execution.parsed?.result === "string" ? execution.parsed.result.length : null,
-      }),
-    }),
+    review_metadata: buildReviewMetadata(cfg, scopeInfo, execution),
     schema_spec: null,
     binary: null,
     status: completed ? "completed" : "failed",
@@ -1163,11 +1380,12 @@ function buildRecord({ provider, cfg, mode, options, scopeInfo, execution, start
     exit_code: execution.exitCode,
     error_code: errorCode,
     error_message: errorMessage,
-    error_summary: completed ? null : errorMessage || errorCode,
+    error_summary: completed ? null : diagnosticErrorSummary(errorCode, errorMessage, scopeInfo, execution),
     error_cause: completed ? null : errorCauseFor(errorCode),
     suggested_action: completed ? null : suggestedAction(errorCode, provider, cfg, errorMessage, execution.http_status ?? null),
     external_review: externalReview,
     disclosure_note: disclosure,
+    runtime_diagnostics: null,
     result,
     structured_output: null,
     permission_denials: [],
@@ -1266,7 +1484,9 @@ async function cmdRun(options) {
   }
   if (!execution) {
     try {
-      execution = await callProvider(provider, cfg, promptFor(mode, options.prompt ?? "", scopeInfo, cfg.display_name));
+      const renderedPrompt = promptFor(mode, options.prompt ?? "", scopeInfo, cfg.display_name);
+      execution = await callProvider(provider, cfg, renderedPrompt);
+      execution.prompt = renderedPrompt;
     } catch (e) {
       execution = providerFailure("provider_unavailable", redactor(process.env)(e?.message ?? String(e)), null, null, null);
     }

--- a/plugins/api-reviewers/scripts/lib/external-review.mjs
+++ b/plugins/api-reviewers/scripts/lib/external-review.mjs
@@ -38,6 +38,7 @@ const CONTENT_RECEIVED_ERROR_CODES = Object.freeze(new Set([
   "kimi_error",
   "parse_error",
   "step_limit_exceeded",
+  "usage_limited",
   "finalization_failed",
   "timeout",
 ]));

--- a/plugins/api-reviewers/scripts/lib/review-prompt.mjs
+++ b/plugins/api-reviewers/scripts/lib/review-prompt.mjs
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 export const REVIEW_PROMPT_CHECKLIST = Object.freeze([
   "Verify exact base/head refs and commits before judging the diff.",
   "Review only the declared scope and list any scope gaps as NOT REVIEWED.",
@@ -8,6 +10,235 @@ export const REVIEW_PROMPT_CHECKLIST = Object.freeze([
 ]);
 
 export const REVIEW_PROMPT_CONTRACT_VERSION = 1;
+export const REVIEW_AUDIT_MANIFEST_VERSION = 1;
+
+function contentBuffer(file) {
+  if (Buffer.isBuffer(file?.content)) return file.content;
+  if (file?.content instanceof Uint8Array) return Buffer.from(file.content);
+  return Buffer.from(String(file?.text ?? ""), "utf8");
+}
+
+function sha256(value) {
+  const input = Buffer.isBuffer(value) || value instanceof Uint8Array
+    ? value
+    : String(value ?? "");
+  return createHash("sha256").update(input).digest("hex");
+}
+
+function hashObject(value) {
+  return Object.freeze({
+    algorithm: "sha256",
+    value: sha256(value),
+  });
+}
+
+function lineCount(text) {
+  const value = String(text ?? "");
+  if (value.length === 0) return 0;
+  const normalized = value.endsWith("\n") ? value.slice(0, -1) : value;
+  if (normalized.length === 0) return 0;
+  let lines = 1;
+  for (let index = 0; index < normalized.length; index += 1) {
+    if (normalized[index] === "\n") {
+      lines += 1;
+    } else if (normalized[index] === "\r") {
+      lines += 1;
+      if (normalized[index + 1] === "\n") index += 1;
+    }
+  }
+  return lines;
+}
+
+function sourceManifest(sourceFiles = []) {
+  const files = Array.isArray(sourceFiles) ? sourceFiles : [];
+  const entries = files.map((file) => {
+    const content = contentBuffer(file);
+    const text = typeof file?.text === "string" ? file.text : content.toString("utf8");
+    return Object.freeze({
+      path: String(file?.path ?? "unknown"),
+      bytes: content.length,
+      lines: lineCount(text),
+      content_hash: hashObject(content),
+    });
+  });
+  return Object.freeze({
+    files: Object.freeze(entries),
+    totals: Object.freeze({
+      files: entries.length,
+      bytes: entries.reduce((sum, file) => sum + file.bytes, 0),
+      lines: entries.reduce((sum, file) => sum + file.lines, 0),
+    }),
+  });
+}
+
+function isWordBoundary(char) {
+  if (!char) return true;
+  const code = char.charCodeAt(0);
+  return !(
+    (code >= 48 && code <= 57)
+    || (code >= 65 && code <= 90)
+    || (code >= 97 && code <= 122)
+    || char === "_"
+    || char === "-"
+  );
+}
+
+function startsWithToken(line, token) {
+  return line.startsWith(token) && isWordBoundary(line[token.length]);
+}
+
+function startsWithLabel(line, label) {
+  if (!line.startsWith(label)) return false;
+  return line.slice(label.length).trimStart().startsWith(":");
+}
+
+function reviewLines(text) {
+  return String(text ?? "").split("\n").map((line) => (
+    line.endsWith("\r") ? line.slice(0, -1) : line
+  ).trimStart());
+}
+
+function hasVerdict(text) {
+  return reviewLines(text).some((rawLine) => {
+    const line = rawLine.toLowerCase();
+    return startsWithLabel(line, "verdict")
+      || startsWithLabel(line, "summary")
+      || startsWithToken(line, "approve")
+      || startsWithToken(line, "approved")
+      || startsWithToken(line, "request changes")
+      || startsWithToken(line, "reject")
+      || startsWithToken(line, "rejected");
+  });
+}
+
+function checklistText(line) {
+  const trimmed = line.trimStart();
+  if (trimmed.startsWith("-") || trimmed.startsWith("*")) return trimmed.slice(1).trimStart();
+  let index = 0;
+  while (index < trimmed.length) {
+    const code = trimmed.charCodeAt(index);
+    if (code < 48 || code > 57) break;
+    index += 1;
+  }
+  if (index === 0 || (trimmed[index] !== "." && trimmed[index] !== ")")) return null;
+  return trimmed.slice(index + 1).trimStart();
+}
+
+function isChecklistVerdict(line) {
+  const text = checklistText(line);
+  if (!text) return false;
+  const lower = text.toLowerCase();
+  return startsWithToken(lower, "pass")
+    || startsWithToken(lower, "fail")
+    || startsWithToken(lower, "not reviewed");
+}
+
+function includesAny(text, phrases) {
+  return phrases.some((phrase) => text.includes(phrase));
+}
+
+function qualityFlags({ result = "", status = null, errorCode = null } = {}) {
+  const text = String(result ?? "");
+  const lowerText = text.toLowerCase();
+  const checklistItemsSeen = reviewLines(text).filter((line) => isChecklistVerdict(line)).length;
+  return Object.freeze({
+    has_verdict: hasVerdict(text),
+    has_blocking_section: includesAny(lowerText, [
+      "blocking finding",
+      "blocking findings",
+      "blocker",
+      "blockers",
+    ]),
+    has_non_blocking_section: includesAny(lowerText, [
+      "non-blocking",
+      "non blocking",
+      "minor concern",
+      "minor concerns",
+      "residual risk",
+      "residual risks",
+    ]),
+    checklist_items_seen: checklistItemsSeen,
+    looks_shallow: text.trim().length > 0 && text.trim().length < 500,
+    failed_review_slot: status !== "completed" || errorCode !== null,
+  });
+}
+
+export function scopeResolutionReason(scopeInfo = {}) {
+  const paths = scopeInfo.scope_paths ?? scopeInfo.paths;
+  if (scopeInfo.scope === "branch-diff" || scopeInfo.name === "branch-diff") {
+    const base = scopeInfo.scope_base ?? scopeInfo.base ?? "main";
+    if (Array.isArray(paths) && paths.length > 0) {
+      return `git diff -z --name-only ${base}...HEAD -- filtered by explicit --scope-paths`;
+    }
+    return `git diff -z --name-only ${base}...HEAD --`;
+  }
+  if (Array.isArray(paths) && paths.length > 0) {
+    return "explicit --scope-paths";
+  }
+  return scopeInfo.scope ?? scopeInfo.name ?? null;
+}
+
+export function buildReviewAuditManifest({
+  prompt = "",
+  sourceFiles = [],
+  git = {},
+  promptBuilder = {},
+  request = {},
+  truncation = {},
+  providerIds = {},
+  scope = {},
+  result = "",
+  status = null,
+  errorCode = null,
+} = {}) {
+  return Object.freeze({
+    schema_version: REVIEW_AUDIT_MANIFEST_VERSION,
+    rendered_prompt_hash: hashObject(prompt),
+    selected_source: sourceManifest(sourceFiles),
+    git_identity: Object.freeze({
+      remote: git.remote ?? null,
+      branch: git.branch ?? null,
+      base_ref: git.baseRef ?? null,
+      base_sha: git.baseCommit ?? null,
+      head_ref: git.headRef ?? null,
+      head_sha: git.headCommit ?? null,
+      diff_stat: git.diffStat ?? null,
+    }),
+    prompt_builder: Object.freeze({
+      contract_version: promptBuilder.contractVersion ?? null,
+      plugin_version: promptBuilder.pluginVersion ?? null,
+      plugin_commit: promptBuilder.pluginCommit ?? null,
+    }),
+    request: Object.freeze({
+      provider: request.provider ?? null,
+      model: request.model ?? null,
+      timeout_ms: request.timeoutMs ?? null,
+      max_tokens: request.maxTokens ?? null,
+      max_steps_per_turn: request.maxStepsPerTurn ?? null,
+      temperature: request.temperature ?? null,
+      stream: request.stream ?? null,
+    }),
+    truncation: Object.freeze({
+      prompt: truncation.prompt ?? null,
+      prompt_at_chars: truncation.promptAtChars ?? null,
+      source: truncation.source ?? null,
+      source_at_bytes: truncation.sourceAtBytes ?? null,
+      output: truncation.output ?? null,
+      output_at_chars: truncation.outputAtChars ?? null,
+    }),
+    provider_ids: Object.freeze({
+      request_id: providerIds.requestId ?? null,
+      session_id: providerIds.sessionId ?? null,
+    }),
+    scope_resolution: Object.freeze({
+      scope: scope.name ?? null,
+      scope_base: scope.base ?? null,
+      scope_paths: Array.isArray(scope.paths) ? Object.freeze([...scope.paths]) : null,
+      reason: scope.reason ?? null,
+    }),
+    review_quality: qualityFlags({ result, status, errorCode }),
+  });
+}
 
 function line(name, value) {
   return `${name}: ${value ?? "unknown"}`;

--- a/plugins/claude/scripts/claude-companion.mjs
+++ b/plugins/claude/scripts/claude-companion.mjs
@@ -26,9 +26,9 @@
 // Subcommands below keep foreground/background lifecycle behavior explicit.
 
 import { fileURLToPath } from "node:url";
-import { dirname, join as joinPath, resolve as resolvePath } from "node:path";
+import { dirname, isAbsolute, join as joinPath, relative as relativePath, resolve as resolvePath } from "node:path";
 import { tmpdir } from "node:os";
-import { writeFileSync, mkdirSync, mkdtempSync, existsSync, chmodSync, renameSync, unlinkSync, readdirSync, rmSync, statSync, readFileSync as _readFileSync } from "node:fs";
+import { writeFileSync, mkdirSync, mkdtempSync, existsSync, chmodSync, renameSync, unlinkSync, readdirSync, rmSync, statSync, lstatSync, readFileSync as _readFileSync } from "node:fs";
 import { execFileSync, spawn } from "node:child_process";
 
 import { parseArgs } from "./lib/args.mjs";
@@ -43,6 +43,7 @@ import { newJobId, verifyPidInfo } from "./lib/identity.mjs";
 import { buildJobRecord, externalReviewForInvocation } from "./lib/job-record.mjs";
 import { reconcileActiveJobs } from "./lib/reconcile.mjs";
 import { cleanGitEnv } from "./lib/git-env.mjs";
+import { REVIEW_PROMPT_CONTRACT_VERSION, buildReviewAuditManifest, buildReviewPrompt } from "./lib/review-prompt.mjs";
 import {
   authDiagnosticFields,
   apiKeyMissingFields as buildApiKeyMissingFields,
@@ -61,7 +62,6 @@ import {
   summarizeScopeDirectory,
   writePromptSidecar,
 } from "./lib/companion-common.mjs";
-import { REVIEW_PROMPT_CONTRACT_VERSION, buildReviewPrompt } from "./lib/review-prompt.mjs";
 
 // ——— plugin-root self-resolution (upstream pattern, spec §4.14) ———
 const PLUGIN_ROOT = resolvePath(dirname(fileURLToPath(import.meta.url)), "..");
@@ -73,11 +73,10 @@ configureState({
 });
 
 const MODELS_CONFIG_PATH = resolvePath(PLUGIN_ROOT, "config/models.json");
+const GIT_BINARY = "/usr/bin/git";
 const CONTINUABLE_STATUSES = new Set(["completed", "failed", "cancelled", "stale"]);
 const RUN_MODES = Object.freeze(["review", "adversarial-review", "custom-review", "rescue"]);
 const PREFLIGHT_MODES = Object.freeze(["review", "adversarial-review", "custom-review"]);
-const GIT_PROMPT_BINARY = "/usr/bin/git";
-const GIT_PROMPT_SAFE_PATH = "/usr/bin:/bin";
 
 function loadModels() {
   if (!existsSync(MODELS_CONFIG_PATH)) return { review_quality: null, rescue: null };
@@ -88,42 +87,6 @@ function fail(code, message, details = {}) {
   process.stderr.write(`claude-companion: ${message}\n`);
   printJson({ ok: false, error: code, message, ...details });
   process.exit(1);
-}
-
-function targetPromptFor(invocation, userPrompt) {
-  if (invocation.mode_profile_name === "rescue") return userPrompt;
-  return buildReviewPrompt({
-    provider: "Claude",
-    mode: invocation.mode_profile_name,
-    repository: invocation.workspace_root ?? null,
-    baseRef: invocation.scope_base,
-    baseCommit: gitCommitForPrompt(invocation.cwd, invocation.scope_base),
-    headRef: "HEAD",
-    headCommit: gitCommitForPrompt(invocation.cwd, "HEAD"),
-    scope: invocation.scope,
-    scopePaths: invocation.scope_paths,
-    userPrompt,
-  });
-}
-
-function gitCommitForPrompt(cwd, ref) {
-  if (!ref) return null;
-  try {
-    return execFileSync(GIT_PROMPT_BINARY, ["rev-parse", "--verify", `${ref}^{commit}`], {
-      cwd,
-      env: cleanGitPromptEnv(),
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    }).trim();
-  } catch {
-    return null;
-  }
-}
-
-function cleanGitPromptEnv() {
-  const env = cleanGitEnv();
-  env.PATH = GIT_PROMPT_SAFE_PATH;
-  return env;
 }
 
 // Wraps git command; reports failure separately from successful empty output
@@ -137,7 +100,7 @@ function cleanGitPromptEnv() {
 
 function tryGit(args, cwd) {
   try {
-    const stdout = execFileSync("git", ["-C", cwd, ...args], {
+    const stdout = execFileSync(GIT_BINARY, ["-C", cwd, ...args], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
       env: cleanGitEnv(),
@@ -146,6 +109,173 @@ function tryGit(args, cwd) {
   } catch (error) {
     return { ok: false, error };
   }
+}
+
+function gitText(args, cwd) {
+  try {
+    return execFileSync(GIT_BINARY, ["-C", cwd, ...args], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      env: cleanGitEnv(),
+    }).trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function repositoryIdentity(cwd, workspaceRoot) {
+  const remote = gitText(["remote", "get-url", "origin"], cwd);
+  if (!remote) return workspaceRoot;
+  const match = /[:/]([^/:]+\/[^/]+?)(?:\.git)?$/.exec(remote);
+  return match ? match[1] : remote;
+}
+
+function promptMetadata(invocation) {
+  return {
+    repository: repositoryIdentity(invocation.cwd, invocation.workspace_root),
+    baseRef: invocation.scope_base ?? null,
+    baseCommit: invocation.scope_base ? gitText(["rev-parse", "--verify", `${invocation.scope_base}^{commit}`], invocation.cwd) : null,
+    headRef: gitText(["branch", "--show-current"], invocation.cwd) ?? "HEAD",
+    headCommit: gitText(["rev-parse", "--verify", "HEAD^{commit}"], invocation.cwd),
+  };
+}
+
+function pluginSourceCommit() {
+  return gitText(["rev-parse", "--verify", "HEAD^{commit}"], PLUGIN_ROOT);
+}
+
+function targetPromptFor(invocation, userPrompt) {
+  if (invocation.mode_profile_name === "rescue") return userPrompt;
+  const meta = promptMetadata(invocation);
+  const modeLine = invocation.mode === "adversarial-review"
+    ? "You are performing an adversarial code review. Prioritize correctness bugs, security risks, regressions, and missing tests."
+    : "You are performing a code review. Prioritize bugs, behavioral regressions, and missing tests.";
+  return buildReviewPrompt({
+    provider: "Claude Code",
+    mode: invocation.mode,
+    repository: meta.repository,
+    baseRef: meta.baseRef,
+    baseCommit: meta.baseCommit,
+    headRef: meta.headRef,
+    headCommit: meta.headCommit,
+    scope: invocation.scope,
+    scopePaths: invocation.scope_paths,
+    userPrompt,
+    extraInstructions: [modeLine],
+  });
+}
+
+function isInsidePath(base, target) {
+  const relative = relativePath(base, target);
+  return relative === "" || (!relative.startsWith("..") && !isAbsolute(relative));
+}
+
+function listContainedFiles(root, dir = root, prefix = "") {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    if (name === ".git") continue;
+    const full = resolvePath(dir, name);
+    const rel = prefix ? `${prefix}/${name}` : name;
+    const lst = lstatSync(full);
+    if (lst.isSymbolicLink()) continue;
+    if (lst.isDirectory()) out.push(...listContainedFiles(root, full, rel));
+    else out.push(rel);
+  }
+  return out.sort((a, b) => a.localeCompare(b));
+}
+
+function auditSourceFiles(containmentPath) {
+  if (!containmentPath || !existsSync(containmentPath)) return [];
+  return listContainedFiles(containmentPath).map((path) => ({
+    path,
+    content: _readFileSync(resolvePath(containmentPath, path)),
+  }));
+}
+
+function scopeResolutionReason(invocation) {
+  const paths = invocation.scope_paths;
+  if (invocation.scope === "branch-diff") {
+    if (Array.isArray(paths) && paths.length > 0) {
+      return `git diff -z --name-only ${invocation.scope_base ?? "main"}...HEAD -- filtered by explicit --scope-paths`;
+    }
+    return `git diff -z --name-only ${invocation.scope_base ?? "main"}...HEAD --`;
+  }
+  if (Array.isArray(paths) && paths.length > 0) {
+    return "explicit --scope-paths";
+  }
+  return invocation.scope ?? null;
+}
+
+function reviewAuditManifest(invocation, prompt, containmentPath, execution) {
+  if (!invocation.review_prompt_contract_version || invocation.mode_profile_name === "rescue") return null;
+  const meta = promptMetadata(invocation);
+  return buildReviewAuditManifest({
+    prompt,
+    sourceFiles: auditSourceFiles(containmentPath),
+    git: {
+      remote: meta.repository,
+      branch: meta.headRef,
+      baseRef: meta.baseRef,
+      baseCommit: meta.baseCommit,
+      headRef: meta.headRef,
+      headCommit: meta.headCommit,
+    },
+    promptBuilder: {
+      contractVersion: invocation.review_prompt_contract_version,
+      pluginVersion: "0.1.0",
+      pluginCommit: pluginSourceCommit(),
+    },
+    request: {
+      provider: invocation.review_prompt_provider ?? "Claude Code",
+      model: invocation.model,
+      timeoutMs: null,
+      maxTokens: null,
+      maxStepsPerTurn: null,
+      temperature: null,
+    },
+    truncation: {
+      prompt: false,
+      source: false,
+      output: false,
+    },
+    providerIds: {
+      sessionId: execution?.claudeSessionId ?? null,
+    },
+    scope: {
+      name: invocation.scope,
+      base: invocation.scope_base ?? null,
+      paths: invocation.scope_paths ?? null,
+      reason: scopeResolutionReason(invocation),
+    },
+    result: execution?.parsed?.result ?? "",
+    status: execution?.exitCode === 0 && execution?.parsed?.ok === true ? "completed" : "failed",
+    errorCode: execution?.parsed?.reason ?? null,
+  });
+}
+
+function buildRuntimeDiagnostics(invocation, containmentPath, childCwd) {
+  const addDir = containmentPath ?? null;
+  const relativeFiles = Array.isArray(invocation.scope_paths)
+    ? invocation.scope_paths
+    : (addDir && resolvePath(addDir) !== resolvePath(invocation.cwd)
+      ? listContainedFiles(addDir)
+      : []);
+  const scopePathMappings = relativeFiles
+    .map((rel) => {
+      const contained = addDir ? resolvePath(addDir, rel) : null;
+      return {
+        original: resolvePath(invocation.cwd, rel),
+        contained,
+        relative: rel,
+        inside_add_dir: addDir && contained ? isInsidePath(addDir, contained) : false,
+      };
+    });
+
+  return {
+    add_dir: addDir,
+    child_cwd: childCwd ?? null,
+    scope_path_mappings: scopePathMappings,
+  };
 }
 
 function mutationDetectionFailure(error) {
@@ -426,7 +556,7 @@ async function cmdRun(rest) {
     scope_paths: scopePaths,
     prompt_head: prompt.slice(0, 200),          // §21.3.1 — no full prompt
     review_prompt_contract_version: profile.name === "rescue" ? null : REVIEW_PROMPT_CONTRACT_VERSION,
-    review_prompt_provider: profile.name === "rescue" ? null : "Claude",
+    review_prompt_provider: profile.name === "rescue" ? null : "Claude Code",
     schema_spec: options.schema ?? null,
     binary: options.binary ?? process.env.CLAUDE_BINARY ?? "claude",
     run_kind: options.background ? "background" : "foreground",
@@ -515,6 +645,7 @@ async function executeRun(invocation, prompt, { foreground }) {
   }
   const childCwd = neutralCwd ?? containment.path;
   const addDir = containment.path;
+  const runtimeDiagnostics = buildRuntimeDiagnostics(invocation, addDir, childCwd);
 
   // Pre-snapshot for review-style paths (§10 post-hoc mutation detection).
   // Profile-driven: plan-mode paths are supposed to be read-only, so we
@@ -562,6 +693,7 @@ async function executeRun(invocation, prompt, { foreground }) {
     const cancelledRecord = buildJobRecord(invocation, {
       status: "cancelled",
       exitCode: null, parsed: null, pidInfo: null, claudeSessionId: null,
+      runtimeDiagnostics,
     }, mutations);
     writeJobFile(workspaceRoot, jobId, cancelledRecord);
     upsertJob(workspaceRoot, cancelledRecord);
@@ -590,6 +722,7 @@ async function executeRun(invocation, prompt, { foreground }) {
           parsed: null,
           pidInfo,
           claudeSessionId: null,
+          runtimeDiagnostics,
         }, mutations);
         writeJobFile(workspaceRoot, jobId, runningRecord);
         upsertJob(workspaceRoot, runningRecord);
@@ -599,6 +732,7 @@ async function executeRun(invocation, prompt, { foreground }) {
     const errorRecord = buildJobRecord(invocation, {
       exitCode: null, parsed: null, pidInfo: null, claudeSessionId: null,
       errorMessage: e.message,
+      runtimeDiagnostics,
     }, mutations);
     writeJobFile(workspaceRoot, jobId, errorRecord);
     upsertJob(workspaceRoot, errorRecord);
@@ -656,6 +790,7 @@ async function executeRun(invocation, prompt, { foreground }) {
   // marker is per-job and best-effort — a missing file means "no cancel
   // requested," not "couldn't read."
   const cancelMarker = consumeCancelMarker(workspaceRoot, jobId);
+  execution.reviewAuditManifest = reviewAuditManifest(invocation, prompt, containment.path, execution);
 
   // ONE buildJobRecord call for the canonical record — spec §21.3.2.
   // signal + timedOut feed classifyExecution: a SIGTERM/SIGKILL exit without
@@ -669,6 +804,8 @@ async function executeRun(invocation, prompt, { foreground }) {
     ...(cancelMarker ? { status: "cancelled" } : {}),
     signal: execution.signal ?? null,
     timedOut: execution.timedOut === true,
+    runtimeDiagnostics,
+    reviewAuditManifest: execution.reviewAuditManifest,
   }, mutations);
 
   // Phase 1+2: contractual persistence (meta.json + state.json) under ONE
@@ -784,6 +921,7 @@ async function cmdRunWorker(rest) {
   // call, side effects) and only the post-run consumer at executeRun would
   // convert "completed" → "cancelled".
   if (consumeCancelMarker(workspaceRoot, options.job)) {
+    try { consumePromptSidecar(resolveJobsDir(workspaceRoot), options.job); } catch { /* best-effort privacy cleanup */ }
     const cancelledRecord = buildJobRecord(invocationFromRecord(meta), {
       status: "cancelled",
       exitCode: null, parsed: null, pidInfo: null, claudeSessionId: null,
@@ -910,7 +1048,7 @@ async function cmdContinue(rest) {
     scope_paths: prior.scope_paths ?? null,
     prompt_head: prompt.slice(0, 200),    // §21.3.1 — no full prompt
     review_prompt_contract_version: priorProfile.name === "rescue" ? null : REVIEW_PROMPT_CONTRACT_VERSION,
-    review_prompt_provider: priorProfile.name === "rescue" ? null : "Claude",
+    review_prompt_provider: priorProfile.name === "rescue" ? null : "Claude Code",
     schema_spec: prior.schema_spec ?? prior.schema ?? null,
     binary: options.binary ?? process.env.CLAUDE_BINARY ?? "claude",
     run_kind: options.background ? "background" : "foreground",

--- a/plugins/claude/scripts/lib/external-review.mjs
+++ b/plugins/claude/scripts/lib/external-review.mjs
@@ -38,6 +38,7 @@ const CONTENT_RECEIVED_ERROR_CODES = Object.freeze(new Set([
   "kimi_error",
   "parse_error",
   "step_limit_exceeded",
+  "usage_limited",
   "finalization_failed",
   "timeout",
 ]));

--- a/plugins/claude/scripts/lib/job-record.mjs
+++ b/plugins/claude/scripts/lib/job-record.mjs
@@ -25,29 +25,9 @@ import {
   buildExternalReview,
   sourceContentTransmissionForExecution,
 } from "./external-review.mjs";
+import path from "node:path";
 
 export const SCHEMA_VERSION = 10;
-
-function stringBytes(value) {
-  return Buffer.byteLength(String(value ?? ""), "utf8");
-}
-
-function buildReviewMetadata(invocation, execution = null, parsed = null) {
-  if (!invocation.review_prompt_contract_version) return null;
-  return Object.freeze({
-    prompt_contract_version: invocation.review_prompt_contract_version,
-    prompt_provider: invocation.review_prompt_provider ?? invocation.target,
-    scope: invocation.scope,
-    scope_base: invocation.scope_base ?? null,
-    scope_paths: invocation.scope_paths ?? null,
-    raw_output: execution ? Object.freeze({
-      stdout_bytes: stringBytes(execution.stdout),
-      stderr_bytes: stringBytes(execution.stderr),
-      parsed_ok: parsed?.ok ?? null,
-      result_chars: typeof parsed?.result === "string" ? parsed.result.length : null,
-    }) : null,
-  });
-}
 
 /**
  * Canonical JobRecord field list. Exported so tests can reference it and
@@ -94,6 +74,7 @@ export const EXPECTED_KEYS = Object.freeze([
   "suggested_action",
   "external_review",
   "disclosure_note",
+  "runtime_diagnostics",
 
   // Result
   "result",
@@ -108,6 +89,28 @@ export const EXPECTED_KEYS = Object.freeze([
 ]);
 
 const EXPECTED_KEYS_SET = new Set(EXPECTED_KEYS);
+
+function stringBytes(value) {
+  return Buffer.byteLength(String(value ?? ""), "utf8");
+}
+
+function buildReviewMetadata(invocation, execution = null, parsed = null) {
+  if (!invocation.review_prompt_contract_version) return null;
+  return Object.freeze({
+    prompt_contract_version: invocation.review_prompt_contract_version,
+    prompt_provider: invocation.review_prompt_provider ?? invocation.target,
+    scope: invocation.scope,
+    scope_base: invocation.scope_base ?? null,
+    scope_paths: invocation.scope_paths ?? null,
+    raw_output: execution ? Object.freeze({
+      stdout_bytes: stringBytes(execution.stdout),
+      stderr_bytes: stringBytes(execution.stderr),
+      parsed_ok: parsed?.ok ?? null,
+      result_chars: typeof parsed?.result === "string" ? parsed.result.length : null,
+    }) : null,
+    audit_manifest: execution?.reviewAuditManifest ?? null,
+  });
+}
 
 export function externalReviewForInvocation(invocation, execution = null) {
   const { status, error_code } = classifyExecution(execution);
@@ -427,6 +430,63 @@ function assertInvocation(invocation) {
   }
 }
 
+function targetFromDenial(denial) {
+  if (typeof denial === "string") return denial;
+  if (!denial || typeof denial !== "object") return null;
+  return denial.target ?? denial.path ?? denial.file_path ?? denial.file ?? null;
+}
+
+function toolFromDenial(denial) {
+  if (!denial || typeof denial !== "object") return null;
+  return denial.tool ?? denial.name ?? null;
+}
+
+function pathInside(base, target) {
+  if (!base || !target || !path.isAbsolute(target)) {
+    return { inside: null, relative: null };
+  }
+  const relative = path.relative(base, target);
+  const inside = relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+  return {
+    inside,
+    relative: inside ? (relative || ".") : null,
+  };
+}
+
+function normalizeRuntimeDiagnostics(input, denials) {
+  if (!input || typeof input !== "object") return null;
+
+  const addDir = typeof input.add_dir === "string" ? input.add_dir : null;
+  const childCwd = typeof input.child_cwd === "string" ? input.child_cwd : null;
+  const scopePathMappings = Array.isArray(input.scope_path_mappings)
+    ? input.scope_path_mappings.map((mapping) => ({
+      original: typeof mapping?.original === "string" ? mapping.original : null,
+      contained: typeof mapping?.contained === "string" ? mapping.contained : null,
+      relative: typeof mapping?.relative === "string" ? mapping.relative : null,
+      inside_add_dir: mapping?.inside_add_dir === true,
+    }))
+    : [];
+  const permissionDenials = Array.isArray(denials)
+    ? denials.map((denial) => {
+      const target = targetFromDenial(denial);
+      const { inside, relative } = pathInside(addDir, target);
+      return {
+        tool: toolFromDenial(denial),
+        target,
+        inside_add_dir: inside,
+        relative_to_add_dir: relative,
+      };
+    })
+    : [];
+
+  return {
+    add_dir: addDir,
+    child_cwd: childCwd,
+    scope_path_mappings: scopePathMappings,
+    permission_denials: permissionDenials,
+  };
+}
+
 /**
  * Build the single canonical JobRecord.
  *
@@ -460,6 +520,11 @@ export function buildJobRecord(invocation, execution, mutations) {
   const diagnostic = buildErrorDiagnostic(invocation, status, error_code, error_message);
 
   const parsed = execution?.parsed ?? null;
+  const permissionDenials = Array.isArray(parsed?.denials) ? parsed.denials : [];
+  const runtimeDiagnostics = normalizeRuntimeDiagnostics(
+    execution?.runtimeDiagnostics ?? null,
+    permissionDenials,
+  );
   const record = {
     // Identity
     id: invocation.job_id,
@@ -502,11 +567,12 @@ export function buildJobRecord(invocation, execution, mutations) {
     suggested_action: diagnostic.suggested_action,
     external_review: externalReviewForInvocation(invocation, execution),
     disclosure_note: diagnostic.disclosure_note,
+    runtime_diagnostics: runtimeDiagnostics,
 
     // Result
     result: parsed?.result ?? null,
     structured_output: parsed?.structured ?? null,
-    permission_denials: Array.isArray(parsed?.denials) ? parsed.denials : [],
+    permission_denials: permissionDenials,
     mutations: [...mutations],
     cost_usd: parsed?.costUsd ?? null,
     usage: parsed?.usage ?? null,

--- a/plugins/claude/scripts/lib/review-prompt.mjs
+++ b/plugins/claude/scripts/lib/review-prompt.mjs
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 export const REVIEW_PROMPT_CHECKLIST = Object.freeze([
   "Verify exact base/head refs and commits before judging the diff.",
   "Review only the declared scope and list any scope gaps as NOT REVIEWED.",
@@ -8,6 +10,235 @@ export const REVIEW_PROMPT_CHECKLIST = Object.freeze([
 ]);
 
 export const REVIEW_PROMPT_CONTRACT_VERSION = 1;
+export const REVIEW_AUDIT_MANIFEST_VERSION = 1;
+
+function contentBuffer(file) {
+  if (Buffer.isBuffer(file?.content)) return file.content;
+  if (file?.content instanceof Uint8Array) return Buffer.from(file.content);
+  return Buffer.from(String(file?.text ?? ""), "utf8");
+}
+
+function sha256(value) {
+  const input = Buffer.isBuffer(value) || value instanceof Uint8Array
+    ? value
+    : String(value ?? "");
+  return createHash("sha256").update(input).digest("hex");
+}
+
+function hashObject(value) {
+  return Object.freeze({
+    algorithm: "sha256",
+    value: sha256(value),
+  });
+}
+
+function lineCount(text) {
+  const value = String(text ?? "");
+  if (value.length === 0) return 0;
+  const normalized = value.endsWith("\n") ? value.slice(0, -1) : value;
+  if (normalized.length === 0) return 0;
+  let lines = 1;
+  for (let index = 0; index < normalized.length; index += 1) {
+    if (normalized[index] === "\n") {
+      lines += 1;
+    } else if (normalized[index] === "\r") {
+      lines += 1;
+      if (normalized[index + 1] === "\n") index += 1;
+    }
+  }
+  return lines;
+}
+
+function sourceManifest(sourceFiles = []) {
+  const files = Array.isArray(sourceFiles) ? sourceFiles : [];
+  const entries = files.map((file) => {
+    const content = contentBuffer(file);
+    const text = typeof file?.text === "string" ? file.text : content.toString("utf8");
+    return Object.freeze({
+      path: String(file?.path ?? "unknown"),
+      bytes: content.length,
+      lines: lineCount(text),
+      content_hash: hashObject(content),
+    });
+  });
+  return Object.freeze({
+    files: Object.freeze(entries),
+    totals: Object.freeze({
+      files: entries.length,
+      bytes: entries.reduce((sum, file) => sum + file.bytes, 0),
+      lines: entries.reduce((sum, file) => sum + file.lines, 0),
+    }),
+  });
+}
+
+function isWordBoundary(char) {
+  if (!char) return true;
+  const code = char.charCodeAt(0);
+  return !(
+    (code >= 48 && code <= 57)
+    || (code >= 65 && code <= 90)
+    || (code >= 97 && code <= 122)
+    || char === "_"
+    || char === "-"
+  );
+}
+
+function startsWithToken(line, token) {
+  return line.startsWith(token) && isWordBoundary(line[token.length]);
+}
+
+function startsWithLabel(line, label) {
+  if (!line.startsWith(label)) return false;
+  return line.slice(label.length).trimStart().startsWith(":");
+}
+
+function reviewLines(text) {
+  return String(text ?? "").split("\n").map((line) => (
+    line.endsWith("\r") ? line.slice(0, -1) : line
+  ).trimStart());
+}
+
+function hasVerdict(text) {
+  return reviewLines(text).some((rawLine) => {
+    const line = rawLine.toLowerCase();
+    return startsWithLabel(line, "verdict")
+      || startsWithLabel(line, "summary")
+      || startsWithToken(line, "approve")
+      || startsWithToken(line, "approved")
+      || startsWithToken(line, "request changes")
+      || startsWithToken(line, "reject")
+      || startsWithToken(line, "rejected");
+  });
+}
+
+function checklistText(line) {
+  const trimmed = line.trimStart();
+  if (trimmed.startsWith("-") || trimmed.startsWith("*")) return trimmed.slice(1).trimStart();
+  let index = 0;
+  while (index < trimmed.length) {
+    const code = trimmed.charCodeAt(index);
+    if (code < 48 || code > 57) break;
+    index += 1;
+  }
+  if (index === 0 || (trimmed[index] !== "." && trimmed[index] !== ")")) return null;
+  return trimmed.slice(index + 1).trimStart();
+}
+
+function isChecklistVerdict(line) {
+  const text = checklistText(line);
+  if (!text) return false;
+  const lower = text.toLowerCase();
+  return startsWithToken(lower, "pass")
+    || startsWithToken(lower, "fail")
+    || startsWithToken(lower, "not reviewed");
+}
+
+function includesAny(text, phrases) {
+  return phrases.some((phrase) => text.includes(phrase));
+}
+
+function qualityFlags({ result = "", status = null, errorCode = null } = {}) {
+  const text = String(result ?? "");
+  const lowerText = text.toLowerCase();
+  const checklistItemsSeen = reviewLines(text).filter((line) => isChecklistVerdict(line)).length;
+  return Object.freeze({
+    has_verdict: hasVerdict(text),
+    has_blocking_section: includesAny(lowerText, [
+      "blocking finding",
+      "blocking findings",
+      "blocker",
+      "blockers",
+    ]),
+    has_non_blocking_section: includesAny(lowerText, [
+      "non-blocking",
+      "non blocking",
+      "minor concern",
+      "minor concerns",
+      "residual risk",
+      "residual risks",
+    ]),
+    checklist_items_seen: checklistItemsSeen,
+    looks_shallow: text.trim().length > 0 && text.trim().length < 500,
+    failed_review_slot: status !== "completed" || errorCode !== null,
+  });
+}
+
+export function scopeResolutionReason(scopeInfo = {}) {
+  const paths = scopeInfo.scope_paths ?? scopeInfo.paths;
+  if (scopeInfo.scope === "branch-diff" || scopeInfo.name === "branch-diff") {
+    const base = scopeInfo.scope_base ?? scopeInfo.base ?? "main";
+    if (Array.isArray(paths) && paths.length > 0) {
+      return `git diff -z --name-only ${base}...HEAD -- filtered by explicit --scope-paths`;
+    }
+    return `git diff -z --name-only ${base}...HEAD --`;
+  }
+  if (Array.isArray(paths) && paths.length > 0) {
+    return "explicit --scope-paths";
+  }
+  return scopeInfo.scope ?? scopeInfo.name ?? null;
+}
+
+export function buildReviewAuditManifest({
+  prompt = "",
+  sourceFiles = [],
+  git = {},
+  promptBuilder = {},
+  request = {},
+  truncation = {},
+  providerIds = {},
+  scope = {},
+  result = "",
+  status = null,
+  errorCode = null,
+} = {}) {
+  return Object.freeze({
+    schema_version: REVIEW_AUDIT_MANIFEST_VERSION,
+    rendered_prompt_hash: hashObject(prompt),
+    selected_source: sourceManifest(sourceFiles),
+    git_identity: Object.freeze({
+      remote: git.remote ?? null,
+      branch: git.branch ?? null,
+      base_ref: git.baseRef ?? null,
+      base_sha: git.baseCommit ?? null,
+      head_ref: git.headRef ?? null,
+      head_sha: git.headCommit ?? null,
+      diff_stat: git.diffStat ?? null,
+    }),
+    prompt_builder: Object.freeze({
+      contract_version: promptBuilder.contractVersion ?? null,
+      plugin_version: promptBuilder.pluginVersion ?? null,
+      plugin_commit: promptBuilder.pluginCommit ?? null,
+    }),
+    request: Object.freeze({
+      provider: request.provider ?? null,
+      model: request.model ?? null,
+      timeout_ms: request.timeoutMs ?? null,
+      max_tokens: request.maxTokens ?? null,
+      max_steps_per_turn: request.maxStepsPerTurn ?? null,
+      temperature: request.temperature ?? null,
+      stream: request.stream ?? null,
+    }),
+    truncation: Object.freeze({
+      prompt: truncation.prompt ?? null,
+      prompt_at_chars: truncation.promptAtChars ?? null,
+      source: truncation.source ?? null,
+      source_at_bytes: truncation.sourceAtBytes ?? null,
+      output: truncation.output ?? null,
+      output_at_chars: truncation.outputAtChars ?? null,
+    }),
+    provider_ids: Object.freeze({
+      request_id: providerIds.requestId ?? null,
+      session_id: providerIds.sessionId ?? null,
+    }),
+    scope_resolution: Object.freeze({
+      scope: scope.name ?? null,
+      scope_base: scope.base ?? null,
+      scope_paths: Array.isArray(scope.paths) ? Object.freeze([...scope.paths]) : null,
+      reason: scope.reason ?? null,
+    }),
+    review_quality: qualityFlags({ result, status, errorCode }),
+  });
+}
 
 function line(name, value) {
   return `${name}: ${value ?? "unknown"}`;

--- a/plugins/claude/scripts/lib/scope.mjs
+++ b/plugins/claude/scripts/lib/scope.mjs
@@ -714,7 +714,7 @@ function scopeStaged(sourceCwd, targetPath) {
   }
 }
 
-function scopeBranchDiff(sourceCwd, targetPath, scopeBase) {
+function scopeBranchDiff(sourceCwd, targetPath, scopeBase, scopePaths = []) {
   assertGitWorktree(sourceCwd);
   const ctx = gitScopeContext(sourceCwd);
   assertGitHead(ctx, sourceCwd);
@@ -735,7 +735,7 @@ function scopeBranchDiff(sourceCwd, targetPath, scopeBase) {
   }
   prepareGitSnapshotTarget(sourceCwd, targetPath);
   const raw = git(ctx.gitRoot, ["diff", "--name-only", "-z", `${mergeBase}..HEAD`]);
-  const files = [];
+  let files = [];
   for (const gitRel of raw.split("\0").filter(Boolean)) {
     const snapshotRel = toSnapshotRel(ctx, gitRel);
     if (!snapshotRel) continue;
@@ -744,8 +744,14 @@ function scopeBranchDiff(sourceCwd, targetPath, scopeBase) {
     }
     files.push({ gitRel, snapshotRel });
   }
+  if (Array.isArray(scopePaths) && scopePaths.length > 0) {
+    files = files.filter(({ snapshotRel }) => scopePaths.some((g) => matchGlob(snapshotRel, g)));
+  }
   if (files.length === 0) {
-    scopeEmpty(`branch-diff selected no files under ${sourceCwd} against base ${JSON.stringify(base)}`);
+    const qualifier = Array.isArray(scopePaths) && scopePaths.length > 0
+      ? ` matching --scope-paths ${scopePaths.join(",")}`
+      : "";
+    scopeEmpty(`branch-diff selected no files${qualifier} under ${sourceCwd} against base ${JSON.stringify(base)}`);
   }
   const materializations = [];
   const entriesByRel = entryMap(scopedGitEntries(ctx, headEntries(ctx.gitRoot)));
@@ -878,7 +884,7 @@ export function populateScope(profile, sourceCwd, targetPath, runtimeInputs = {}
   switch (profile.scope) {
     case "working-tree": scopeWorkingTree(sourceCwd, targetPath); break;
     case "staged":       scopeStaged(sourceCwd, targetPath); break;
-    case "branch-diff":  scopeBranchDiff(sourceCwd, targetPath, runtimeInputs.scopeBase); break;
+    case "branch-diff":  scopeBranchDiff(sourceCwd, targetPath, runtimeInputs.scopeBase, runtimeInputs.scopePaths); break;
     case "head":         scopeHead(sourceCwd, targetPath, containmentHandle); break;
     case "custom":       scopeCustom(sourceCwd, targetPath, runtimeInputs.scopePaths); break;
     default:

--- a/plugins/claude/skills/claude-result-handling/SKILL.md
+++ b/plugins/claude/skills/claude-result-handling/SKILL.md
@@ -39,7 +39,19 @@ comes back to you.
   "scope_paths":         null | ["<glob>"], // custom scope globs if any
 
   "prompt_head":         "<first 200 chars>", // spec §21.3.1 — no full prompt persisted
-  "review_metadata":     null | { "prompt_contract_version": 1, "prompt_provider": "Claude|Gemini|Kimi", "scope": "working-tree|branch-diff|staged|head|custom", "scope_base": null | "<ref>", "scope_paths": null | ["<glob>"], "raw_output": null | { "stdout_bytes": N, "stderr_bytes": N, "parsed_ok": true | false | null, "result_chars": N | null } },
+  "review_metadata":     null | {
+    "prompt_contract_version": 1,
+    "prompt_provider":  "Claude Code|Gemini CLI|Kimi",
+    "scope":            "working-tree|branch-diff|staged|head|custom",
+    "scope_base":       null | "<ref>",
+    "scope_paths":      null | ["<glob>"],
+    "raw_output":       null | {
+      "stdout_bytes":   0,
+      "stderr_bytes":   0,
+      "parsed_ok":      null | true | false,
+      "result_chars":   null | 0
+    }
+  },
   "schema_spec":         null | "<json-schema-string>",
   "binary":              "claude",
 
@@ -47,7 +59,7 @@ comes back to you.
   "started_at":          "<iso-8601>",
   "ended_at":            null | "<iso-8601>",
   "exit_code":           null | 0 | 1 | 2,
-  "error_code":          null | "scope_failed" | "spawn_failed" | "claude_error" | "gemini_error" | "kimi_error" | "parse_error" | "step_limit_exceeded" | "finalization_failed" | "timeout" | "stale_active_job",
+  "error_code":          null | "scope_failed" | "spawn_failed" | "claude_error" | "gemini_error" | "kimi_error" | "parse_error" | "step_limit_exceeded" | "usage_limited" | "finalization_failed" | "timeout" | "stale_active_job",
   "error_message":       null | "<human>",
   "error_summary":       null | "<short operator-facing summary>",
   "error_cause":         null | "<why this happened>",
@@ -67,6 +79,26 @@ comes back to you.
     "disclosure":        "<external disclosure statement>"
   },
   "disclosure_note":     null | "<what was or was not sent externally>",
+  "runtime_diagnostics": null | {
+    "add_dir":           null | "<exact --add-dir path>",
+    "child_cwd":         null | "<exact child process cwd>",
+    "scope_path_mappings": [
+      {
+        "original":      "<source repo path>",
+        "contained":     "<contained copied path>",
+        "relative":      "<relative selected path>",
+        "inside_add_dir": true | false
+      }
+    ],
+    "permission_denials": [
+      {
+        "tool":          null | "<tool>",
+        "target":        null | "<path or denied target>",
+        "inside_add_dir": null | true | false,
+        "relative_to_add_dir": null | "<relative path>"
+      }
+    ]
+  },
 
   "result":              null | "<text from Claude>",  // null on queued; "" allowed on schema runs
   "structured_output":   null | { ... },                // populated on --json-schema runs
@@ -187,6 +219,9 @@ from short-lived index contention.
 - `step_limit_exceeded` — Kimi exhausted its configured step budget after
   launch. Selected source content was sent; render the diagnostic fields and
   suggest continuing/resuming the job if a provider session id is available.
+- `usage_limited` — Kimi reported a quota, usage-limit, billing-cycle, or
+  credit-limit failure before returning JSON. Selected source content may have
+  been sent; render `error_summary`, `error_cause`, and `suggested_action`.
 - `finalization_failed` — the target ran, but the companion failed while
   writing the terminal record or state. Render the structured diagnostic
   fields and preserve `error_message`; this is an operator/storage failure,

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -3,7 +3,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, join as joinPath, resolve as resolvePath } from "node:path";
 import {
   existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, unlinkSync,
-  writeFileSync, chmodSync, readdirSync, statSync,
+  writeFileSync, chmodSync, readdirSync, statSync, lstatSync,
 } from "node:fs";
 import { execFileSync, spawn } from "node:child_process";
 import { tmpdir } from "node:os";
@@ -18,6 +18,7 @@ import { newJobId, verifyPidInfo } from "./lib/identity.mjs";
 import { buildJobRecord, externalReviewForInvocation } from "./lib/job-record.mjs";
 import { reconcileActiveJobs } from "./lib/reconcile.mjs";
 import { cleanGitEnv } from "./lib/git-env.mjs";
+import { REVIEW_PROMPT_CONTRACT_VERSION, buildReviewAuditManifest, buildReviewPrompt } from "./lib/review-prompt.mjs";
 import { spawnGemini } from "./lib/gemini.mjs";
 import { writeCancelMarker, consumeCancelMarker } from "./lib/cancel-marker.mjs";
 import {
@@ -38,16 +39,14 @@ import {
   summarizeScopeDirectory,
   writePromptSidecar,
 } from "./lib/companion-common.mjs";
-import { REVIEW_PROMPT_CONTRACT_VERSION, buildReviewPrompt } from "./lib/review-prompt.mjs";
 
 const PLUGIN_ROOT = resolvePath(dirname(fileURLToPath(import.meta.url)), "..");
 const MODELS_CONFIG_PATH = resolvePath(PLUGIN_ROOT, "config/models.json");
 const READ_ONLY_POLICY = resolvePath(PLUGIN_ROOT, "policies/read-only.toml");
+const GIT_BINARY = "/usr/bin/git";
 const CONTINUABLE_STATUSES = new Set(["completed", "failed", "cancelled", "stale"]);
 const RUN_MODES = Object.freeze(["review", "adversarial-review", "custom-review", "rescue"]);
 const PREFLIGHT_MODES = Object.freeze(["review", "adversarial-review", "custom-review"]);
-const GIT_PROMPT_BINARY = "/usr/bin/git";
-const GIT_PROMPT_SAFE_PATH = "/usr/bin:/bin";
 
 configureState({
   pluginDataEnv: "GEMINI_PLUGIN_DATA",
@@ -65,51 +64,152 @@ function fail(code, message, details = {}) {
   process.exit(1);
 }
 
-function targetPromptFor(invocation, userPrompt) {
-  if (invocation.mode_profile_name === "rescue") return userPrompt;
-  return buildReviewPrompt({
-    provider: "Gemini",
-    mode: invocation.mode_profile_name,
-    repository: invocation.workspace_root ?? null,
-    baseRef: invocation.scope_base,
-    baseCommit: gitCommitForPrompt(invocation.cwd, invocation.scope_base),
-    headRef: "HEAD",
-    headCommit: gitCommitForPrompt(invocation.cwd, "HEAD"),
-    scope: invocation.scope,
-    scopePaths: invocation.scope_paths,
-    userPrompt,
-  });
-}
-
-function gitCommitForPrompt(cwd, ref) {
-  if (!ref) return null;
-  try {
-    return execFileSync(GIT_PROMPT_BINARY, ["rev-parse", "--verify", `${ref}^{commit}`], {
-      cwd,
-      env: cleanGitPromptEnv(),
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    }).trim();
-  } catch {
-    return null;
-  }
-}
-
-function cleanGitPromptEnv() {
-  const env = cleanGitEnv();
-  env.PATH = GIT_PROMPT_SAFE_PATH;
-  return env;
-}
-
 // Mutation-detection git scrub: same shared list as claude-companion +
 // scope.mjs. PR #21 review: previous local 5-key list missed
 // GIT_CONFIG_GLOBAL — fold onto plugin lib's canonical scrub.
 
 function gitStatus(args, cwd) {
-  return execFileSync("git", ["-C", cwd, ...args], {
+  return execFileSync(GIT_BINARY, ["-C", cwd, ...args], {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
     env: cleanGitEnv(),
+  });
+}
+
+function gitText(args, cwd) {
+  try {
+    return execFileSync(GIT_BINARY, ["-C", cwd, ...args], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      env: cleanGitEnv(),
+    }).trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function repositoryIdentity(cwd, workspaceRoot) {
+  const remote = gitText(["remote", "get-url", "origin"], cwd);
+  if (!remote) return workspaceRoot;
+  const match = /[:/]([^/:]+\/[^/]+?)(?:\.git)?$/.exec(remote);
+  return match ? match[1] : remote;
+}
+
+function promptMetadata(invocation) {
+  return {
+    repository: repositoryIdentity(invocation.cwd, invocation.workspace_root),
+    baseRef: invocation.scope_base ?? null,
+    baseCommit: invocation.scope_base ? gitText(["rev-parse", "--verify", `${invocation.scope_base}^{commit}`], invocation.cwd) : null,
+    headRef: gitText(["branch", "--show-current"], invocation.cwd) ?? "HEAD",
+    headCommit: gitText(["rev-parse", "--verify", "HEAD^{commit}"], invocation.cwd),
+  };
+}
+
+function pluginSourceCommit() {
+  return gitText(["rev-parse", "--verify", "HEAD^{commit}"], PLUGIN_ROOT);
+}
+
+function targetPromptFor(invocation, userPrompt) {
+  if (invocation.mode_profile_name === "rescue") return userPrompt;
+  const meta = promptMetadata(invocation);
+  const modeLine = invocation.mode === "adversarial-review"
+    ? "You are performing an adversarial code review. Prioritize correctness bugs, security risks, regressions, and missing tests."
+    : "You are performing a code review. Prioritize bugs, behavioral regressions, and missing tests.";
+  return buildReviewPrompt({
+    provider: "Gemini CLI",
+    mode: invocation.mode,
+    repository: meta.repository,
+    baseRef: meta.baseRef,
+    baseCommit: meta.baseCommit,
+    headRef: meta.headRef,
+    headCommit: meta.headCommit,
+    scope: invocation.scope,
+    scopePaths: invocation.scope_paths,
+    userPrompt,
+    extraInstructions: [modeLine],
+  });
+}
+
+function listContainedFiles(root, dir = root, prefix = "") {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    if (name === ".git") continue;
+    const full = resolvePath(dir, name);
+    const rel = prefix ? `${prefix}/${name}` : name;
+    const lst = lstatSync(full);
+    if (lst.isSymbolicLink()) continue;
+    if (lst.isDirectory()) out.push(...listContainedFiles(root, full, rel));
+    else out.push(rel);
+  }
+  return out.sort((a, b) => a.localeCompare(b));
+}
+
+function auditSourceFiles(containmentPath) {
+  if (!containmentPath || !existsSync(containmentPath)) return [];
+  return listContainedFiles(containmentPath).map((path) => ({
+    path,
+    content: readFileSync(resolvePath(containmentPath, path)),
+  }));
+}
+
+function scopeResolutionReason(invocation) {
+  const paths = invocation.scope_paths;
+  if (invocation.scope === "branch-diff") {
+    if (Array.isArray(paths) && paths.length > 0) {
+      return `git diff -z --name-only ${invocation.scope_base ?? "main"}...HEAD -- filtered by explicit --scope-paths`;
+    }
+    return `git diff -z --name-only ${invocation.scope_base ?? "main"}...HEAD --`;
+  }
+  if (Array.isArray(paths) && paths.length > 0) {
+    return "explicit --scope-paths";
+  }
+  return invocation.scope ?? null;
+}
+
+function reviewAuditManifest(invocation, prompt, containmentPath, execution) {
+  if (!invocation.review_prompt_contract_version || invocation.mode_profile_name === "rescue") return null;
+  const meta = promptMetadata(invocation);
+  return buildReviewAuditManifest({
+    prompt,
+    sourceFiles: auditSourceFiles(containmentPath),
+    git: {
+      remote: meta.repository,
+      branch: meta.headRef,
+      baseRef: meta.baseRef,
+      baseCommit: meta.baseCommit,
+      headRef: meta.headRef,
+      headCommit: meta.headCommit,
+    },
+    promptBuilder: {
+      contractVersion: invocation.review_prompt_contract_version,
+      pluginVersion: "0.1.0",
+      pluginCommit: pluginSourceCommit(),
+    },
+    request: {
+      provider: invocation.review_prompt_provider ?? "Gemini CLI",
+      model: invocation.model,
+      timeoutMs: null,
+      maxTokens: null,
+      maxStepsPerTurn: null,
+      temperature: null,
+    },
+    truncation: {
+      prompt: false,
+      source: false,
+      output: false,
+    },
+    providerIds: {
+      sessionId: execution?.geminiSessionId ?? null,
+    },
+    scope: {
+      name: invocation.scope,
+      base: invocation.scope_base ?? null,
+      paths: invocation.scope_paths ?? null,
+      reason: scopeResolutionReason(invocation),
+    },
+    result: execution?.parsed?.result ?? "",
+    status: execution?.exitCode === 0 && execution?.parsed?.ok === true ? "completed" : "failed",
+    errorCode: execution?.parsed?.reason ?? null,
   });
 }
 
@@ -353,7 +453,7 @@ async function cmdRun(rest) {
     scope_paths: scopePaths,
     prompt_head: prompt.slice(0, 200),
     review_prompt_contract_version: profile.name === "rescue" ? null : REVIEW_PROMPT_CONTRACT_VERSION,
-    review_prompt_provider: profile.name === "rescue" ? null : "Gemini",
+    review_prompt_provider: profile.name === "rescue" ? null : "Gemini CLI",
     schema_spec: null,
     binary: options.binary ?? process.env.GEMINI_BINARY ?? "gemini",
     run_kind: options.background ? "background" : "foreground",
@@ -543,6 +643,7 @@ async function executeRun(invocation, prompt, { foreground }) {
   // marker BEFORE signaling so finalization can force status=cancelled
   // even when the target traps SIGTERM and exits 0 with valid output.
   const cancelMarker = consumeCancelMarker(workspaceRoot, jobId);
+  execution.reviewAuditManifest = reviewAuditManifest(executedInvocation, prompt, containment.path, execution);
 
   // signal + timedOut feed classifyExecution: a SIGTERM/SIGKILL exit without
   // timedOut is an operator cancel → status="cancelled" (#16 follow-up 2);
@@ -555,6 +656,7 @@ async function executeRun(invocation, prompt, { foreground }) {
     ...(cancelMarker ? { status: "cancelled" } : {}),
     signal: execution.signal ?? null,
     timedOut: execution.timedOut === true,
+    reviewAuditManifest: execution.reviewAuditManifest,
   }, mutations);
 
   // BLOCKER 2 fix: atomic-under-lock meta + state commit. See
@@ -667,6 +769,7 @@ async function cmdRunWorker(rest) {
   // call, side effects) and only the post-run consumer at executeRun would
   // convert "completed" → "cancelled".
   if (consumeCancelMarker(workspaceRoot, options.job)) {
+    try { consumePromptSidecar(resolveJobsDir(workspaceRoot), options.job); } catch { /* best-effort privacy cleanup */ }
     const cancelledRecord = buildJobRecord(invocationFromRecord(meta), {
       status: "cancelled",
       exitCode: null, parsed: null, pidInfo: null, geminiSessionId: null,
@@ -783,7 +886,7 @@ async function cmdContinue(rest) {
     scope_paths: prior.scope_paths ?? null,
     prompt_head: prompt.slice(0, 200),
     review_prompt_contract_version: priorProfile.name === "rescue" ? null : REVIEW_PROMPT_CONTRACT_VERSION,
-    review_prompt_provider: priorProfile.name === "rescue" ? null : "Gemini",
+    review_prompt_provider: priorProfile.name === "rescue" ? null : "Gemini CLI",
     schema_spec: prior.schema_spec ?? null,
     binary: options.binary ?? process.env.GEMINI_BINARY ?? "gemini",
     run_kind: options.background ? "background" : "foreground",

--- a/plugins/gemini/scripts/lib/external-review.mjs
+++ b/plugins/gemini/scripts/lib/external-review.mjs
@@ -38,6 +38,7 @@ const CONTENT_RECEIVED_ERROR_CODES = Object.freeze(new Set([
   "kimi_error",
   "parse_error",
   "step_limit_exceeded",
+  "usage_limited",
   "finalization_failed",
   "timeout",
 ]));

--- a/plugins/gemini/scripts/lib/job-record.mjs
+++ b/plugins/gemini/scripts/lib/job-record.mjs
@@ -25,29 +25,9 @@ import {
   buildExternalReview,
   sourceContentTransmissionForExecution,
 } from "./external-review.mjs";
+import path from "node:path";
 
 export const SCHEMA_VERSION = 10;
-
-function stringBytes(value) {
-  return Buffer.byteLength(String(value ?? ""), "utf8");
-}
-
-function buildReviewMetadata(invocation, execution = null, parsed = null) {
-  if (!invocation.review_prompt_contract_version) return null;
-  return Object.freeze({
-    prompt_contract_version: invocation.review_prompt_contract_version,
-    prompt_provider: invocation.review_prompt_provider ?? invocation.target,
-    scope: invocation.scope,
-    scope_base: invocation.scope_base ?? null,
-    scope_paths: invocation.scope_paths ?? null,
-    raw_output: execution ? Object.freeze({
-      stdout_bytes: stringBytes(execution.stdout),
-      stderr_bytes: stringBytes(execution.stderr),
-      parsed_ok: parsed?.ok ?? null,
-      result_chars: typeof parsed?.result === "string" ? parsed.result.length : null,
-    }) : null,
-  });
-}
 
 /**
  * Canonical JobRecord field list. Exported so tests can reference it and
@@ -94,6 +74,7 @@ export const EXPECTED_KEYS = Object.freeze([
   "suggested_action",
   "external_review",
   "disclosure_note",
+  "runtime_diagnostics",
 
   // Result
   "result",
@@ -108,6 +89,28 @@ export const EXPECTED_KEYS = Object.freeze([
 ]);
 
 const EXPECTED_KEYS_SET = new Set(EXPECTED_KEYS);
+
+function stringBytes(value) {
+  return Buffer.byteLength(String(value ?? ""), "utf8");
+}
+
+function buildReviewMetadata(invocation, execution = null, parsed = null) {
+  if (!invocation.review_prompt_contract_version) return null;
+  return Object.freeze({
+    prompt_contract_version: invocation.review_prompt_contract_version,
+    prompt_provider: invocation.review_prompt_provider ?? invocation.target,
+    scope: invocation.scope,
+    scope_base: invocation.scope_base ?? null,
+    scope_paths: invocation.scope_paths ?? null,
+    raw_output: execution ? Object.freeze({
+      stdout_bytes: stringBytes(execution.stdout),
+      stderr_bytes: stringBytes(execution.stderr),
+      parsed_ok: parsed?.ok ?? null,
+      result_chars: typeof parsed?.result === "string" ? parsed.result.length : null,
+    }) : null,
+    audit_manifest: execution?.reviewAuditManifest ?? null,
+  });
+}
 
 export function externalReviewForInvocation(invocation, execution = null) {
   const { status, error_code } = classifyExecution(execution);
@@ -423,6 +426,63 @@ function assertInvocation(invocation) {
   }
 }
 
+function targetFromDenial(denial) {
+  if (typeof denial === "string") return denial;
+  if (!denial || typeof denial !== "object") return null;
+  return denial.target ?? denial.path ?? denial.file_path ?? denial.file ?? null;
+}
+
+function toolFromDenial(denial) {
+  if (!denial || typeof denial !== "object") return null;
+  return denial.tool ?? denial.name ?? null;
+}
+
+function pathInside(base, target) {
+  if (!base || !target || !path.isAbsolute(target)) {
+    return { inside: null, relative: null };
+  }
+  const relative = path.relative(base, target);
+  const inside = relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+  return {
+    inside,
+    relative: inside ? (relative || ".") : null,
+  };
+}
+
+function normalizeRuntimeDiagnostics(input, denials) {
+  if (!input || typeof input !== "object") return null;
+
+  const addDir = typeof input.add_dir === "string" ? input.add_dir : null;
+  const childCwd = typeof input.child_cwd === "string" ? input.child_cwd : null;
+  const scopePathMappings = Array.isArray(input.scope_path_mappings)
+    ? input.scope_path_mappings.map((mapping) => ({
+      original: typeof mapping?.original === "string" ? mapping.original : null,
+      contained: typeof mapping?.contained === "string" ? mapping.contained : null,
+      relative: typeof mapping?.relative === "string" ? mapping.relative : null,
+      inside_add_dir: mapping?.inside_add_dir === true,
+    }))
+    : [];
+  const permissionDenials = Array.isArray(denials)
+    ? denials.map((denial) => {
+      const target = targetFromDenial(denial);
+      const { inside, relative } = pathInside(addDir, target);
+      return {
+        tool: toolFromDenial(denial),
+        target,
+        inside_add_dir: inside,
+        relative_to_add_dir: relative,
+      };
+    })
+    : [];
+
+  return {
+    add_dir: addDir,
+    child_cwd: childCwd,
+    scope_path_mappings: scopePathMappings,
+    permission_denials: permissionDenials,
+  };
+}
+
 /**
  * Build the single canonical JobRecord.
  *
@@ -456,6 +516,11 @@ export function buildJobRecord(invocation, execution, mutations) {
   const diagnostic = buildErrorDiagnostic(invocation, status, error_code, error_message);
 
   const parsed = execution?.parsed ?? null;
+  const permissionDenials = Array.isArray(parsed?.denials) ? parsed.denials : [];
+  const runtimeDiagnostics = normalizeRuntimeDiagnostics(
+    execution?.runtimeDiagnostics ?? null,
+    permissionDenials,
+  );
   const record = {
     // Identity
     id: invocation.job_id,
@@ -498,11 +563,12 @@ export function buildJobRecord(invocation, execution, mutations) {
     suggested_action: diagnostic.suggested_action,
     external_review: externalReviewForInvocation(invocation, execution),
     disclosure_note: diagnostic.disclosure_note,
+    runtime_diagnostics: runtimeDiagnostics,
 
     // Result
     result: parsed?.result ?? null,
     structured_output: parsed?.structured ?? null,
-    permission_denials: Array.isArray(parsed?.denials) ? parsed.denials : [],
+    permission_denials: permissionDenials,
     mutations: [...mutations],
     cost_usd: parsed?.costUsd ?? null,
     usage: parsed?.usage ?? null,

--- a/plugins/gemini/scripts/lib/review-prompt.mjs
+++ b/plugins/gemini/scripts/lib/review-prompt.mjs
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 export const REVIEW_PROMPT_CHECKLIST = Object.freeze([
   "Verify exact base/head refs and commits before judging the diff.",
   "Review only the declared scope and list any scope gaps as NOT REVIEWED.",
@@ -8,6 +10,235 @@ export const REVIEW_PROMPT_CHECKLIST = Object.freeze([
 ]);
 
 export const REVIEW_PROMPT_CONTRACT_VERSION = 1;
+export const REVIEW_AUDIT_MANIFEST_VERSION = 1;
+
+function contentBuffer(file) {
+  if (Buffer.isBuffer(file?.content)) return file.content;
+  if (file?.content instanceof Uint8Array) return Buffer.from(file.content);
+  return Buffer.from(String(file?.text ?? ""), "utf8");
+}
+
+function sha256(value) {
+  const input = Buffer.isBuffer(value) || value instanceof Uint8Array
+    ? value
+    : String(value ?? "");
+  return createHash("sha256").update(input).digest("hex");
+}
+
+function hashObject(value) {
+  return Object.freeze({
+    algorithm: "sha256",
+    value: sha256(value),
+  });
+}
+
+function lineCount(text) {
+  const value = String(text ?? "");
+  if (value.length === 0) return 0;
+  const normalized = value.endsWith("\n") ? value.slice(0, -1) : value;
+  if (normalized.length === 0) return 0;
+  let lines = 1;
+  for (let index = 0; index < normalized.length; index += 1) {
+    if (normalized[index] === "\n") {
+      lines += 1;
+    } else if (normalized[index] === "\r") {
+      lines += 1;
+      if (normalized[index + 1] === "\n") index += 1;
+    }
+  }
+  return lines;
+}
+
+function sourceManifest(sourceFiles = []) {
+  const files = Array.isArray(sourceFiles) ? sourceFiles : [];
+  const entries = files.map((file) => {
+    const content = contentBuffer(file);
+    const text = typeof file?.text === "string" ? file.text : content.toString("utf8");
+    return Object.freeze({
+      path: String(file?.path ?? "unknown"),
+      bytes: content.length,
+      lines: lineCount(text),
+      content_hash: hashObject(content),
+    });
+  });
+  return Object.freeze({
+    files: Object.freeze(entries),
+    totals: Object.freeze({
+      files: entries.length,
+      bytes: entries.reduce((sum, file) => sum + file.bytes, 0),
+      lines: entries.reduce((sum, file) => sum + file.lines, 0),
+    }),
+  });
+}
+
+function isWordBoundary(char) {
+  if (!char) return true;
+  const code = char.charCodeAt(0);
+  return !(
+    (code >= 48 && code <= 57)
+    || (code >= 65 && code <= 90)
+    || (code >= 97 && code <= 122)
+    || char === "_"
+    || char === "-"
+  );
+}
+
+function startsWithToken(line, token) {
+  return line.startsWith(token) && isWordBoundary(line[token.length]);
+}
+
+function startsWithLabel(line, label) {
+  if (!line.startsWith(label)) return false;
+  return line.slice(label.length).trimStart().startsWith(":");
+}
+
+function reviewLines(text) {
+  return String(text ?? "").split("\n").map((line) => (
+    line.endsWith("\r") ? line.slice(0, -1) : line
+  ).trimStart());
+}
+
+function hasVerdict(text) {
+  return reviewLines(text).some((rawLine) => {
+    const line = rawLine.toLowerCase();
+    return startsWithLabel(line, "verdict")
+      || startsWithLabel(line, "summary")
+      || startsWithToken(line, "approve")
+      || startsWithToken(line, "approved")
+      || startsWithToken(line, "request changes")
+      || startsWithToken(line, "reject")
+      || startsWithToken(line, "rejected");
+  });
+}
+
+function checklistText(line) {
+  const trimmed = line.trimStart();
+  if (trimmed.startsWith("-") || trimmed.startsWith("*")) return trimmed.slice(1).trimStart();
+  let index = 0;
+  while (index < trimmed.length) {
+    const code = trimmed.charCodeAt(index);
+    if (code < 48 || code > 57) break;
+    index += 1;
+  }
+  if (index === 0 || (trimmed[index] !== "." && trimmed[index] !== ")")) return null;
+  return trimmed.slice(index + 1).trimStart();
+}
+
+function isChecklistVerdict(line) {
+  const text = checklistText(line);
+  if (!text) return false;
+  const lower = text.toLowerCase();
+  return startsWithToken(lower, "pass")
+    || startsWithToken(lower, "fail")
+    || startsWithToken(lower, "not reviewed");
+}
+
+function includesAny(text, phrases) {
+  return phrases.some((phrase) => text.includes(phrase));
+}
+
+function qualityFlags({ result = "", status = null, errorCode = null } = {}) {
+  const text = String(result ?? "");
+  const lowerText = text.toLowerCase();
+  const checklistItemsSeen = reviewLines(text).filter((line) => isChecklistVerdict(line)).length;
+  return Object.freeze({
+    has_verdict: hasVerdict(text),
+    has_blocking_section: includesAny(lowerText, [
+      "blocking finding",
+      "blocking findings",
+      "blocker",
+      "blockers",
+    ]),
+    has_non_blocking_section: includesAny(lowerText, [
+      "non-blocking",
+      "non blocking",
+      "minor concern",
+      "minor concerns",
+      "residual risk",
+      "residual risks",
+    ]),
+    checklist_items_seen: checklistItemsSeen,
+    looks_shallow: text.trim().length > 0 && text.trim().length < 500,
+    failed_review_slot: status !== "completed" || errorCode !== null,
+  });
+}
+
+export function scopeResolutionReason(scopeInfo = {}) {
+  const paths = scopeInfo.scope_paths ?? scopeInfo.paths;
+  if (scopeInfo.scope === "branch-diff" || scopeInfo.name === "branch-diff") {
+    const base = scopeInfo.scope_base ?? scopeInfo.base ?? "main";
+    if (Array.isArray(paths) && paths.length > 0) {
+      return `git diff -z --name-only ${base}...HEAD -- filtered by explicit --scope-paths`;
+    }
+    return `git diff -z --name-only ${base}...HEAD --`;
+  }
+  if (Array.isArray(paths) && paths.length > 0) {
+    return "explicit --scope-paths";
+  }
+  return scopeInfo.scope ?? scopeInfo.name ?? null;
+}
+
+export function buildReviewAuditManifest({
+  prompt = "",
+  sourceFiles = [],
+  git = {},
+  promptBuilder = {},
+  request = {},
+  truncation = {},
+  providerIds = {},
+  scope = {},
+  result = "",
+  status = null,
+  errorCode = null,
+} = {}) {
+  return Object.freeze({
+    schema_version: REVIEW_AUDIT_MANIFEST_VERSION,
+    rendered_prompt_hash: hashObject(prompt),
+    selected_source: sourceManifest(sourceFiles),
+    git_identity: Object.freeze({
+      remote: git.remote ?? null,
+      branch: git.branch ?? null,
+      base_ref: git.baseRef ?? null,
+      base_sha: git.baseCommit ?? null,
+      head_ref: git.headRef ?? null,
+      head_sha: git.headCommit ?? null,
+      diff_stat: git.diffStat ?? null,
+    }),
+    prompt_builder: Object.freeze({
+      contract_version: promptBuilder.contractVersion ?? null,
+      plugin_version: promptBuilder.pluginVersion ?? null,
+      plugin_commit: promptBuilder.pluginCommit ?? null,
+    }),
+    request: Object.freeze({
+      provider: request.provider ?? null,
+      model: request.model ?? null,
+      timeout_ms: request.timeoutMs ?? null,
+      max_tokens: request.maxTokens ?? null,
+      max_steps_per_turn: request.maxStepsPerTurn ?? null,
+      temperature: request.temperature ?? null,
+      stream: request.stream ?? null,
+    }),
+    truncation: Object.freeze({
+      prompt: truncation.prompt ?? null,
+      prompt_at_chars: truncation.promptAtChars ?? null,
+      source: truncation.source ?? null,
+      source_at_bytes: truncation.sourceAtBytes ?? null,
+      output: truncation.output ?? null,
+      output_at_chars: truncation.outputAtChars ?? null,
+    }),
+    provider_ids: Object.freeze({
+      request_id: providerIds.requestId ?? null,
+      session_id: providerIds.sessionId ?? null,
+    }),
+    scope_resolution: Object.freeze({
+      scope: scope.name ?? null,
+      scope_base: scope.base ?? null,
+      scope_paths: Array.isArray(scope.paths) ? Object.freeze([...scope.paths]) : null,
+      reason: scope.reason ?? null,
+    }),
+    review_quality: qualityFlags({ result, status, errorCode }),
+  });
+}
 
 function line(name, value) {
   return `${name}: ${value ?? "unknown"}`;

--- a/plugins/gemini/scripts/lib/scope.mjs
+++ b/plugins/gemini/scripts/lib/scope.mjs
@@ -714,7 +714,7 @@ function scopeStaged(sourceCwd, targetPath) {
   }
 }
 
-function scopeBranchDiff(sourceCwd, targetPath, scopeBase) {
+function scopeBranchDiff(sourceCwd, targetPath, scopeBase, scopePaths = []) {
   assertGitWorktree(sourceCwd);
   const ctx = gitScopeContext(sourceCwd);
   assertGitHead(ctx, sourceCwd);
@@ -735,7 +735,7 @@ function scopeBranchDiff(sourceCwd, targetPath, scopeBase) {
   }
   prepareGitSnapshotTarget(sourceCwd, targetPath);
   const raw = git(ctx.gitRoot, ["diff", "--name-only", "-z", `${mergeBase}..HEAD`]);
-  const files = [];
+  let files = [];
   for (const gitRel of raw.split("\0").filter(Boolean)) {
     const snapshotRel = toSnapshotRel(ctx, gitRel);
     if (!snapshotRel) continue;
@@ -744,8 +744,14 @@ function scopeBranchDiff(sourceCwd, targetPath, scopeBase) {
     }
     files.push({ gitRel, snapshotRel });
   }
+  if (Array.isArray(scopePaths) && scopePaths.length > 0) {
+    files = files.filter(({ snapshotRel }) => scopePaths.some((g) => matchGlob(snapshotRel, g)));
+  }
   if (files.length === 0) {
-    scopeEmpty(`branch-diff selected no files under ${sourceCwd} against base ${JSON.stringify(base)}`);
+    const qualifier = Array.isArray(scopePaths) && scopePaths.length > 0
+      ? ` matching --scope-paths ${scopePaths.join(",")}`
+      : "";
+    scopeEmpty(`branch-diff selected no files${qualifier} under ${sourceCwd} against base ${JSON.stringify(base)}`);
   }
   const materializations = [];
   const entriesByRel = entryMap(scopedGitEntries(ctx, headEntries(ctx.gitRoot)));
@@ -878,7 +884,7 @@ export function populateScope(profile, sourceCwd, targetPath, runtimeInputs = {}
   switch (profile.scope) {
     case "working-tree": scopeWorkingTree(sourceCwd, targetPath); break;
     case "staged":       scopeStaged(sourceCwd, targetPath); break;
-    case "branch-diff":  scopeBranchDiff(sourceCwd, targetPath, runtimeInputs.scopeBase); break;
+    case "branch-diff":  scopeBranchDiff(sourceCwd, targetPath, runtimeInputs.scopeBase, runtimeInputs.scopePaths); break;
     case "head":         scopeHead(sourceCwd, targetPath, containmentHandle); break;
     case "custom":       scopeCustom(sourceCwd, targetPath, runtimeInputs.scopePaths); break;
     default:

--- a/plugins/grok/scripts/grok-web-reviewer.mjs
+++ b/plugins/grok/scripts/grok-web-reviewer.mjs
@@ -1,34 +1,39 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { existsSync } from "node:fs";
-import { mkdir, readFile, readdir, realpath, rename, rm, rmdir, stat, unlink, writeFile } from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
+import { mkdir, open, readFile, readdir, realpath, rename, rm, rmdir, stat, unlink, writeFile } from "node:fs/promises";
 import { hostname } from "node:os";
 import { dirname, isAbsolute, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { cleanGitEnv as cleanCanonicalGitEnv } from "./lib/git-env.mjs";
-import { REVIEW_PROMPT_CONTRACT_VERSION, buildReviewPrompt } from "./lib/review-prompt.mjs";
+import { REVIEW_PROMPT_CONTRACT_VERSION, buildReviewAuditManifest, buildReviewPrompt, scopeResolutionReason } from "./lib/review-prompt.mjs";
 
 const VALID_MODES = new Set(["review", "adversarial-review", "custom-review"]);
 const DEFAULT_BASE_URL = "http://127.0.0.1:8000/v1";
 const DEFAULT_MODEL = "grok-4.20-fast";
 const DEFAULT_TIMEOUT_MS = 30000;
 const DEFAULT_DOCTOR_TIMEOUT_MS = 2000;
+const DEFAULT_CHAT_DOCTOR_TIMEOUT_MS = 10000;
 const MAX_SCOPE_FILE_BYTES = 256 * 1024;
 const MAX_SCOPE_TOTAL_BYTES = 1024 * 1024;
+const GIT_SHOW_MAX_BUFFER_BYTES = 16 * 1024 * 1024;
 const MAX_STATE_JOBS = 50;
 const STATE_LOCK_STALE_MS = 60 * 1000;
 const SCHEMA_VERSION = 10;
 const MIN_SECRET_REDACTION_LENGTH = 8;
 const GIT_BINARY = "/usr/bin/git";
 const GIT_SAFE_PATH = "/usr/bin:/bin";
+const PLUGIN_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const SCOPE_FILE_OPEN_FLAGS = fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0);
 
 function printJson(obj) {
   process.stdout.write(`${JSON.stringify(obj, null, 2)}\n`);
 }
 
 function parseArgs(argv) {
-  const out = { _: [] };
+  const out = Object.create(null);
+  out._ = [];
   for (let i = 0; i < argv.length; i += 1) {
     const token = argv[i];
     if (!token.startsWith("--")) {
@@ -37,10 +42,13 @@ function parseArgs(argv) {
     }
     const eq = token.indexOf("=");
     if (eq !== -1) {
-      out[token.slice(2, eq)] = token.slice(eq + 1);
+      const key = token.slice(2, eq);
+      assertSafeOptionKey(key, token);
+      out[key] = token.slice(eq + 1);
       continue;
     }
     const key = token.slice(2);
+    assertSafeOptionKey(key, token);
     const next = argv[i + 1];
     if (next == null || next.startsWith("--")) out[key] = true;
     else {
@@ -49,6 +57,12 @@ function parseArgs(argv) {
     }
   }
   return out;
+}
+
+function assertSafeOptionKey(key, token) {
+  if (!key || key === "__proto__" || key === "prototype" || key === "constructor") {
+    throw new Error(`unsupported option ${token}`);
+  }
 }
 
 function normalizeBaseUrl(value) {
@@ -66,6 +80,7 @@ function config(env = process.env) {
     model: env.GROK_WEB_MODEL || DEFAULT_MODEL,
     timeout_ms: parsePositiveInteger(env.GROK_WEB_TIMEOUT_MS, DEFAULT_TIMEOUT_MS),
     doctor_timeout_ms: parsePositiveInteger(env.GROK_WEB_DOCTOR_TIMEOUT_MS, DEFAULT_DOCTOR_TIMEOUT_MS),
+    chat_doctor_timeout_ms: parsePositiveInteger(env.GROK_WEB_CHAT_DOCTOR_TIMEOUT_MS, DEFAULT_CHAT_DOCTOR_TIMEOUT_MS),
     credential_ref: env.GROK_WEB_TUNNEL_API_KEY ? "GROK_WEB_TUNNEL_API_KEY" : null,
     credential_value: env.GROK_WEB_TUNNEL_API_KEY || null,
   };
@@ -127,6 +142,7 @@ function runCommand(command, args = [], options = {}) {
     cwd: options.cwd,
     env: options.env,
     encoding: "utf8",
+    maxBuffer: options.maxBuffer,
     shell: false,
     windowsHide: true,
   });
@@ -151,6 +167,22 @@ function git(args, cwd, options = {}) {
   return res.stdout.trim();
 }
 
+function gitRaw(args, cwd, options = {}) {
+  const res = runCommand(GIT_BINARY, args, {
+    cwd,
+    env: { ...cleanGitEnv(), PATH: GIT_SAFE_PATH },
+    maxBuffer: options.maxBuffer,
+  });
+  if (res.error) throw new Error(`git_failed:${res.error.message}`);
+  if (res.signal) throw new Error(`git_failed:signal:${res.signal}`);
+  if (res.status !== 0) {
+    if (options.allowFailure) return null;
+    const detail = String(res.stderr || res.stdout || `git exited with status ${res.status}`).trim();
+    throw new Error(`git_failed:${detail}`);
+  }
+  return res.stdout;
+}
+
 function gitCommitForPrompt(cwd, ref) {
   if (!ref) return null;
   try {
@@ -173,6 +205,30 @@ function splitScopePaths(value) {
   return String(value).split(/[,\n]/).map((s) => s.trim()).filter(Boolean);
 }
 
+function splitGitPathList(output) {
+  return output ? output.split("\0").filter(Boolean) : [];
+}
+
+function matchGlob(rel, pattern) {
+  let re = "^";
+  for (let i = 0; i < pattern.length; i += 1) {
+    const c = pattern[i];
+    if (c === "*") {
+      if (pattern[i + 1] === "*") {
+        re += ".*";
+        i += 1;
+        if (pattern[i + 1] === "/") i += 1;
+      } else {
+        re += "[^/]*";
+      }
+    } else if (c === "?") re += "[^/]";
+    else if (".^$+(){}|\\[]".includes(c)) re += `\\${c}`;
+    else re += c;
+  }
+  re += "$";
+  return new RegExp(re).test(rel);
+}
+
 function scopeName(options) {
   return options.scope ?? (options.mode === "custom-review" ? "custom" : "branch-diff");
 }
@@ -185,45 +241,121 @@ function selectedScopePaths(scope, options, cwd) {
   }
   if (scope === "branch-diff") {
     const base = options["scope-base"] ?? "main";
-    const changed = git(["diff", "--name-only", `${base}...HEAD`, "--"], cwd);
-    const relPaths = changed ? changed.split("\n").filter(Boolean) : [];
+    const changed = gitRaw(["diff", "-z", "--name-only", `${base}...HEAD`, "--"], cwd);
+    const requested = splitScopePaths(options["scope-paths"]);
+    const changedPaths = splitGitPathList(changed);
+    const relPaths = requested.length > 0
+      ? changedPaths.filter((relPath) => requested.some((pattern) => matchGlob(relPath, pattern)))
+      : changedPaths;
     if (relPaths.length === 0) throw new Error("scope_empty: branch-diff selected no files");
     return relPaths;
   }
   throw new Error(`unsupported_scope:${scope}`);
 }
 
-async function readScopeFiles(workspaceRoot, relPaths) {
+function validateScopePath(workspaceRoot, relPath) {
+  if (relPath.includes("..") || isAbsolute(relPath) || relPath.includes("\\")) {
+    throw new Error(`unsafe_scope_path:${relPath}`);
+  }
+  const abs = resolve(workspaceRoot, relPath);
+  const normalizedRel = relative(workspaceRoot, abs);
+  if (normalizedRel.startsWith("..") || normalizedRel === "") {
+    throw new Error(`unsafe_scope_path:${relPath}`);
+  }
+  return { abs, normalizedRel };
+}
+
+function addScopeFile(files, normalizedRel, text, totalBytes) {
+  if (text.length === 0) return;
+  const bytes = Buffer.byteLength(text, "utf8");
+  if (bytes > MAX_SCOPE_FILE_BYTES) {
+    throw new Error(`scope_file_too_large:${normalizedRel}: ${bytes} bytes exceeds ${MAX_SCOPE_FILE_BYTES} byte limit`);
+  }
+  totalBytes.value += bytes;
+  if (totalBytes.value > MAX_SCOPE_TOTAL_BYTES) {
+    throw new Error(`scope_total_too_large:${totalBytes.value} bytes exceeds ${MAX_SCOPE_TOTAL_BYTES} byte limit`);
+  }
+  files.push({ path: normalizedRel, text });
+}
+
+async function readUtf8ScopeFileWithinLimit(filePath, normalizedRel) {
+  const handle = await open(filePath, SCOPE_FILE_OPEN_FLAGS);
+  try {
+    const info = await handle.stat();
+    if (!info.isFile()) return null;
+    if (info.size > MAX_SCOPE_FILE_BYTES) {
+      throw new Error(`scope_file_too_large:${normalizedRel}: ${info.size} bytes exceeds ${MAX_SCOPE_FILE_BYTES} byte limit`);
+    }
+
+    const chunks = [];
+    let total = 0;
+    for (;;) {
+      const remaining = MAX_SCOPE_FILE_BYTES + 1 - total;
+      if (remaining <= 0) {
+        throw new Error(`scope_file_too_large:${normalizedRel}: exceeds ${MAX_SCOPE_FILE_BYTES} byte limit`);
+      }
+      const buffer = Buffer.allocUnsafe(Math.min(remaining, 64 * 1024));
+      const { bytesRead } = await handle.read(buffer, 0, buffer.length, null);
+      if (bytesRead === 0) break;
+      total += bytesRead;
+      if (total > MAX_SCOPE_FILE_BYTES) {
+        throw new Error(`scope_file_too_large:${normalizedRel}: ${total} bytes exceeds ${MAX_SCOPE_FILE_BYTES} byte limit`);
+      }
+      chunks.push(buffer.subarray(0, bytesRead));
+    }
+    if (total === 0) return "";
+    return Buffer.concat(chunks, total).toString("utf8");
+  } finally {
+    await handle.close();
+  }
+}
+
+async function readGitScopeFiles(gitCwd, workspaceRoot, relPaths) {
   const files = [];
-  let totalBytes = 0;
+  const totalBytes = { value: 0 };
+  for (const relPath of relPaths) {
+    const { normalizedRel } = validateScopePath(workspaceRoot, relPath);
+    const blobSpec = `HEAD:${relPath}`;
+    const sizeText = gitRaw(["cat-file", "-s", blobSpec], gitCwd, { allowFailure: true });
+    if (sizeText === null) continue;
+    const blobBytes = Number.parseInt(sizeText.trim(), 10);
+    if (!Number.isSafeInteger(blobBytes) || blobBytes < 0) {
+      throw new Error(`scope_invalid_git_blob_size:${normalizedRel}`);
+    }
+    if (blobBytes > MAX_SCOPE_FILE_BYTES) {
+      throw new Error(`scope_file_too_large:${normalizedRel}:${blobBytes}`);
+    }
+    const text = gitRaw(["show", blobSpec], gitCwd, {
+      allowFailure: true,
+      maxBuffer: GIT_SHOW_MAX_BUFFER_BYTES,
+    });
+    if (text === null) continue;
+    addScopeFile(files, normalizedRel, text, totalBytes);
+  }
+  if (files.length === 0) throw new Error("scope_empty: selected files are missing or empty");
+  return files;
+}
+
+async function readFilesystemScopeFiles(workspaceRoot, relPaths) {
+  const files = [];
+  const totalBytes = { value: 0 };
   const realWorkspaceRoot = await realpath(workspaceRoot);
   for (const relPath of relPaths) {
-    if (relPath.includes("..") || isAbsolute(relPath) || relPath.includes("\\")) {
-      throw new Error(`unsafe_scope_path:${relPath}`);
+    const { abs, normalizedRel } = validateScopePath(workspaceRoot, relPath);
+    let realAbs;
+    try {
+      realAbs = await realpath(abs);
+    } catch (error) {
+      if (error?.code === "ENOENT") continue;
+      throw error;
     }
-    const abs = resolve(workspaceRoot, relPath);
-    const normalizedRel = relative(workspaceRoot, abs);
-    if (normalizedRel.startsWith("..") || normalizedRel === "") {
-      throw new Error(`unsafe_scope_path:${relPath}`);
-    }
-    if (!existsSync(abs)) continue;
-    const realAbs = await realpath(abs);
     const realRel = relative(realWorkspaceRoot, realAbs);
     if (realRel.startsWith("..") || realRel === "") {
       throw new Error(`unsafe_scope_path:${relPath}`);
     }
-    const info = await stat(realAbs);
-    if (!info.isFile()) continue;
-    if (info.size > MAX_SCOPE_FILE_BYTES) {
-      throw new Error(`scope_file_too_large:${normalizedRel}: ${info.size} bytes exceeds ${MAX_SCOPE_FILE_BYTES} byte limit`);
-    }
-    totalBytes += info.size;
-    if (totalBytes > MAX_SCOPE_TOTAL_BYTES) {
-      throw new Error(`scope_total_too_large:${totalBytes} bytes exceeds ${MAX_SCOPE_TOTAL_BYTES} byte limit`);
-    }
-    const text = await readFile(realAbs, "utf8");
-    if (text.length === 0) continue;
-    files.push({ path: normalizedRel, text });
+    const text = await readUtf8ScopeFileWithinLimit(realAbs, normalizedRel);
+    if (text === null) continue;
+    addScopeFile(files, normalizedRel, text, totalBytes);
   }
   if (files.length === 0) throw new Error("scope_empty: selected files are missing or empty");
   return files;
@@ -255,17 +387,28 @@ async function collectScope(options) {
   const scope = scopeName(options);
   const scopeBase = scope === "branch-diff" ? options["scope-base"] ?? "main" : null;
   const relPaths = selectedScopePaths(scope, options, cwd);
-  const files = await readScopeFiles(workspaceRoot, relPaths);
+  const files = scope === "branch-diff"
+    ? await readGitScopeFiles(cwd, workspaceRoot, relPaths)
+    : await readFilesystemScopeFiles(workspaceRoot, relPaths);
   return {
     cwd,
     workspaceRoot,
     scope,
     scope_base: scopeBase,
-    base_commit: gitCommitForPrompt(cwd, scopeBase),
-    head_commit: gitCommitForPrompt(cwd, "HEAD"),
     scope_paths: relPaths,
+    repository: repositoryIdentity(cwd, workspaceRoot),
+    base_commit: scopeBase ? gitCommitForPrompt(cwd, scopeBase) : null,
+    head_ref: git(["branch", "--show-current"], cwd, { allowFailure: true }) || "HEAD",
+    head_commit: gitCommitForPrompt(cwd, "HEAD"),
     files,
   };
+}
+
+function repositoryIdentity(cwd, workspaceRoot) {
+  const remote = git(["remote", "get-url", "origin"], cwd, { allowFailure: true });
+  if (!remote) return workspaceRoot;
+  const match = /[:/]([^/:]+\/[^/]+?)(?:\.git)?$/.exec(remote);
+  return match ? match[1] : remote;
 }
 
 function promptFor(mode, userPrompt, scopeInfo) {
@@ -276,17 +419,16 @@ function promptFor(mode, userPrompt, scopeInfo) {
   return buildReviewPrompt({
     provider: "Grok Web",
     mode,
-    repository: scopeInfo.workspaceRoot ?? null,
+    repository: scopeInfo.repository,
     baseRef: scopeInfo.scope_base ?? null,
     baseCommit: scopeInfo.base_commit ?? null,
-    headRef: "HEAD",
+    headRef: scopeInfo.head_ref ?? "HEAD",
     headCommit: scopeInfo.head_commit ?? null,
     scope: scopeInfo.scope,
     scopePaths: scopeInfo.scope_paths,
     userPrompt,
     extraInstructions: [
       modeLine,
-      "Return a concise verdict and findings. Do not edit files.",
       "This request is routed through a local subscription-backed Grok web tunnel, not paid xAI API billing.",
       `Selected files:\n${files}`,
     ],
@@ -310,6 +452,13 @@ function providerFailure(reason, message, httpStatus, raw = null, payloadSent = 
   };
 }
 
+function providerFailureWithDiagnostic(reason, message, httpStatus, raw = null, payloadSent = null, diagnostics = null) {
+  return {
+    ...providerFailure(reason, message, httpStatus, raw, payloadSent),
+    diagnostics,
+  };
+}
+
 function classifyHttpFailure(status) {
   if (status === 401 || status === 403) return "session_expired";
   if (status === 429) return "usage_limited";
@@ -322,6 +471,26 @@ function errorMessageFromResponse(parsed, text, redact) {
     return redact(parsed.value?.error?.message ?? parsed.value?.message ?? JSON.stringify(parsed.value)).slice(0, 800);
   }
   return redact(text).slice(0, 800);
+}
+
+function chatBadRequestCode(parsed, text) {
+  const value = parsed.ok ? parsed.value : null;
+  const codeOrType = [
+    value?.error?.code,
+    value?.error?.type,
+  ].filter(Boolean).join(" ").toLowerCase();
+  if (/\b(model_not_found|invalid_model|unknown_model)\b/.test(codeOrType)) {
+    return "grok_chat_model_rejected";
+  }
+  const haystack = [
+    value?.error?.message,
+    value?.message,
+    text,
+  ].filter(Boolean).join(" ").toLowerCase();
+  if (/\b(?:model|model id|model name)\b.{0,80}\b(?:not found|unknown|unsupported|does not exist|not accepted)\b/.test(haystack)) {
+    return "grok_chat_model_rejected";
+  }
+  return "models_ok_chat_400";
 }
 
 function payloadSentForFetchError(error) {
@@ -370,7 +539,20 @@ async function callGrokTunnel(cfg, prompt, env = process.env) {
     const text = await response.text();
     const parsed = parseJson(text);
     if (!response.ok) {
-      return providerFailure(classifyHttpFailure(response.status), errorMessageFromResponse(parsed, text, redact), response.status, parsed.ok ? parsed.value : null, true);
+      return providerFailureWithDiagnostic(
+        classifyHttpFailure(response.status),
+        errorMessageFromResponse(parsed, text, redact),
+        response.status,
+        parsed.ok ? parsed.value : null,
+        true,
+        {
+          endpoint_class: "chat_completions",
+          model: cfg.model,
+          stream: false,
+          message_count: requestBody.messages.length,
+          prompt_chars: prompt.length,
+        },
+      );
     }
     if (!parsed.ok) return providerFailure("malformed_response", parsed.error, response.status, null, true);
     const content = parsed.value?.choices?.[0]?.message?.content;
@@ -389,6 +571,13 @@ async function callGrokTunnel(cfg, prompt, env = process.env) {
       http_status: response.status,
       credential_ref: cfg.credential_ref,
       endpoint: cfg.base_url,
+      diagnostics: {
+        configured_timeout_ms: cfg.timeout_ms,
+        prompt_chars: prompt.length,
+        max_tokens: null,
+        temperature: requestBody.temperature ?? null,
+        stream: false,
+      },
     };
   } catch (e) {
     const reason = e?.name === "AbortError" ? "tunnel_timeout" : "tunnel_unavailable";
@@ -442,6 +631,57 @@ async function probeGrokTunnel(cfg, env = process.env) {
   }
 }
 
+async function probeGrokChat(cfg, env = process.env) {
+  const endpoint = `${cfg.base_url}/chat/completions`;
+  const headers = { "content-type": "application/json" };
+  if (cfg.credential_value) headers.authorization = `Bearer ${cfg.credential_value}`;
+  const redact = redactor(env);
+  const requestBody = {
+    model: cfg.model,
+    stream: false,
+    messages: [{ role: "user", content: "Return exactly: ok" }],
+    temperature: 0,
+  };
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), cfg.chat_doctor_timeout_ms);
+  try {
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(requestBody),
+      signal: controller.signal,
+    });
+    const text = await response.text();
+    const parsed = text ? parseJson(text) : { ok: true, value: null };
+    if (!response.ok) {
+      return {
+        chat_ready: false,
+        error_code: response.status === 400 ? chatBadRequestCode(parsed, text) : classifyHttpFailure(response.status),
+        error_message: errorMessageFromResponse(parsed, text, redact),
+        http_status: response.status,
+        probe_endpoint: endpoint,
+      };
+    }
+    return {
+      chat_ready: true,
+      error_code: null,
+      error_message: null,
+      http_status: response.status,
+      probe_endpoint: endpoint,
+    };
+  } catch (e) {
+    return {
+      chat_ready: false,
+      error_code: e?.name === "AbortError" ? "grok_chat_timeout" : "tunnel_unavailable",
+      error_message: tunnelTransportMessage(e, env, redact),
+      http_status: null,
+      probe_endpoint: endpoint,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 function sourceTransmission(completed, payloadSent) {
   if (completed || payloadSent === true) return "sent";
   if (payloadSent === false) return "not_sent";
@@ -469,6 +709,9 @@ function suggestedAction(errorCode) {
   if (errorCode === "tunnel_timeout") return "The local Grok web tunnel did not respond before GROK_WEB_TIMEOUT_MS; inspect the tunnel and retry.";
   if (errorCode === "session_expired") return "Refresh the Grok web login/session used by the local tunnel, then retry.";
   if (errorCode === "usage_limited") return "Wait for Grok subscription usage to recover, reduce concurrency, or inspect the local tunnel.";
+  if (errorCode === "grok_chat_model_rejected") return "The tunnel lists models, but the configured GROK_WEB_MODEL is not accepted by chat; correct GROK_WEB_MODEL or tunnel model routing, then retry.";
+  if (errorCode === "grok_chat_timeout") return "The Grok chat readiness probe exceeded GROK_WEB_CHAT_DOCTOR_TIMEOUT_MS; inspect the local tunnel latency or raise that timeout, then retry.";
+  if (errorCode === "models_ok_chat_400") return "The tunnel lists models but chat is not review-capable; refresh the Grok web session, inspect tunnel logs and rate-limit endpoint health, then retry.";
   if (errorCode === "malformed_response") return "Inspect or update the local Grok web tunnel; it returned an unsupported response shape.";
   return "Inspect error_message and repair the local Grok web tunnel before retrying.";
 }
@@ -479,10 +722,72 @@ function errorCauseFor(errorCode) {
   return "grok_web_tunnel";
 }
 
+function buildReviewMetadata(cfg, scopeInfo, execution = null) {
+  const auditManifest = execution?.prompt ? buildReviewAuditManifest({
+    prompt: execution.prompt,
+    sourceFiles: scopeInfo.files ?? [],
+    git: {
+      remote: scopeInfo.repository ?? null,
+      branch: scopeInfo.head_ref ?? null,
+      baseRef: scopeInfo.scope_base ?? null,
+      baseCommit: scopeInfo.base_commit ?? null,
+      headRef: scopeInfo.head_ref ?? null,
+      headCommit: scopeInfo.head_commit ?? null,
+    },
+    promptBuilder: {
+      contractVersion: REVIEW_PROMPT_CONTRACT_VERSION,
+      pluginVersion: "0.1.0",
+      pluginCommit: gitCommitForPrompt(PLUGIN_ROOT, "HEAD"),
+    },
+    request: {
+      provider: cfg.display_name,
+      model: cfg.model,
+      timeoutMs: execution.diagnostics?.configured_timeout_ms ?? cfg.timeout_ms ?? null,
+      maxTokens: execution.diagnostics?.max_tokens ?? null,
+      temperature: execution.diagnostics?.temperature ?? null,
+      stream: false,
+    },
+    truncation: {
+      prompt: false,
+      source: false,
+      output: false,
+    },
+    providerIds: {
+      sessionId: execution.session_id ?? null,
+    },
+    scope: {
+      name: scopeInfo.scope,
+      base: scopeInfo.scope_base ?? null,
+      paths: scopeInfo.scope_paths ?? null,
+      reason: scopeResolutionReason(scopeInfo),
+    },
+    result: execution.parsed?.result ?? "",
+    status: execution.exitCode === 0 && execution.parsed?.ok === true ? "completed" : "failed",
+    errorCode: execution.parsed?.reason ?? null,
+  }) : null;
+  return {
+    prompt_contract_version: REVIEW_PROMPT_CONTRACT_VERSION,
+    prompt_provider: cfg.display_name,
+    scope: scopeInfo.scope,
+    scope_base: scopeInfo.scope_base ?? null,
+    scope_paths: scopeInfo.scope_paths ?? null,
+    raw_output: execution ? {
+      http_status: execution.http_status ?? null,
+      raw_model: execution.parsed?.raw_model ?? null,
+      parsed_ok: execution.parsed?.ok ?? null,
+      result_chars: typeof execution.parsed?.result === "string" ? execution.parsed.result.length : null,
+    } : null,
+    audit_manifest: auditManifest,
+  };
+}
+
 function buildRecord({ cfg, mode, options, scopeInfo, execution, startedAt, endedAt }) {
   const completed = execution.exitCode === 0 && execution.parsed?.ok === true;
   const errorCode = completed ? null : (execution.parsed?.reason ?? "tunnel_error");
   const errorMessage = completed ? null : (execution.parsed?.error ?? "");
+  const diagnostic = execution.diagnostics
+    ? `${errorMessage || errorCode} (${Object.entries(execution.diagnostics).map(([key, value]) => `${key}=${value}`).join(" ")})`
+    : (errorMessage || errorCode);
   const reviewDisclosure = disclosure(cfg, completed, execution.payload_sent ?? null);
   const transmission = sourceTransmission(completed, execution.payload_sent ?? null);
   return {
@@ -507,19 +812,7 @@ function buildRecord({ cfg, mode, options, scopeInfo, execution, startedAt, ende
     scope_base: scopeInfo.scope_base ?? null,
     scope_paths: scopeInfo.scope_paths ?? null,
     prompt_head: String(options.prompt ?? "").slice(0, 200),
-    review_metadata: Object.freeze({
-      prompt_contract_version: REVIEW_PROMPT_CONTRACT_VERSION,
-      prompt_provider: cfg.display_name,
-      scope: scopeInfo.scope,
-      scope_base: scopeInfo.scope_base ?? null,
-      scope_paths: scopeInfo.scope_paths ?? null,
-      raw_output: Object.freeze({
-        http_status: execution.http_status ?? null,
-        raw_model: execution.parsed?.raw_model ?? null,
-        parsed_ok: execution.parsed?.ok ?? null,
-        result_chars: typeof execution.parsed?.result === "string" ? execution.parsed.result.length : null,
-      }),
-    }),
+    review_metadata: buildReviewMetadata(cfg, scopeInfo, execution),
     schema_spec: null,
     binary: null,
     status: completed ? "completed" : "failed",
@@ -528,7 +821,7 @@ function buildRecord({ cfg, mode, options, scopeInfo, execution, startedAt, ende
     exit_code: execution.exitCode,
     error_code: errorCode,
     error_message: errorMessage,
-    error_summary: completed ? null : errorMessage || errorCode,
+    error_summary: completed ? null : diagnostic,
     error_cause: completed ? null : errorCauseFor(errorCode),
     suggested_action: completed ? null : suggestedAction(errorCode),
     external_review: {
@@ -546,6 +839,7 @@ function buildRecord({ cfg, mode, options, scopeInfo, execution, startedAt, ende
       disclosure: reviewDisclosure,
     },
     disclosure_note: reviewDisclosure,
+    runtime_diagnostics: null,
     result: completed ? execution.parsed.result : null,
     structured_output: null,
     permission_denials: [],
@@ -871,28 +1165,42 @@ async function cmdList(env = process.env) {
 async function doctorFields(env = process.env) {
   const cfg = config(env);
   const probe = await probeGrokTunnel(cfg, env);
-  const ready = probe.reachable === true;
+  const chatProbe = probe.reachable ? await probeGrokChat(cfg, env) : {
+    chat_ready: false,
+    error_code: probe.error_code,
+    error_message: probe.error_message,
+    http_status: null,
+    probe_endpoint: `${cfg.base_url}/chat/completions`,
+  };
+  const ready = probe.reachable === true && chatProbe.chat_ready === true;
+  const errorCode = ready ? null : (chatProbe.error_code ?? probe.error_code);
   return {
     provider: "grok-web",
     status: "ok",
     ready,
     reachable: probe.reachable,
+    chat_ready: chatProbe.chat_ready,
     summary: ready
-      ? "Grok subscription-backed local tunnel reviewer is configured and reachable."
-      : "Grok subscription-backed local tunnel is not reachable.",
+      ? "Grok subscription-backed local tunnel reviewer is configured and chat-ready."
+      : (probe.reachable
+        ? "Grok tunnel models endpoint is reachable, but chat completion is not review-ready."
+        : "Grok subscription-backed local tunnel is not reachable."),
     next_action: ready
       ? "Run a Grok web review."
-      : suggestedAction(probe.error_code),
+      : suggestedAction(errorCode),
     auth_mode: cfg.auth_mode,
     credential_ref: cfg.credential_ref,
     endpoint: cfg.base_url,
     probe_endpoint: probe.probe_endpoint,
+    chat_probe_endpoint: chatProbe.probe_endpoint,
     model: cfg.model,
     timeout_ms: cfg.timeout_ms,
     doctor_timeout_ms: cfg.doctor_timeout_ms,
-    error_code: probe.error_code,
-    error_message: probe.error_message,
+    chat_doctor_timeout_ms: cfg.chat_doctor_timeout_ms,
+    error_code: errorCode,
+    error_message: ready ? null : (chatProbe.error_message ?? probe.error_message),
     http_status: probe.http_status,
+    chat_http_status: chatProbe.http_status,
   };
 }
 
@@ -927,6 +1235,7 @@ async function cmdRun(options) {
     }
     if (!execution) try {
       execution = await callGrokTunnel(cfg, prompt);
+      execution.prompt = prompt;
     } catch (e) {
       execution = providerFailure(
         e.message.startsWith("bad_args:") ? "bad_args" : "tunnel_error",

--- a/plugins/grok/scripts/lib/review-prompt.mjs
+++ b/plugins/grok/scripts/lib/review-prompt.mjs
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 export const REVIEW_PROMPT_CHECKLIST = Object.freeze([
   "Verify exact base/head refs and commits before judging the diff.",
   "Review only the declared scope and list any scope gaps as NOT REVIEWED.",
@@ -8,6 +10,235 @@ export const REVIEW_PROMPT_CHECKLIST = Object.freeze([
 ]);
 
 export const REVIEW_PROMPT_CONTRACT_VERSION = 1;
+export const REVIEW_AUDIT_MANIFEST_VERSION = 1;
+
+function contentBuffer(file) {
+  if (Buffer.isBuffer(file?.content)) return file.content;
+  if (file?.content instanceof Uint8Array) return Buffer.from(file.content);
+  return Buffer.from(String(file?.text ?? ""), "utf8");
+}
+
+function sha256(value) {
+  const input = Buffer.isBuffer(value) || value instanceof Uint8Array
+    ? value
+    : String(value ?? "");
+  return createHash("sha256").update(input).digest("hex");
+}
+
+function hashObject(value) {
+  return Object.freeze({
+    algorithm: "sha256",
+    value: sha256(value),
+  });
+}
+
+function lineCount(text) {
+  const value = String(text ?? "");
+  if (value.length === 0) return 0;
+  const normalized = value.endsWith("\n") ? value.slice(0, -1) : value;
+  if (normalized.length === 0) return 0;
+  let lines = 1;
+  for (let index = 0; index < normalized.length; index += 1) {
+    if (normalized[index] === "\n") {
+      lines += 1;
+    } else if (normalized[index] === "\r") {
+      lines += 1;
+      if (normalized[index + 1] === "\n") index += 1;
+    }
+  }
+  return lines;
+}
+
+function sourceManifest(sourceFiles = []) {
+  const files = Array.isArray(sourceFiles) ? sourceFiles : [];
+  const entries = files.map((file) => {
+    const content = contentBuffer(file);
+    const text = typeof file?.text === "string" ? file.text : content.toString("utf8");
+    return Object.freeze({
+      path: String(file?.path ?? "unknown"),
+      bytes: content.length,
+      lines: lineCount(text),
+      content_hash: hashObject(content),
+    });
+  });
+  return Object.freeze({
+    files: Object.freeze(entries),
+    totals: Object.freeze({
+      files: entries.length,
+      bytes: entries.reduce((sum, file) => sum + file.bytes, 0),
+      lines: entries.reduce((sum, file) => sum + file.lines, 0),
+    }),
+  });
+}
+
+function isWordBoundary(char) {
+  if (!char) return true;
+  const code = char.charCodeAt(0);
+  return !(
+    (code >= 48 && code <= 57)
+    || (code >= 65 && code <= 90)
+    || (code >= 97 && code <= 122)
+    || char === "_"
+    || char === "-"
+  );
+}
+
+function startsWithToken(line, token) {
+  return line.startsWith(token) && isWordBoundary(line[token.length]);
+}
+
+function startsWithLabel(line, label) {
+  if (!line.startsWith(label)) return false;
+  return line.slice(label.length).trimStart().startsWith(":");
+}
+
+function reviewLines(text) {
+  return String(text ?? "").split("\n").map((line) => (
+    line.endsWith("\r") ? line.slice(0, -1) : line
+  ).trimStart());
+}
+
+function hasVerdict(text) {
+  return reviewLines(text).some((rawLine) => {
+    const line = rawLine.toLowerCase();
+    return startsWithLabel(line, "verdict")
+      || startsWithLabel(line, "summary")
+      || startsWithToken(line, "approve")
+      || startsWithToken(line, "approved")
+      || startsWithToken(line, "request changes")
+      || startsWithToken(line, "reject")
+      || startsWithToken(line, "rejected");
+  });
+}
+
+function checklistText(line) {
+  const trimmed = line.trimStart();
+  if (trimmed.startsWith("-") || trimmed.startsWith("*")) return trimmed.slice(1).trimStart();
+  let index = 0;
+  while (index < trimmed.length) {
+    const code = trimmed.charCodeAt(index);
+    if (code < 48 || code > 57) break;
+    index += 1;
+  }
+  if (index === 0 || (trimmed[index] !== "." && trimmed[index] !== ")")) return null;
+  return trimmed.slice(index + 1).trimStart();
+}
+
+function isChecklistVerdict(line) {
+  const text = checklistText(line);
+  if (!text) return false;
+  const lower = text.toLowerCase();
+  return startsWithToken(lower, "pass")
+    || startsWithToken(lower, "fail")
+    || startsWithToken(lower, "not reviewed");
+}
+
+function includesAny(text, phrases) {
+  return phrases.some((phrase) => text.includes(phrase));
+}
+
+function qualityFlags({ result = "", status = null, errorCode = null } = {}) {
+  const text = String(result ?? "");
+  const lowerText = text.toLowerCase();
+  const checklistItemsSeen = reviewLines(text).filter((line) => isChecklistVerdict(line)).length;
+  return Object.freeze({
+    has_verdict: hasVerdict(text),
+    has_blocking_section: includesAny(lowerText, [
+      "blocking finding",
+      "blocking findings",
+      "blocker",
+      "blockers",
+    ]),
+    has_non_blocking_section: includesAny(lowerText, [
+      "non-blocking",
+      "non blocking",
+      "minor concern",
+      "minor concerns",
+      "residual risk",
+      "residual risks",
+    ]),
+    checklist_items_seen: checklistItemsSeen,
+    looks_shallow: text.trim().length > 0 && text.trim().length < 500,
+    failed_review_slot: status !== "completed" || errorCode !== null,
+  });
+}
+
+export function scopeResolutionReason(scopeInfo = {}) {
+  const paths = scopeInfo.scope_paths ?? scopeInfo.paths;
+  if (scopeInfo.scope === "branch-diff" || scopeInfo.name === "branch-diff") {
+    const base = scopeInfo.scope_base ?? scopeInfo.base ?? "main";
+    if (Array.isArray(paths) && paths.length > 0) {
+      return `git diff -z --name-only ${base}...HEAD -- filtered by explicit --scope-paths`;
+    }
+    return `git diff -z --name-only ${base}...HEAD --`;
+  }
+  if (Array.isArray(paths) && paths.length > 0) {
+    return "explicit --scope-paths";
+  }
+  return scopeInfo.scope ?? scopeInfo.name ?? null;
+}
+
+export function buildReviewAuditManifest({
+  prompt = "",
+  sourceFiles = [],
+  git = {},
+  promptBuilder = {},
+  request = {},
+  truncation = {},
+  providerIds = {},
+  scope = {},
+  result = "",
+  status = null,
+  errorCode = null,
+} = {}) {
+  return Object.freeze({
+    schema_version: REVIEW_AUDIT_MANIFEST_VERSION,
+    rendered_prompt_hash: hashObject(prompt),
+    selected_source: sourceManifest(sourceFiles),
+    git_identity: Object.freeze({
+      remote: git.remote ?? null,
+      branch: git.branch ?? null,
+      base_ref: git.baseRef ?? null,
+      base_sha: git.baseCommit ?? null,
+      head_ref: git.headRef ?? null,
+      head_sha: git.headCommit ?? null,
+      diff_stat: git.diffStat ?? null,
+    }),
+    prompt_builder: Object.freeze({
+      contract_version: promptBuilder.contractVersion ?? null,
+      plugin_version: promptBuilder.pluginVersion ?? null,
+      plugin_commit: promptBuilder.pluginCommit ?? null,
+    }),
+    request: Object.freeze({
+      provider: request.provider ?? null,
+      model: request.model ?? null,
+      timeout_ms: request.timeoutMs ?? null,
+      max_tokens: request.maxTokens ?? null,
+      max_steps_per_turn: request.maxStepsPerTurn ?? null,
+      temperature: request.temperature ?? null,
+      stream: request.stream ?? null,
+    }),
+    truncation: Object.freeze({
+      prompt: truncation.prompt ?? null,
+      prompt_at_chars: truncation.promptAtChars ?? null,
+      source: truncation.source ?? null,
+      source_at_bytes: truncation.sourceAtBytes ?? null,
+      output: truncation.output ?? null,
+      output_at_chars: truncation.outputAtChars ?? null,
+    }),
+    provider_ids: Object.freeze({
+      request_id: providerIds.requestId ?? null,
+      session_id: providerIds.sessionId ?? null,
+    }),
+    scope_resolution: Object.freeze({
+      scope: scope.name ?? null,
+      scope_base: scope.base ?? null,
+      scope_paths: Array.isArray(scope.paths) ? Object.freeze([...scope.paths]) : null,
+      reason: scope.reason ?? null,
+    }),
+    review_quality: qualityFlags({ result, status, errorCode }),
+  });
+}
 
 function line(name, value) {
   return `${name}: ${value ?? "unknown"}`;

--- a/plugins/kimi/scripts/kimi-companion.mjs
+++ b/plugins/kimi/scripts/kimi-companion.mjs
@@ -3,7 +3,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, join as joinPath, resolve as resolvePath } from "node:path";
 import {
   existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, unlinkSync,
-  writeFileSync, chmodSync, readdirSync, statSync,
+  writeFileSync, chmodSync, readdirSync, statSync, lstatSync,
 } from "node:fs";
 import { execFileSync, spawn } from "node:child_process";
 import { tmpdir } from "node:os";
@@ -21,6 +21,7 @@ import { cleanGitEnv } from "./lib/git-env.mjs";
 import { spawnKimi } from "./lib/kimi.mjs";
 import { writeCancelMarker, consumeCancelMarker } from "./lib/cancel-marker.mjs";
 import { isCodexSandbox } from "./lib/codex-env.mjs";
+import { REVIEW_PROMPT_CONTRACT_VERSION, buildReviewAuditManifest, buildReviewPrompt } from "./lib/review-prompt.mjs";
 import {
   PING_PROMPT,
   consumePromptSidecar,
@@ -34,16 +35,14 @@ import {
   summarizeScopeDirectory,
   writePromptSidecar,
 } from "./lib/companion-common.mjs";
-import { REVIEW_PROMPT_CONTRACT_VERSION, buildReviewPrompt } from "./lib/review-prompt.mjs";
 
 const PLUGIN_ROOT = resolvePath(dirname(fileURLToPath(import.meta.url)), "..");
 const MODELS_CONFIG_PATH = resolvePath(PLUGIN_ROOT, "config/models.json");
+const GIT_BINARY = "/usr/bin/git";
 const CONTINUABLE_STATUSES = new Set(["completed", "failed", "cancelled", "stale"]);
 const RUN_MODES = Object.freeze(["review", "adversarial-review", "custom-review", "rescue"]);
 const PREFLIGHT_MODES = Object.freeze(["review", "adversarial-review", "custom-review"]);
 const DEFAULT_KIMI_REVIEW_TIMEOUT_MS = 180000;
-const GIT_PROMPT_BINARY = "/usr/bin/git";
-const GIT_PROMPT_SAFE_PATH = "/usr/bin:/bin";
 
 configureState({
   pluginDataEnv: "KIMI_PLUGIN_DATA",
@@ -61,9 +60,43 @@ function fail(code, message, details = {}) {
   process.exit(1);
 }
 
-function targetPromptFor(profile, userPrompt, invocation = {}) {
-  if (profile.permission_mode !== "plan") return userPrompt;
-  const modeLine = profile.name === "adversarial-review"
+function gitText(args, cwd) {
+  try {
+    return execFileSync(GIT_BINARY, ["-C", cwd, ...args], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      env: cleanGitEnv(),
+    }).trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function repositoryIdentity(cwd, workspaceRoot) {
+  const remote = gitText(["remote", "get-url", "origin"], cwd);
+  if (!remote) return workspaceRoot;
+  const match = /[:/]([^/:]+\/[^/]+?)(?:\.git)?$/.exec(remote);
+  return match ? match[1] : remote;
+}
+
+function promptMetadata(invocation) {
+  return {
+    repository: repositoryIdentity(invocation.cwd, invocation.workspace_root),
+    baseRef: invocation.scope_base ?? null,
+    baseCommit: invocation.scope_base ? gitText(["rev-parse", "--verify", `${invocation.scope_base}^{commit}`], invocation.cwd) : null,
+    headRef: gitText(["branch", "--show-current"], invocation.cwd) ?? "HEAD",
+    headCommit: gitText(["rev-parse", "--verify", "HEAD^{commit}"], invocation.cwd),
+  };
+}
+
+function pluginSourceCommit() {
+  return gitText(["rev-parse", "--verify", "HEAD^{commit}"], PLUGIN_ROOT);
+}
+
+function targetPromptFor(userPrompt, invocation) {
+  if (invocation.mode_profile_name === "rescue") return userPrompt;
+  const meta = promptMetadata(invocation);
+  const modeLine = invocation.mode === "adversarial-review"
     ? "You are performing an adversarial code review. Prioritize correctness bugs, security risks, regressions, and missing tests."
     : "You are performing a code review. Prioritize bugs, behavioral regressions, and missing tests.";
   const liveContext = [
@@ -74,14 +107,14 @@ function targetPromptFor(profile, userPrompt, invocation = {}) {
   ].join("\n");
   return buildReviewPrompt({
     provider: "Kimi",
-    mode: profile.name,
-    repository: invocation.workspace_root ?? null,
-    baseRef: invocation.scope_base ?? null,
-    baseCommit: gitCommitForPrompt(invocation.cwd, invocation.scope_base),
-    headRef: "HEAD",
-    headCommit: gitCommitForPrompt(invocation.cwd, "HEAD"),
-    scope: invocation.scope ?? profile.scope,
-    scopePaths: invocation.scope_paths ?? null,
+    mode: invocation.mode,
+    repository: meta.repository,
+    baseRef: meta.baseRef,
+    baseCommit: meta.baseCommit,
+    headRef: meta.headRef,
+    headCommit: meta.headCommit,
+    scope: invocation.scope,
+    scopePaths: invocation.scope_paths,
     userPrompt,
     extraInstructions: [
       modeLine,
@@ -91,24 +124,87 @@ function targetPromptFor(profile, userPrompt, invocation = {}) {
   });
 }
 
-function gitCommitForPrompt(cwd, ref) {
-  if (!ref) return null;
-  try {
-    return execFileSync(GIT_PROMPT_BINARY, ["rev-parse", "--verify", `${ref}^{commit}`], {
-      cwd,
-      env: cleanGitPromptEnv(),
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    }).trim();
-  } catch {
-    return null;
+function listContainedFiles(root, dir = root, prefix = "") {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    if (name === ".git") continue;
+    const full = resolvePath(dir, name);
+    const rel = prefix ? `${prefix}/${name}` : name;
+    const lst = lstatSync(full);
+    if (lst.isSymbolicLink()) continue;
+    if (lst.isDirectory()) out.push(...listContainedFiles(root, full, rel));
+    else out.push(rel);
   }
+  return out.sort((a, b) => a.localeCompare(b));
 }
 
-function cleanGitPromptEnv() {
-  const env = cleanGitEnv();
-  env.PATH = GIT_PROMPT_SAFE_PATH;
-  return env;
+function auditSourceFiles(containmentPath) {
+  if (!containmentPath || !existsSync(containmentPath)) return [];
+  return listContainedFiles(containmentPath).map((path) => ({
+    path,
+    content: readFileSync(resolvePath(containmentPath, path)),
+  }));
+}
+
+function scopeResolutionReason(invocation) {
+  const paths = invocation.scope_paths;
+  if (invocation.scope === "branch-diff") {
+    if (Array.isArray(paths) && paths.length > 0) {
+      return `git diff -z --name-only ${invocation.scope_base ?? "main"}...HEAD -- filtered by explicit --scope-paths`;
+    }
+    return `git diff -z --name-only ${invocation.scope_base ?? "main"}...HEAD --`;
+  }
+  if (Array.isArray(paths) && paths.length > 0) {
+    return "explicit --scope-paths";
+  }
+  return invocation.scope ?? null;
+}
+
+function reviewAuditManifest(invocation, prompt, containmentPath, execution) {
+  if (!invocation.review_prompt_contract_version || invocation.mode_profile_name === "rescue") return null;
+  const meta = promptMetadata(invocation);
+  return buildReviewAuditManifest({
+    prompt,
+    sourceFiles: auditSourceFiles(containmentPath),
+    git: {
+      remote: meta.repository,
+      branch: meta.headRef,
+      baseRef: meta.baseRef,
+      baseCommit: meta.baseCommit,
+      headRef: meta.headRef,
+      headCommit: meta.headCommit,
+    },
+    promptBuilder: {
+      contractVersion: invocation.review_prompt_contract_version,
+      pluginVersion: "0.1.0",
+      pluginCommit: pluginSourceCommit(),
+    },
+    request: {
+      provider: invocation.review_prompt_provider ?? "Kimi",
+      model: invocation.model,
+      timeoutMs: invocation.timeout_ms ?? null,
+      maxTokens: null,
+      maxStepsPerTurn: invocation.max_steps_per_turn ?? null,
+      temperature: null,
+    },
+    truncation: {
+      prompt: false,
+      source: false,
+      output: false,
+    },
+    providerIds: {
+      sessionId: execution?.kimiSessionId ?? null,
+    },
+    scope: {
+      name: invocation.scope,
+      base: invocation.scope_base ?? null,
+      paths: invocation.scope_paths ?? null,
+      reason: scopeResolutionReason(invocation),
+    },
+    result: execution?.parsed?.result ?? "",
+    status: execution?.exitCode === 0 && execution?.parsed?.ok === true ? "completed" : "failed",
+    errorCode: execution?.parsed?.reason ?? null,
+  });
 }
 
 // Mutation-detection git scrub: same shared list as claude-companion +
@@ -116,7 +212,7 @@ function cleanGitPromptEnv() {
 // GIT_CONFIG_GLOBAL — fold onto plugin lib's canonical scrub.
 
 function gitStatus(args, cwd) {
-  return execFileSync("git", ["-C", cwd, ...args], {
+  return execFileSync(GIT_BINARY, ["-C", cwd, ...args], {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
     env: cleanGitEnv(),
@@ -447,7 +543,7 @@ async function cmdRun(rest) {
   writeRuntimeOptionsSidecar(workspaceRoot, jobId, { max_steps_per_turn: maxStepsPerTurn });
   writeJobFile(workspaceRoot, jobId, queuedRecord);
   upsertJob(workspaceRoot, queuedRecord);
-  const targetPrompt = targetPromptFor(profile, prompt, invocation);
+  const targetPrompt = targetPromptFor(prompt, invocation);
 
   if (options.background) {
     try {
@@ -625,6 +721,7 @@ async function executeRun(invocation, prompt, { foreground }) {
   // marker BEFORE signaling so finalization can force status=cancelled
   // even when the target traps SIGTERM and exits 0 with valid output.
   const cancelMarker = consumeCancelMarker(workspaceRoot, jobId);
+  execution.reviewAuditManifest = reviewAuditManifest(executedInvocation, prompt, containment.path, execution);
 
   // signal + timedOut feed classifyExecution: a SIGTERM/SIGKILL exit without
   // timedOut is an operator cancel → status="cancelled" (#16 follow-up 2);
@@ -637,6 +734,7 @@ async function executeRun(invocation, prompt, { foreground }) {
     ...(cancelMarker ? { status: "cancelled" } : {}),
     signal: execution.signal ?? null,
     timedOut: execution.timedOut === true,
+    reviewAuditManifest: execution.reviewAuditManifest,
   }, mutations);
 
   // BLOCKER 2 fix: atomic-under-lock meta + state commit. See
@@ -751,6 +849,7 @@ async function cmdRunWorker(rest) {
   // call, side effects) and only the post-run consumer at executeRun would
   // convert "completed" → "cancelled".
   if (consumeCancelMarker(workspaceRoot, options.job)) {
+    try { consumePromptSidecar(resolveJobsDir(workspaceRoot), options.job); } catch { /* best-effort privacy cleanup */ }
     const cancelledRecord = buildJobRecord(invocationFromRecord(meta, runtimeOptions), {
       status: "cancelled",
       exitCode: null, parsed: null, pidInfo: null, kimiSessionId: null,
@@ -871,7 +970,7 @@ async function cmdContinue(rest) {
   writeRuntimeOptionsSidecar(workspaceRoot, newJobId_, { max_steps_per_turn: maxStepsPerTurn });
   writeJobFile(workspaceRoot, newJobId_, queuedRecord);
   upsertJob(workspaceRoot, queuedRecord);
-  const targetPrompt = targetPromptFor(priorProfile, prompt, invocation);
+  const targetPrompt = targetPromptFor(prompt, invocation);
 
   if (options.background) {
     try {

--- a/plugins/kimi/scripts/lib/external-review.mjs
+++ b/plugins/kimi/scripts/lib/external-review.mjs
@@ -38,6 +38,7 @@ const CONTENT_RECEIVED_ERROR_CODES = Object.freeze(new Set([
   "kimi_error",
   "parse_error",
   "step_limit_exceeded",
+  "usage_limited",
   "finalization_failed",
   "timeout",
 ]));

--- a/plugins/kimi/scripts/lib/job-record.mjs
+++ b/plugins/kimi/scripts/lib/job-record.mjs
@@ -25,29 +25,9 @@ import {
   buildExternalReview,
   sourceContentTransmissionForExecution,
 } from "./external-review.mjs";
+import path from "node:path";
 
 export const SCHEMA_VERSION = 10;
-
-function stringBytes(value) {
-  return Buffer.byteLength(String(value ?? ""), "utf8");
-}
-
-function buildReviewMetadata(invocation, execution = null, parsed = null) {
-  if (!invocation.review_prompt_contract_version) return null;
-  return Object.freeze({
-    prompt_contract_version: invocation.review_prompt_contract_version,
-    prompt_provider: invocation.review_prompt_provider ?? invocation.target,
-    scope: invocation.scope,
-    scope_base: invocation.scope_base ?? null,
-    scope_paths: invocation.scope_paths ?? null,
-    raw_output: execution ? Object.freeze({
-      stdout_bytes: stringBytes(execution.stdout),
-      stderr_bytes: stringBytes(execution.stderr),
-      parsed_ok: parsed?.ok ?? null,
-      result_chars: typeof parsed?.result === "string" ? parsed.result.length : null,
-    }) : null,
-  });
-}
 
 /**
  * Canonical JobRecord field list. Exported so tests can reference it and
@@ -94,6 +74,7 @@ export const EXPECTED_KEYS = Object.freeze([
   "suggested_action",
   "external_review",
   "disclosure_note",
+  "runtime_diagnostics",
 
   // Result
   "result",
@@ -108,6 +89,28 @@ export const EXPECTED_KEYS = Object.freeze([
 ]);
 
 const EXPECTED_KEYS_SET = new Set(EXPECTED_KEYS);
+
+function stringBytes(value) {
+  return Buffer.byteLength(String(value ?? ""), "utf8");
+}
+
+function buildReviewMetadata(invocation, execution = null, parsed = null) {
+  if (!invocation.review_prompt_contract_version) return null;
+  return Object.freeze({
+    prompt_contract_version: invocation.review_prompt_contract_version,
+    prompt_provider: invocation.review_prompt_provider ?? invocation.target,
+    scope: invocation.scope,
+    scope_base: invocation.scope_base ?? null,
+    scope_paths: invocation.scope_paths ?? null,
+    raw_output: execution ? Object.freeze({
+      stdout_bytes: stringBytes(execution.stdout),
+      stderr_bytes: stringBytes(execution.stderr),
+      parsed_ok: parsed?.ok ?? null,
+      result_chars: typeof parsed?.result === "string" ? parsed.result.length : null,
+    }) : null,
+    audit_manifest: execution?.reviewAuditManifest ?? null,
+  });
+}
 
 export function externalReviewForInvocation(invocation, execution = null) {
   const { status, error_code } = classifyExecution(execution);
@@ -145,6 +148,7 @@ export function externalReviewForInvocation(invocation, execution = null) {
  *                         routing on error_code doesn't conflate disk/lock failures
  *                         with missing-binary errors. PR #21 review HIGH 1.
  *   step_limit_exceeded — Kimi emitted its non-JSON max-step exhaustion sentinel.
+ *   usage_limited  — Kimi emitted a non-JSON quota/usage-limit failure.
  *   parse_error     — parsed.ok === false with reason starting "json_parse"/"empty_stdout".
  *   timeout         — execution.timedOut === true (companion's wall-clock kill).
  *   kimi_error    — exitCode !== 0 with parseable JSON from Kimi.
@@ -237,6 +241,13 @@ function classifyExecution(execution) {
         error_message: parsed.error ?? reason,
       };
     }
+    if (reason === "usage_limited") {
+      return {
+        status: "failed",
+        error_code: "usage_limited",
+        error_message: parsed.error ?? reason,
+      };
+    }
     if (reason === "json_parse_error" || reason === "empty_stdout") {
       return {
         status: "failed",
@@ -301,6 +312,18 @@ function buildErrorDiagnostic(invocation, status, error_code, error_message) {
         "the requested stream-json payload. The companion recognized the sentinel and preserved it as a provider resource-limit diagnostic.",
       suggested_action:
         "Retry with a higher step budget using --max-steps-per-turn <n>, or rerun with a narrower scope.",
+      disclosure_note: null,
+    };
+  }
+  if (status === "failed" && error_code === "usage_limited") {
+    return {
+      error_summary: `${target.displayName} Code CLI reported a subscription usage limit before returning a review result.`,
+      error_cause:
+        `${target.displayName} emitted a plain-text quota or billing-cycle failure instead of ` +
+        "the requested stream-json payload. The companion recognized it as an account usage limit, not a JSON parse failure.",
+      suggested_action:
+        `Wait for ${target.displayName} quota to recover, reduce reviewer concurrency, or run ` +
+        `\`${target.binaryName}\` interactively to inspect account usage. Track tier or credit changes separately from this review run.`,
       disclosure_note: null,
     };
   }
@@ -459,6 +482,63 @@ function assertInvocation(invocation) {
   }
 }
 
+function targetFromDenial(denial) {
+  if (typeof denial === "string") return denial;
+  if (!denial || typeof denial !== "object") return null;
+  return denial.target ?? denial.path ?? denial.file_path ?? denial.file ?? null;
+}
+
+function toolFromDenial(denial) {
+  if (!denial || typeof denial !== "object") return null;
+  return denial.tool ?? denial.name ?? null;
+}
+
+function pathInside(base, target) {
+  if (!base || !target || !path.isAbsolute(target)) {
+    return { inside: null, relative: null };
+  }
+  const relative = path.relative(base, target);
+  const inside = relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+  return {
+    inside,
+    relative: inside ? (relative || ".") : null,
+  };
+}
+
+function normalizeRuntimeDiagnostics(input, denials) {
+  if (!input || typeof input !== "object") return null;
+
+  const addDir = typeof input.add_dir === "string" ? input.add_dir : null;
+  const childCwd = typeof input.child_cwd === "string" ? input.child_cwd : null;
+  const scopePathMappings = Array.isArray(input.scope_path_mappings)
+    ? input.scope_path_mappings.map((mapping) => ({
+      original: typeof mapping?.original === "string" ? mapping.original : null,
+      contained: typeof mapping?.contained === "string" ? mapping.contained : null,
+      relative: typeof mapping?.relative === "string" ? mapping.relative : null,
+      inside_add_dir: mapping?.inside_add_dir === true,
+    }))
+    : [];
+  const permissionDenials = Array.isArray(denials)
+    ? denials.map((denial) => {
+      const target = targetFromDenial(denial);
+      const { inside, relative } = pathInside(addDir, target);
+      return {
+        tool: toolFromDenial(denial),
+        target,
+        inside_add_dir: inside,
+        relative_to_add_dir: relative,
+      };
+    })
+    : [];
+
+  return {
+    add_dir: addDir,
+    child_cwd: childCwd,
+    scope_path_mappings: scopePathMappings,
+    permission_denials: permissionDenials,
+  };
+}
+
 /**
  * Build the single canonical JobRecord.
  *
@@ -492,6 +572,11 @@ export function buildJobRecord(invocation, execution, mutations) {
   const diagnostic = buildErrorDiagnostic(invocation, status, error_code, error_message);
 
   const parsed = execution?.parsed ?? null;
+  const permissionDenials = Array.isArray(parsed?.denials) ? parsed.denials : [];
+  const runtimeDiagnostics = normalizeRuntimeDiagnostics(
+    execution?.runtimeDiagnostics ?? null,
+    permissionDenials,
+  );
   const record = {
     // Identity
     id: invocation.job_id,
@@ -534,11 +619,12 @@ export function buildJobRecord(invocation, execution, mutations) {
     suggested_action: diagnostic.suggested_action,
     external_review: externalReviewForInvocation(invocation, execution),
     disclosure_note: diagnostic.disclosure_note,
+    runtime_diagnostics: runtimeDiagnostics,
 
     // Result
     result: parsed?.result ?? null,
     structured_output: parsed?.structured ?? null,
-    permission_denials: Array.isArray(parsed?.denials) ? parsed.denials : [],
+    permission_denials: permissionDenials,
     mutations: [...mutations],
     cost_usd: parsed?.costUsd ?? null,
     usage: parsed?.usage ?? null,

--- a/plugins/kimi/scripts/lib/kimi.mjs
+++ b/plugins/kimi/scripts/lib/kimi.mjs
@@ -68,6 +68,7 @@ function parseResumeSessionId(text) {
 }
 
 const STEP_LIMIT_RE = /^Max number of steps reached:\s*(\d+)\s*$/;
+const USAGE_LIMIT_RE = /(?:Error code:\s*403|usage limit|quota|billing cycle)/i;
 
 function parseJsonLineSessionId(text) {
   for (const line of String(text ?? "").split("\n").reverse()) {
@@ -92,6 +93,13 @@ function findStepLimitLine(stdout) {
   return null;
 }
 
+function usageLimitMessage(stdout, stderr) {
+  const combined = `${stdout ?? ""}\n${stderr ?? ""}`;
+  if (!USAGE_LIMIT_RE.test(combined)) return null;
+  const trimmed = combined.trim();
+  return trimmed.length > 4000 ? `${trimmed.slice(0, 4000)}...` : trimmed;
+}
+
 function stepLimitResult(match, stdout, stderr) {
   const error = match[0].trim();
   return {
@@ -110,6 +118,16 @@ function stepLimitResult(match, stdout, stderr) {
 export function parseKimiResult(stdout, stderr = "", options = {}) {
   const trimmed = stdout.trim();
   if (!trimmed) {
+    const usageLimited = usageLimitMessage("", stderr);
+    if (usageLimited) {
+      return {
+        ok: false,
+        reason: "usage_limited",
+        error: usageLimited,
+        raw: stdout,
+        sessionId: parseResumeSessionId(stderr) ?? parseJsonLineSessionId(stderr),
+      };
+    }
     const stderrSummary = summarizeStderr(stderr);
     if (stderrSummary) {
       return { ok: false, reason: "kimi_stderr", error: stderrSummary, raw: stdout };
@@ -136,6 +154,19 @@ export function parseKimiResult(stdout, stderr = "", options = {}) {
     try {
       parsed = JSON.parse(trimmed.split("\n").filter((line) => line.trim().startsWith("{")).pop());
     } catch {
+      const usageLimited = usageLimitMessage(stdout, stderr);
+      if (usageLimited) {
+        return {
+          ok: false,
+          reason: "usage_limited",
+          error: usageLimited,
+          raw: stdout,
+          sessionId:
+            parseResumeSessionId(`${stdout}\n${stderr}`) ??
+            parseJsonLineSessionId(stdout) ??
+            parseJsonLineSessionId(stderr),
+        };
+      }
       return { ok: false, reason: "json_parse_error", error: e.message, raw: stdout };
     }
   }

--- a/plugins/kimi/scripts/lib/review-prompt.mjs
+++ b/plugins/kimi/scripts/lib/review-prompt.mjs
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 export const REVIEW_PROMPT_CHECKLIST = Object.freeze([
   "Verify exact base/head refs and commits before judging the diff.",
   "Review only the declared scope and list any scope gaps as NOT REVIEWED.",
@@ -8,6 +10,235 @@ export const REVIEW_PROMPT_CHECKLIST = Object.freeze([
 ]);
 
 export const REVIEW_PROMPT_CONTRACT_VERSION = 1;
+export const REVIEW_AUDIT_MANIFEST_VERSION = 1;
+
+function contentBuffer(file) {
+  if (Buffer.isBuffer(file?.content)) return file.content;
+  if (file?.content instanceof Uint8Array) return Buffer.from(file.content);
+  return Buffer.from(String(file?.text ?? ""), "utf8");
+}
+
+function sha256(value) {
+  const input = Buffer.isBuffer(value) || value instanceof Uint8Array
+    ? value
+    : String(value ?? "");
+  return createHash("sha256").update(input).digest("hex");
+}
+
+function hashObject(value) {
+  return Object.freeze({
+    algorithm: "sha256",
+    value: sha256(value),
+  });
+}
+
+function lineCount(text) {
+  const value = String(text ?? "");
+  if (value.length === 0) return 0;
+  const normalized = value.endsWith("\n") ? value.slice(0, -1) : value;
+  if (normalized.length === 0) return 0;
+  let lines = 1;
+  for (let index = 0; index < normalized.length; index += 1) {
+    if (normalized[index] === "\n") {
+      lines += 1;
+    } else if (normalized[index] === "\r") {
+      lines += 1;
+      if (normalized[index + 1] === "\n") index += 1;
+    }
+  }
+  return lines;
+}
+
+function sourceManifest(sourceFiles = []) {
+  const files = Array.isArray(sourceFiles) ? sourceFiles : [];
+  const entries = files.map((file) => {
+    const content = contentBuffer(file);
+    const text = typeof file?.text === "string" ? file.text : content.toString("utf8");
+    return Object.freeze({
+      path: String(file?.path ?? "unknown"),
+      bytes: content.length,
+      lines: lineCount(text),
+      content_hash: hashObject(content),
+    });
+  });
+  return Object.freeze({
+    files: Object.freeze(entries),
+    totals: Object.freeze({
+      files: entries.length,
+      bytes: entries.reduce((sum, file) => sum + file.bytes, 0),
+      lines: entries.reduce((sum, file) => sum + file.lines, 0),
+    }),
+  });
+}
+
+function isWordBoundary(char) {
+  if (!char) return true;
+  const code = char.charCodeAt(0);
+  return !(
+    (code >= 48 && code <= 57)
+    || (code >= 65 && code <= 90)
+    || (code >= 97 && code <= 122)
+    || char === "_"
+    || char === "-"
+  );
+}
+
+function startsWithToken(line, token) {
+  return line.startsWith(token) && isWordBoundary(line[token.length]);
+}
+
+function startsWithLabel(line, label) {
+  if (!line.startsWith(label)) return false;
+  return line.slice(label.length).trimStart().startsWith(":");
+}
+
+function reviewLines(text) {
+  return String(text ?? "").split("\n").map((line) => (
+    line.endsWith("\r") ? line.slice(0, -1) : line
+  ).trimStart());
+}
+
+function hasVerdict(text) {
+  return reviewLines(text).some((rawLine) => {
+    const line = rawLine.toLowerCase();
+    return startsWithLabel(line, "verdict")
+      || startsWithLabel(line, "summary")
+      || startsWithToken(line, "approve")
+      || startsWithToken(line, "approved")
+      || startsWithToken(line, "request changes")
+      || startsWithToken(line, "reject")
+      || startsWithToken(line, "rejected");
+  });
+}
+
+function checklistText(line) {
+  const trimmed = line.trimStart();
+  if (trimmed.startsWith("-") || trimmed.startsWith("*")) return trimmed.slice(1).trimStart();
+  let index = 0;
+  while (index < trimmed.length) {
+    const code = trimmed.charCodeAt(index);
+    if (code < 48 || code > 57) break;
+    index += 1;
+  }
+  if (index === 0 || (trimmed[index] !== "." && trimmed[index] !== ")")) return null;
+  return trimmed.slice(index + 1).trimStart();
+}
+
+function isChecklistVerdict(line) {
+  const text = checklistText(line);
+  if (!text) return false;
+  const lower = text.toLowerCase();
+  return startsWithToken(lower, "pass")
+    || startsWithToken(lower, "fail")
+    || startsWithToken(lower, "not reviewed");
+}
+
+function includesAny(text, phrases) {
+  return phrases.some((phrase) => text.includes(phrase));
+}
+
+function qualityFlags({ result = "", status = null, errorCode = null } = {}) {
+  const text = String(result ?? "");
+  const lowerText = text.toLowerCase();
+  const checklistItemsSeen = reviewLines(text).filter((line) => isChecklistVerdict(line)).length;
+  return Object.freeze({
+    has_verdict: hasVerdict(text),
+    has_blocking_section: includesAny(lowerText, [
+      "blocking finding",
+      "blocking findings",
+      "blocker",
+      "blockers",
+    ]),
+    has_non_blocking_section: includesAny(lowerText, [
+      "non-blocking",
+      "non blocking",
+      "minor concern",
+      "minor concerns",
+      "residual risk",
+      "residual risks",
+    ]),
+    checklist_items_seen: checklistItemsSeen,
+    looks_shallow: text.trim().length > 0 && text.trim().length < 500,
+    failed_review_slot: status !== "completed" || errorCode !== null,
+  });
+}
+
+export function scopeResolutionReason(scopeInfo = {}) {
+  const paths = scopeInfo.scope_paths ?? scopeInfo.paths;
+  if (scopeInfo.scope === "branch-diff" || scopeInfo.name === "branch-diff") {
+    const base = scopeInfo.scope_base ?? scopeInfo.base ?? "main";
+    if (Array.isArray(paths) && paths.length > 0) {
+      return `git diff -z --name-only ${base}...HEAD -- filtered by explicit --scope-paths`;
+    }
+    return `git diff -z --name-only ${base}...HEAD --`;
+  }
+  if (Array.isArray(paths) && paths.length > 0) {
+    return "explicit --scope-paths";
+  }
+  return scopeInfo.scope ?? scopeInfo.name ?? null;
+}
+
+export function buildReviewAuditManifest({
+  prompt = "",
+  sourceFiles = [],
+  git = {},
+  promptBuilder = {},
+  request = {},
+  truncation = {},
+  providerIds = {},
+  scope = {},
+  result = "",
+  status = null,
+  errorCode = null,
+} = {}) {
+  return Object.freeze({
+    schema_version: REVIEW_AUDIT_MANIFEST_VERSION,
+    rendered_prompt_hash: hashObject(prompt),
+    selected_source: sourceManifest(sourceFiles),
+    git_identity: Object.freeze({
+      remote: git.remote ?? null,
+      branch: git.branch ?? null,
+      base_ref: git.baseRef ?? null,
+      base_sha: git.baseCommit ?? null,
+      head_ref: git.headRef ?? null,
+      head_sha: git.headCommit ?? null,
+      diff_stat: git.diffStat ?? null,
+    }),
+    prompt_builder: Object.freeze({
+      contract_version: promptBuilder.contractVersion ?? null,
+      plugin_version: promptBuilder.pluginVersion ?? null,
+      plugin_commit: promptBuilder.pluginCommit ?? null,
+    }),
+    request: Object.freeze({
+      provider: request.provider ?? null,
+      model: request.model ?? null,
+      timeout_ms: request.timeoutMs ?? null,
+      max_tokens: request.maxTokens ?? null,
+      max_steps_per_turn: request.maxStepsPerTurn ?? null,
+      temperature: request.temperature ?? null,
+      stream: request.stream ?? null,
+    }),
+    truncation: Object.freeze({
+      prompt: truncation.prompt ?? null,
+      prompt_at_chars: truncation.promptAtChars ?? null,
+      source: truncation.source ?? null,
+      source_at_bytes: truncation.sourceAtBytes ?? null,
+      output: truncation.output ?? null,
+      output_at_chars: truncation.outputAtChars ?? null,
+    }),
+    provider_ids: Object.freeze({
+      request_id: providerIds.requestId ?? null,
+      session_id: providerIds.sessionId ?? null,
+    }),
+    scope_resolution: Object.freeze({
+      scope: scope.name ?? null,
+      scope_base: scope.base ?? null,
+      scope_paths: Array.isArray(scope.paths) ? Object.freeze([...scope.paths]) : null,
+      reason: scope.reason ?? null,
+    }),
+    review_quality: qualityFlags({ result, status, errorCode }),
+  });
+}
 
 function line(name, value) {
   return `${name}: ${value ?? "unknown"}`;

--- a/plugins/kimi/scripts/lib/scope.mjs
+++ b/plugins/kimi/scripts/lib/scope.mjs
@@ -714,7 +714,7 @@ function scopeStaged(sourceCwd, targetPath) {
   }
 }
 
-function scopeBranchDiff(sourceCwd, targetPath, scopeBase) {
+function scopeBranchDiff(sourceCwd, targetPath, scopeBase, scopePaths = []) {
   assertGitWorktree(sourceCwd);
   const ctx = gitScopeContext(sourceCwd);
   assertGitHead(ctx, sourceCwd);
@@ -735,7 +735,7 @@ function scopeBranchDiff(sourceCwd, targetPath, scopeBase) {
   }
   prepareGitSnapshotTarget(sourceCwd, targetPath);
   const raw = git(ctx.gitRoot, ["diff", "--name-only", "-z", `${mergeBase}..HEAD`]);
-  const files = [];
+  let files = [];
   for (const gitRel of raw.split("\0").filter(Boolean)) {
     const snapshotRel = toSnapshotRel(ctx, gitRel);
     if (!snapshotRel) continue;
@@ -744,8 +744,14 @@ function scopeBranchDiff(sourceCwd, targetPath, scopeBase) {
     }
     files.push({ gitRel, snapshotRel });
   }
+  if (Array.isArray(scopePaths) && scopePaths.length > 0) {
+    files = files.filter(({ snapshotRel }) => scopePaths.some((g) => matchGlob(snapshotRel, g)));
+  }
   if (files.length === 0) {
-    scopeEmpty(`branch-diff selected no files under ${sourceCwd} against base ${JSON.stringify(base)}`);
+    const qualifier = Array.isArray(scopePaths) && scopePaths.length > 0
+      ? ` matching --scope-paths ${scopePaths.join(",")}`
+      : "";
+    scopeEmpty(`branch-diff selected no files${qualifier} under ${sourceCwd} against base ${JSON.stringify(base)}`);
   }
   const materializations = [];
   const entriesByRel = entryMap(scopedGitEntries(ctx, headEntries(ctx.gitRoot)));
@@ -878,7 +884,7 @@ export function populateScope(profile, sourceCwd, targetPath, runtimeInputs = {}
   switch (profile.scope) {
     case "working-tree": scopeWorkingTree(sourceCwd, targetPath); break;
     case "staged":       scopeStaged(sourceCwd, targetPath); break;
-    case "branch-diff":  scopeBranchDiff(sourceCwd, targetPath, runtimeInputs.scopeBase); break;
+    case "branch-diff":  scopeBranchDiff(sourceCwd, targetPath, runtimeInputs.scopeBase, runtimeInputs.scopePaths); break;
     case "head":         scopeHead(sourceCwd, targetPath, containmentHandle); break;
     case "custom":       scopeCustom(sourceCwd, targetPath, runtimeInputs.scopePaths); break;
     default:

--- a/scripts/codex-plugin-cache-doctor.mjs
+++ b/scripts/codex-plugin-cache-doctor.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { homedir } from "node:os";
+
+const MARKETPLACE = "codex-plugin-multi";
+const DEFAULT_PLUGINS = ["api-reviewers", "claude", "gemini", "grok", "kimi"];
+
+function parseArgs(argv) {
+  const out = Object.create(null);
+  out.plugins = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === "--plugin") {
+      const value = argv[++i];
+      if (!value || value.startsWith("--")) throw new Error("--plugin requires a value");
+      out.plugins.push(value);
+    } else if (token.startsWith("--")) {
+      const key = token.slice(2);
+      const value = argv[++i];
+      if (!key || key === "__proto__" || key === "prototype" || key === "constructor") {
+        throw new Error(`unsupported option ${token}`);
+      }
+      if (!value || value.startsWith("--")) throw new Error(`${token} requires a value`);
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+function listSkills(root, plugin) {
+  const dir = join(root, plugin, "skills");
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && existsSync(join(dir, entry.name, "SKILL.md")))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+function enabledInConfig(home, plugin) {
+  const config = join(home, "config.toml");
+  if (!existsSync(config)) return false;
+  const text = readFileSync(config, "utf8");
+  const escaped = `${plugin}@${MARKETPLACE}`.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = new RegExp(`\\[plugins\\."${escaped}"\\]([\\s\\S]*?)(?:\\n\\[|$)`).exec(text);
+  return match ? /\benabled\s*=\s*true\b/.test(match[1]) : false;
+}
+
+function profileReport(name, home, plugins, sourceRoot) {
+  const pluginReports = {};
+  let ok = true;
+  for (const plugin of plugins) {
+    const expected = listSkills(sourceRoot, plugin);
+    const cacheRoot = join(home, "plugins", "cache", MARKETPLACE, plugin, "0.1.0");
+    const cached = listSkills(cacheRoot, ".");
+    const missing = expected.filter((skill) => !cached.includes(skill));
+    const extra = cached.filter((skill) => !expected.includes(skill));
+    const inSync = missing.length === 0 && extra.length === 0 && expected.length > 0;
+    const enabled = enabledInConfig(home, plugin);
+    if (!inSync || !enabled) ok = false;
+    pluginReports[plugin] = {
+      enabled,
+      cache_path: cacheRoot,
+      cache_in_sync: inSync,
+      expected_skills: expected,
+      cached_skills: cached,
+      missing_skills: missing,
+      extra_skills: extra,
+    };
+  }
+  return {
+    name,
+    home,
+    enabled: plugins.length === 1 ? pluginReports[plugins[0]].enabled : undefined,
+    cache_in_sync: plugins.length === 1 ? pluginReports[plugins[0]].cache_in_sync : undefined,
+    missing_skills: plugins.length === 1 ? pluginReports[plugins[0]].missing_skills : undefined,
+    plugins: pluginReports,
+    ok,
+  };
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const repo = resolve(args.repo ?? process.cwd());
+  const primaryHome = resolve(args["codex-home"] ?? process.env.CODEX_HOME ?? join(homedir(), ".codex"));
+  const secondHome = args["second-codex-home"] ? resolve(args["second-codex-home"]) : null;
+  const plugins = args.plugins.length > 0 ? args.plugins : DEFAULT_PLUGINS;
+  const repoPlugins = join(repo, "plugins");
+  const marketplaceRoot = join(primaryHome, ".tmp", "marketplaces", MARKETPLACE);
+  const marketplacePlugins = join(marketplaceRoot, "plugins");
+  const sourceRoot = existsSync(marketplacePlugins) ? marketplacePlugins : repoPlugins;
+
+  const profiles = {
+    primary: profileReport("primary", primaryHome, plugins, sourceRoot),
+  };
+  if (secondHome) profiles.second = profileReport("second", secondHome, plugins, sourceRoot);
+
+  const ok = Object.values(profiles).every((profile) => profile.ok);
+  const nextActions = [];
+  if (!existsSync(marketplaceRoot)) {
+    nextActions.push("Add the marketplace with `codex plugin marketplace add seungpyoson/codex-plugin-multi`.");
+  } else {
+    nextActions.push("Refresh Git marketplace installs with `codex plugin marketplace upgrade codex-plugin-multi`.");
+  }
+  nextActions.push("If upgrade reports `not configured as a Git marketplace`, remove and re-add the marketplace from GitHub.");
+  nextActions.push("Enable missing plugins in `/plugins` or config.toml for the Codex profile that will run reviews.");
+  nextActions.push("Restart already-open Codex TUI sessions; skill picker inventory is loaded in memory.");
+  nextActions.push("Verify with `codex debug prompt-input 'list skills'` from the target CODEX_HOME.");
+
+  process.stdout.write(`${JSON.stringify({
+    ok,
+    repo,
+    marketplace: {
+      name: MARKETPLACE,
+      root: marketplaceRoot,
+      present: existsSync(marketplaceRoot),
+      source_root: sourceRoot,
+    },
+    profiles,
+    next_actions: nextActions,
+  }, null, 2)}\n`);
+}
+
+main();

--- a/scripts/lib/external-review.mjs
+++ b/scripts/lib/external-review.mjs
@@ -38,6 +38,7 @@ const CONTENT_RECEIVED_ERROR_CODES = Object.freeze(new Set([
   "kimi_error",
   "parse_error",
   "step_limit_exceeded",
+  "usage_limited",
   "finalization_failed",
   "timeout",
 ]));

--- a/scripts/lib/review-prompt.mjs
+++ b/scripts/lib/review-prompt.mjs
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 export const REVIEW_PROMPT_CHECKLIST = Object.freeze([
   "Verify exact base/head refs and commits before judging the diff.",
   "Review only the declared scope and list any scope gaps as NOT REVIEWED.",
@@ -8,6 +10,235 @@ export const REVIEW_PROMPT_CHECKLIST = Object.freeze([
 ]);
 
 export const REVIEW_PROMPT_CONTRACT_VERSION = 1;
+export const REVIEW_AUDIT_MANIFEST_VERSION = 1;
+
+function contentBuffer(file) {
+  if (Buffer.isBuffer(file?.content)) return file.content;
+  if (file?.content instanceof Uint8Array) return Buffer.from(file.content);
+  return Buffer.from(String(file?.text ?? ""), "utf8");
+}
+
+function sha256(value) {
+  const input = Buffer.isBuffer(value) || value instanceof Uint8Array
+    ? value
+    : String(value ?? "");
+  return createHash("sha256").update(input).digest("hex");
+}
+
+function hashObject(value) {
+  return Object.freeze({
+    algorithm: "sha256",
+    value: sha256(value),
+  });
+}
+
+function lineCount(text) {
+  const value = String(text ?? "");
+  if (value.length === 0) return 0;
+  const normalized = value.endsWith("\n") ? value.slice(0, -1) : value;
+  if (normalized.length === 0) return 0;
+  let lines = 1;
+  for (let index = 0; index < normalized.length; index += 1) {
+    if (normalized[index] === "\n") {
+      lines += 1;
+    } else if (normalized[index] === "\r") {
+      lines += 1;
+      if (normalized[index + 1] === "\n") index += 1;
+    }
+  }
+  return lines;
+}
+
+function sourceManifest(sourceFiles = []) {
+  const files = Array.isArray(sourceFiles) ? sourceFiles : [];
+  const entries = files.map((file) => {
+    const content = contentBuffer(file);
+    const text = typeof file?.text === "string" ? file.text : content.toString("utf8");
+    return Object.freeze({
+      path: String(file?.path ?? "unknown"),
+      bytes: content.length,
+      lines: lineCount(text),
+      content_hash: hashObject(content),
+    });
+  });
+  return Object.freeze({
+    files: Object.freeze(entries),
+    totals: Object.freeze({
+      files: entries.length,
+      bytes: entries.reduce((sum, file) => sum + file.bytes, 0),
+      lines: entries.reduce((sum, file) => sum + file.lines, 0),
+    }),
+  });
+}
+
+function isWordBoundary(char) {
+  if (!char) return true;
+  const code = char.charCodeAt(0);
+  return !(
+    (code >= 48 && code <= 57)
+    || (code >= 65 && code <= 90)
+    || (code >= 97 && code <= 122)
+    || char === "_"
+    || char === "-"
+  );
+}
+
+function startsWithToken(line, token) {
+  return line.startsWith(token) && isWordBoundary(line[token.length]);
+}
+
+function startsWithLabel(line, label) {
+  if (!line.startsWith(label)) return false;
+  return line.slice(label.length).trimStart().startsWith(":");
+}
+
+function reviewLines(text) {
+  return String(text ?? "").split("\n").map((line) => (
+    line.endsWith("\r") ? line.slice(0, -1) : line
+  ).trimStart());
+}
+
+function hasVerdict(text) {
+  return reviewLines(text).some((rawLine) => {
+    const line = rawLine.toLowerCase();
+    return startsWithLabel(line, "verdict")
+      || startsWithLabel(line, "summary")
+      || startsWithToken(line, "approve")
+      || startsWithToken(line, "approved")
+      || startsWithToken(line, "request changes")
+      || startsWithToken(line, "reject")
+      || startsWithToken(line, "rejected");
+  });
+}
+
+function checklistText(line) {
+  const trimmed = line.trimStart();
+  if (trimmed.startsWith("-") || trimmed.startsWith("*")) return trimmed.slice(1).trimStart();
+  let index = 0;
+  while (index < trimmed.length) {
+    const code = trimmed.charCodeAt(index);
+    if (code < 48 || code > 57) break;
+    index += 1;
+  }
+  if (index === 0 || (trimmed[index] !== "." && trimmed[index] !== ")")) return null;
+  return trimmed.slice(index + 1).trimStart();
+}
+
+function isChecklistVerdict(line) {
+  const text = checklistText(line);
+  if (!text) return false;
+  const lower = text.toLowerCase();
+  return startsWithToken(lower, "pass")
+    || startsWithToken(lower, "fail")
+    || startsWithToken(lower, "not reviewed");
+}
+
+function includesAny(text, phrases) {
+  return phrases.some((phrase) => text.includes(phrase));
+}
+
+function qualityFlags({ result = "", status = null, errorCode = null } = {}) {
+  const text = String(result ?? "");
+  const lowerText = text.toLowerCase();
+  const checklistItemsSeen = reviewLines(text).filter((line) => isChecklistVerdict(line)).length;
+  return Object.freeze({
+    has_verdict: hasVerdict(text),
+    has_blocking_section: includesAny(lowerText, [
+      "blocking finding",
+      "blocking findings",
+      "blocker",
+      "blockers",
+    ]),
+    has_non_blocking_section: includesAny(lowerText, [
+      "non-blocking",
+      "non blocking",
+      "minor concern",
+      "minor concerns",
+      "residual risk",
+      "residual risks",
+    ]),
+    checklist_items_seen: checklistItemsSeen,
+    looks_shallow: text.trim().length > 0 && text.trim().length < 500,
+    failed_review_slot: status !== "completed" || errorCode !== null,
+  });
+}
+
+export function scopeResolutionReason(scopeInfo = {}) {
+  const paths = scopeInfo.scope_paths ?? scopeInfo.paths;
+  if (scopeInfo.scope === "branch-diff" || scopeInfo.name === "branch-diff") {
+    const base = scopeInfo.scope_base ?? scopeInfo.base ?? "main";
+    if (Array.isArray(paths) && paths.length > 0) {
+      return `git diff -z --name-only ${base}...HEAD -- filtered by explicit --scope-paths`;
+    }
+    return `git diff -z --name-only ${base}...HEAD --`;
+  }
+  if (Array.isArray(paths) && paths.length > 0) {
+    return "explicit --scope-paths";
+  }
+  return scopeInfo.scope ?? scopeInfo.name ?? null;
+}
+
+export function buildReviewAuditManifest({
+  prompt = "",
+  sourceFiles = [],
+  git = {},
+  promptBuilder = {},
+  request = {},
+  truncation = {},
+  providerIds = {},
+  scope = {},
+  result = "",
+  status = null,
+  errorCode = null,
+} = {}) {
+  return Object.freeze({
+    schema_version: REVIEW_AUDIT_MANIFEST_VERSION,
+    rendered_prompt_hash: hashObject(prompt),
+    selected_source: sourceManifest(sourceFiles),
+    git_identity: Object.freeze({
+      remote: git.remote ?? null,
+      branch: git.branch ?? null,
+      base_ref: git.baseRef ?? null,
+      base_sha: git.baseCommit ?? null,
+      head_ref: git.headRef ?? null,
+      head_sha: git.headCommit ?? null,
+      diff_stat: git.diffStat ?? null,
+    }),
+    prompt_builder: Object.freeze({
+      contract_version: promptBuilder.contractVersion ?? null,
+      plugin_version: promptBuilder.pluginVersion ?? null,
+      plugin_commit: promptBuilder.pluginCommit ?? null,
+    }),
+    request: Object.freeze({
+      provider: request.provider ?? null,
+      model: request.model ?? null,
+      timeout_ms: request.timeoutMs ?? null,
+      max_tokens: request.maxTokens ?? null,
+      max_steps_per_turn: request.maxStepsPerTurn ?? null,
+      temperature: request.temperature ?? null,
+      stream: request.stream ?? null,
+    }),
+    truncation: Object.freeze({
+      prompt: truncation.prompt ?? null,
+      prompt_at_chars: truncation.promptAtChars ?? null,
+      source: truncation.source ?? null,
+      source_at_bytes: truncation.sourceAtBytes ?? null,
+      output: truncation.output ?? null,
+      output_at_chars: truncation.outputAtChars ?? null,
+    }),
+    provider_ids: Object.freeze({
+      request_id: providerIds.requestId ?? null,
+      session_id: providerIds.sessionId ?? null,
+    }),
+    scope_resolution: Object.freeze({
+      scope: scope.name ?? null,
+      scope_base: scope.base ?? null,
+      scope_paths: Array.isArray(scope.paths) ? Object.freeze([...scope.paths]) : null,
+      reason: scope.reason ?? null,
+    }),
+    review_quality: qualityFlags({ result, status, errorCode }),
+  });
+}
 
 function line(name, value) {
   return `${name}: ${value ?? "unknown"}`;

--- a/tests/smoke/api-reviewers.smoke.test.mjs
+++ b/tests/smoke/api-reviewers.smoke.test.mjs
@@ -45,6 +45,7 @@ const API_REVIEWER_EXPECTED_KEYS = Object.freeze([
   "suggested_action",
   "external_review",
   "disclosure_note",
+  "runtime_diagnostics",
   "result",
   "structured_output",
   "permission_denials",
@@ -184,6 +185,18 @@ test("doctor reports DeepSeek API-key readiness by key name only", async () => {
   assert.equal(parsed.ready, true);
   assert.equal(parsed.credential_ref, "DEEPSEEK_API_KEY");
   assert.equal(parsed.auth_mode, "api_key");
+  assert.doesNotMatch(result.stdout, /secret-test-value/);
+});
+
+test("rejects prototype-shaped option keys", async () => {
+  const result = await run(["doctor", "--__proto__", "polluted"], {
+    env: { DEEPSEEK_API_KEY: "secret-test-value" },
+  });
+  const parsed = parseJson(result.stdout);
+
+  assert.equal(result.status, 1);
+  assert.equal(parsed.ok, false);
+  assert.match(parsed.error, /unsupported option --__proto__/);
   assert.doesNotMatch(result.stdout, /secret-test-value/);
 });
 
@@ -1171,6 +1184,29 @@ test("DeepSeek direct API custom-review completes and persists JobRecord", async
   assert.equal(record.model, "deepseek-v4-pro");
   assert.equal(record.credential_ref, "DEEPSEEK_API_KEY");
   assert.equal(record.schema_version, 10);
+  assert.equal(record.review_metadata.prompt_contract_version, 1);
+  assert.equal(record.review_metadata.prompt_provider, "DeepSeek");
+  assert.equal(record.review_metadata.raw_output.http_status, 200);
+  assert.match(record.review_metadata.audit_manifest.rendered_prompt_hash.value, /^[a-f0-9]{64}$/);
+  assert.deepEqual(record.review_metadata.audit_manifest.selected_source.files.map((file) => ({
+    path: file.path,
+    bytes: file.bytes,
+    hashOk: /^[a-f0-9]{64}$/.test(file.content_hash.value),
+  })), [
+    { path: "seed.txt", bytes: "hello from selected scope\n".length, hashOk: true },
+  ]);
+  assert.equal(record.review_metadata.audit_manifest.request.model, "deepseek-v4-pro");
+  assert.equal(record.review_metadata.audit_manifest.request.max_tokens, 65536);
+  assert.equal(record.review_metadata.audit_manifest.request.temperature, 0);
+  assert.match(record.review_metadata.audit_manifest.prompt_builder.plugin_commit, /^[a-f0-9]{40}$/);
+  assert.notEqual(
+    record.review_metadata.audit_manifest.prompt_builder.plugin_commit,
+    record.review_metadata.audit_manifest.git_identity.head_sha,
+    "plugin_commit must identify the plugin source, not the reviewed repository head"
+  );
+  assert.equal(record.review_metadata.audit_manifest.provider_ids.session_id, "chatcmpl-test");
+  assert.equal(JSON.stringify(record.review_metadata.audit_manifest).includes("Check this file"), false);
+  assert.equal(JSON.stringify(record.review_metadata.audit_manifest).includes("hello from selected scope"), false);
   assert.equal(record.kimi_session_id, null);
   assert.deepEqual(record.external_review, {
     marker: "EXTERNAL REVIEW",
@@ -1332,6 +1368,63 @@ test("direct API reviewers redact configured non-API_KEY credential names", asyn
   assert.doesNotMatch(result.stdout, /token-token-value/);
 });
 
+test("direct API reviewers redact realistic short configured credentials without redacting one-byte collisions", async () => {
+  const cwd = makeWorkspace();
+  const pluginRoot = makeInstalledApiReviewersRoot();
+  writeFileSync(path.join(pluginRoot, "config", "providers.json"), JSON.stringify({
+    deepseek: {
+      display_name: "DeepSeek",
+      auth_mode: "api_key",
+      env_keys: ["DEEPSEEK_CREDENTIAL"],
+      base_url: "https://api.deepseek.com",
+      model: "deepseek-v4-flash",
+    },
+  }, null, 2));
+  const result = await run([
+    "run",
+    "--provider", "deepseek",
+    "--mode", "custom-review",
+    "--scope", "custom",
+    "--scope-paths", "seed.txt",
+    "--foreground",
+    "--prompt", "Check this file.",
+  ], {
+    cwd,
+    companion: path.join(pluginRoot, "scripts", "api-reviewer.mjs"),
+    env: {
+      API_REVIEWERS_MOCK_RESPONSE: mockResponse("deepseek-v4-flash", "chatcmpl-test", "a normal alphabet payload"),
+      DEEPSEEK_CREDENTIAL: "a",
+    },
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const record = parseJson(result.stdout);
+  assert.equal(record.status, "completed");
+  assert.equal(record.result, "a normal alphabet payload");
+  assert.doesNotMatch(result.stdout, /\[REDACTED\] normal/);
+
+  const shortSecretResult = await run([
+    "run",
+    "--provider", "deepseek",
+    "--mode", "custom-review",
+    "--scope", "custom",
+    "--scope-paths", "seed.txt",
+    "--foreground",
+    "--prompt", "Check this file.",
+  ], {
+    cwd,
+    companion: path.join(pluginRoot, "scripts", "api-reviewer.mjs"),
+    env: {
+      API_REVIEWERS_MOCK_RESPONSE: mockResponse("deepseek-v4-flash", "chatcmpl-test", "provider echoed abcd"),
+      DEEPSEEK_CREDENTIAL: "abcd",
+    },
+  });
+  assert.equal(shortSecretResult.status, 0, shortSecretResult.stderr || shortSecretResult.stdout);
+  const shortSecretRecord = parseJson(shortSecretResult.stdout);
+  assert.equal(shortSecretRecord.status, "completed");
+  assert.equal(shortSecretRecord.result, "provider echoed [REDACTED]");
+  assert.doesNotMatch(shortSecretResult.stdout, /provider echoed abcd/);
+});
+
 test("direct API reviewer prompt names the selected provider", async () => {
   const cwd = makeWorkspace();
   const result = await run([
@@ -1413,6 +1506,16 @@ test("direct API timeout marks selected content as sent", async () => {
     assert.notEqual(result.stdout, "", result.stderr);
     const record = parseJson(result.stdout);
     assert.equal(record.error_code, "timeout");
+    assert.match(record.error_summary, /timeout after \d+ms/i);
+    assert.match(record.error_summary, /configured_timeout_ms=20/);
+    assert.match(record.error_summary, /selected_files=1/);
+    assert.match(record.error_summary, /selected_bytes=\d+/);
+    assert.match(record.error_summary, /prompt_chars=\d+/);
+    assert.match(record.error_summary, /estimated_tokens=\d+/);
+    const promptChars = Number(/prompt_chars=(\d+)/.exec(record.error_summary)?.[1]);
+    const estimatedTokens = Number(/estimated_tokens=(\d+)/.exec(record.error_summary)?.[1]);
+    assert.equal(estimatedTokens, Math.ceil(promptChars / 4));
+    assert.match(record.error_message, /This operation was aborted|aborted/i);
     assert.match(record.suggested_action, /timeout/i);
     assert.match(record.suggested_action, /API_REVIEWERS_TIMEOUT_MS/);
     assert.equal(record.external_review.source_content_transmission, "sent");
@@ -1651,6 +1754,7 @@ test("direct API live malformed responses mark selected content as sent", async 
 test("branch-diff default reviews committed changes against main with scrubbed git env", async () => {
   const cwd = makeBranchDiffWorkspace();
   const dataDir = mkdtempSync(path.join(tmpdir(), "api-reviewers-data-"));
+  writeFileSync(path.join(cwd, "feature.txt"), "DIRTY_SELECTED_SECRET\n");
   const result = await run([
     "run",
     "--provider", "deepseek",
@@ -1662,7 +1766,7 @@ test("branch-diff default reviews committed changes against main with scrubbed g
     env: {
       API_REVIEWERS_PLUGIN_DATA: dataDir,
       API_REVIEWERS_MOCK_RESPONSE: mockResponse("deepseek-v4-pro"),
-      API_REVIEWERS_MOCK_ASSERT_PROMPT_INCLUDES: "Live verification context",
+      API_REVIEWERS_MOCK_ASSERT_PROMPT_INCLUDES: "committed feature change",
       DEEPSEEK_API_KEY: "secret-test-value",
       GIT_DIR: path.join(cwd, "not-a-repo"),
       GIT_CONFIG_GLOBAL: path.join(cwd, "malicious-gitconfig"),
@@ -1675,9 +1779,80 @@ test("branch-diff default reviews committed changes against main with scrubbed g
   assert.equal(record.scope_base, "main");
   assert.deepEqual(record.scope_paths, ["feature.txt"]);
   assert.doesNotMatch(result.stdout, /secret-test-value/);
+  assert.doesNotMatch(result.stdout, /DIRTY_SELECTED_SECRET/);
 });
 
-test("branch-diff git spawn failure returns structured scope failure JobRecord", async () => {
+test("branch-diff scope paths narrow committed changes", async () => {
+  const cwd = makeBranchDiffWorkspace();
+  const dataDir = mkdtempSync(path.join(tmpdir(), "api-reviewers-data-"));
+  writeFileSync(path.join(cwd, "extra.txt"), "extra committed change\n");
+  git(cwd, ["add", "extra.txt"]);
+  git(cwd, ["commit", "-m", "extra"]);
+  const result = await run([
+    "run",
+    "--provider", "deepseek",
+    "--mode", "review",
+    "--scope", "branch-diff",
+    "--scope-paths", "feature.txt",
+    "--foreground",
+    "--prompt", "Check this branch.",
+  ], {
+    cwd,
+    env: {
+      API_REVIEWERS_PLUGIN_DATA: dataDir,
+      API_REVIEWERS_MOCK_RESPONSE: mockResponse("deepseek-v4-pro"),
+      API_REVIEWERS_MOCK_ASSERT_PROMPT_INCLUDES: "feature.txt",
+      DEEPSEEK_API_KEY: "secret-test-value",
+    },
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const record = parseJson(result.stdout);
+  assert.deepEqual(record.scope_paths, ["feature.txt"]);
+  assert.deepEqual(
+    record.review_metadata.audit_manifest.selected_source.files.map((file) => file.path),
+    ["feature.txt"]
+  );
+  assert.equal(
+    record.review_metadata.audit_manifest.scope_resolution.reason,
+    "git diff -z --name-only main...HEAD -- filtered by explicit --scope-paths"
+  );
+  assert.doesNotMatch(result.stdout, /extra committed change/);
+});
+
+test("branch-diff scope paths honor glob patterns when narrowing committed changes", async () => {
+  const cwd = makeBranchDiffWorkspace();
+  const dataDir = mkdtempSync(path.join(tmpdir(), "api-reviewers-data-"));
+  writeFileSync(path.join(cwd, "extra.txt"), "extra committed change\n");
+  git(cwd, ["add", "extra.txt"]);
+  git(cwd, ["commit", "-m", "extra"]);
+  const result = await run([
+    "run",
+    "--provider", "deepseek",
+    "--mode", "review",
+    "--scope", "branch-diff",
+    "--scope-paths", "feature.*",
+    "--foreground",
+    "--prompt", "Check this branch.",
+  ], {
+    cwd,
+    env: {
+      API_REVIEWERS_PLUGIN_DATA: dataDir,
+      API_REVIEWERS_MOCK_RESPONSE: mockResponse("deepseek-v4-pro"),
+      API_REVIEWERS_MOCK_ASSERT_PROMPT_INCLUDES: "feature.txt",
+      DEEPSEEK_API_KEY: "secret-test-value",
+    },
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const record = parseJson(result.stdout);
+  assert.deepEqual(record.scope_paths, ["feature.txt"]);
+  assert.deepEqual(
+    record.review_metadata.audit_manifest.selected_source.files.map((file) => file.path),
+    ["feature.txt"]
+  );
+  assert.doesNotMatch(result.stdout, /extra committed change/);
+});
+
+test("branch-diff uses hardened git path despite ambient PATH sabotage", async () => {
   const cwd = makeBranchDiffWorkspace();
   const dataDir = mkdtempSync(path.join(tmpdir(), "api-reviewers-data-"));
   const result = await run([
@@ -1695,12 +1870,11 @@ test("branch-diff git spawn failure returns structured scope failure JobRecord",
       PATH: "",
     },
   });
-  assert.equal(result.status, 1);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
   const record = parseJson(result.stdout);
-  assert.equal(record.status, "failed");
-  assert.equal(record.error_code, "scope_failed");
-  assert.match(record.error_message, /git_failed:/);
-  assert.match(record.suggested_action, /Adjust --scope/);
+  assert.equal(record.status, "completed");
+  assert.equal(record.error_code, null);
+  assert.equal(record.external_review.source_content_transmission, "sent");
   assert.doesNotMatch(result.stdout, /secret-test-value/);
 });
 

--- a/tests/smoke/claude-companion.smoke.test.mjs
+++ b/tests/smoke/claude-companion.smoke.test.mjs
@@ -112,7 +112,7 @@ test("run --mode=review --foreground: emits JobRecord with status=completed", ()
   const { stdout, stderr, status, dataDir } = runCompanion(
     ["run", "--mode=review", "--foreground", "--model", "claude-haiku-4-5-20251001",
      "--cwd", cwd, "--", "review: x=1"],
-    { cwd }
+    { cwd, env: { CLAUDE_MOCK_ASSERT_PROMPT_INCLUDES: "Provider: Claude Code" } }
   );
   try {
     assert.equal(status, 0, `exit ${status}: stderr=${stderr}`);
@@ -124,7 +124,22 @@ test("run --mode=review --foreground: emits JobRecord with status=completed", ()
     assert.ok(result.job_id, "job_id set");
     assert.equal(result.result, "Mock Claude response.");
     assert.deepEqual(result.permission_denials, []);
-    assert.equal(result.schema_version, 10, "schema_version bumped for delegated review metadata");
+    assert.equal(result.schema_version, 10, "schema_version bumped for delegated review metadata and runtime diagnostics");
+    assert.equal(result.review_metadata.prompt_contract_version, 1);
+    assert.equal(result.review_metadata.prompt_provider, "Claude Code");
+    assert.equal(result.review_metadata.raw_output.parsed_ok, true);
+    assert.match(result.review_metadata.audit_manifest.rendered_prompt_hash.value, /^[a-f0-9]{64}$/);
+    assert.equal(result.review_metadata.audit_manifest.request.model, "claude-haiku-4-5-20251001");
+    assert.equal(result.review_metadata.audit_manifest.request.timeout_ms, null);
+    assert.match(result.review_metadata.audit_manifest.prompt_builder.plugin_commit, /^[a-f0-9]{40}$/);
+    assert.notEqual(
+      result.review_metadata.audit_manifest.prompt_builder.plugin_commit,
+      result.review_metadata.audit_manifest.git_identity.head_sha,
+      "plugin_commit must identify the plugin source, not the reviewed repository head"
+    );
+    assert.equal(result.review_metadata.audit_manifest.scope_resolution.scope, result.scope);
+    assert.equal(result.review_metadata.audit_manifest.selected_source.files.length > 0, true);
+    assert.equal(JSON.stringify(result.review_metadata.audit_manifest).includes("review: x=1"), false);
     assert.equal("prompt" in result, false,
       "§21.3.1: full prompt must not appear on JobRecord");
     assert.equal("ok" in result, false,
@@ -930,10 +945,51 @@ test("adversarial-review scope=branch-diff: only changed files appear in --add-d
     const result = JSON.parse(stdout);
     const fx = readStdoutLog(dataDir, result.job_id);
     const files = fx.t7_add_dir_files ?? [];
+    assert.deepEqual(result.runtime_diagnostics.scope_path_mappings, [{
+      original: path.join(cwd, "foo.md"),
+      contained: path.join(result.runtime_diagnostics.add_dir, "foo.md"),
+      relative: "foo.md",
+      inside_add_dir: true,
+    }]);
     assert.ok(files.includes("foo.md"),
       `branch-diff scope missing foo.md; saw: ${files.join(",")}`);
     assert.ok(!files.includes("old.md"),
       `branch-diff scope leaked old.md; saw: ${files.join(",")}`);
+  } finally {
+    cleanup(dataDir);
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("adversarial-review scope=branch-diff: scope paths narrow copied and audited files", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "smoke-adv-paths-"));
+  spawnSync("git", ["init", "-q", "-b", "main"], { cwd, env: fixtureGitEnv() });
+  spawnSync("bash", ["-c",
+    "echo old > old.md && git add old.md && " +
+    "git -c core.hooksPath=/dev/null commit -q -m main && " +
+    "git checkout -qb feature && " +
+    "echo wanted > wanted.md && echo extra > extra.md && git add wanted.md extra.md && " +
+    "git -c core.hooksPath=/dev/null commit -q -m feature"], { cwd, env: fixtureGitEnv() });
+  const { stdout, status, stderr, dataDir } = runCompanion(
+    ["run", "--mode=adversarial-review", "--foreground",
+     "--model", "claude-haiku-4-5-20251001",
+     "--cwd", cwd, "--scope-paths", "wanted.md", "--", "focus"],
+    { cwd, env: { CLAUDE_MOCK_LIST_ADDDIR: "1" } }
+  );
+  try {
+    assert.equal(status, 0, `exit ${status}: ${stderr}`);
+    const result = JSON.parse(stdout);
+    const fx = readStdoutLog(dataDir, result.job_id);
+    const files = fx.t7_add_dir_files ?? [];
+    assert.deepEqual(files, ["wanted.md"]);
+    assert.deepEqual(
+      result.review_metadata.audit_manifest.selected_source.files.map((file) => file.path),
+      ["wanted.md"]
+    );
+    assert.equal(
+      result.review_metadata.audit_manifest.scope_resolution.reason,
+      "git diff -z --name-only main...HEAD -- filtered by explicit --scope-paths"
+    );
   } finally {
     cleanup(dataDir);
     rmSync(cwd, { recursive: true, force: true });
@@ -960,9 +1016,32 @@ test("custom-review scope=custom: reviews explicit bundle files from a non-git d
       assert.equal(result.mode, "custom-review");
       assert.equal(result.scope, "custom");
       assert.deepEqual(result.scope_paths, ["PR23.diff", "notes.md"]);
+      assert.ok(result.runtime_diagnostics.add_dir,
+        "custom-review should persist the exact --add-dir path granted to Claude");
+      assert.ok(result.runtime_diagnostics.child_cwd,
+        "custom-review should persist the exact child cwd used for Claude");
+      assert.notEqual(result.runtime_diagnostics.add_dir, result.runtime_diagnostics.child_cwd,
+        "custom-review should run from a neutral cwd, not the scoped add-dir");
+      assert.deepEqual(result.runtime_diagnostics.scope_path_mappings, [
+        {
+          original: path.join(cwd, "PR23.diff"),
+          contained: path.join(result.runtime_diagnostics.add_dir, "PR23.diff"),
+          relative: "PR23.diff",
+          inside_add_dir: true,
+        },
+        {
+          original: path.join(cwd, "notes.md"),
+          contained: path.join(result.runtime_diagnostics.add_dir, "notes.md"),
+          relative: "notes.md",
+          inside_add_dir: true,
+        },
+      ]);
       const fx = readStdoutLog(dataDir, result.job_id);
       assert.equal(fx.t7_saw_file, true, "custom-review should include PR23.diff in --add-dir");
       assert.deepEqual(fx.t7_add_dir_files.sort(), ["PR23.diff", "notes.md"]);
+      assert.equal(fx.t7_add_dir, result.runtime_diagnostics.add_dir);
+      assert.equal(existsSync(result.runtime_diagnostics.child_cwd), false,
+        `neutral Claude cwd should be disposed after custom review: ${result.runtime_diagnostics.child_cwd}`);
     } finally {
       cleanup(dataDir);
     }
@@ -1594,6 +1673,8 @@ test("_run-worker: cancel marker prevents target spawn, sets status=cancelled", 
     const wsDir = path.dirname(metaPath);
     const markerDir = path.join(wsDir, record.job_id);
     spawnSync("mkdir", ["-p", markerDir]);
+    const promptPath = path.join(markerDir, "prompt.txt");
+    writeFileSync(promptPath, "queued prompt with selected source\n", { mode: 0o600 });
     const markerPath = path.join(markerDir, "cancel-requested.flag");
     writeFileSync(markerPath, new Date().toISOString() + "\n");
 
@@ -1616,6 +1697,8 @@ test("_run-worker: cancel marker prevents target spawn, sets status=cancelled", 
     // Marker was consumed (unlinked) so a second pickup wouldn't double-cancel.
     assert.equal(existsSync(markerPath), false,
       "worker must consume (unlink) the marker on pickup");
+    assert.equal(existsSync(promptPath), false,
+      "worker must remove prompt sidecar when queued cancel prevents target spawn");
   } finally {
     rmSync(dataDir, { recursive: true, force: true });
     rmSync(cwd, { recursive: true, force: true });

--- a/tests/smoke/gemini-companion.smoke.test.mjs
+++ b/tests/smoke/gemini-companion.smoke.test.mjs
@@ -404,6 +404,8 @@ test("gemini _run-worker: cancel marker prevents target spawn, sets status=cance
     const wsDir = path.dirname(metaPath);
     const markerDir = path.join(wsDir, record.job_id);
     mkdirSync(markerDir, { recursive: true });
+    const promptPath = path.join(markerDir, "prompt.txt");
+    writeFileSync(promptPath, "queued prompt with selected source\n", { mode: 0o600 });
     const markerPath = path.join(markerDir, "cancel-requested.flag");
     writeFileSync(markerPath, new Date().toISOString() + "\n");
 
@@ -423,6 +425,8 @@ test("gemini _run-worker: cancel marker prevents target spawn, sets status=cance
       "worker must not record pid_info when refusing to spawn");
     assert.equal(existsSync(markerPath), false,
       "worker must consume (unlink) the marker on pickup");
+    assert.equal(existsSync(promptPath), false,
+      "worker must remove prompt sidecar when queued cancel prevents target spawn");
   } finally {
     rmTree(runRes.dataDir);
     rmTree(cwd);
@@ -1164,12 +1168,31 @@ test("gemini review foreground: omits native Gemini sandbox inside Codex sandbox
   seedMinimalRepo(cwd);
   const { stdout, stderr, status, dataDir } = runCompanion(
     ["run", "--mode=review", "--foreground", "--cwd", cwd, "--", "review: x=1"],
-    { cwd, env: { CODEX_SANDBOX: "seatbelt", GEMINI_MOCK_ASSERT_FILE: "seed.txt" } },
+    { cwd, env: {
+      CODEX_SANDBOX: "seatbelt",
+      GEMINI_MOCK_ASSERT_FILE: "seed.txt",
+      GEMINI_MOCK_ASSERT_PROMPT_INCLUDES: "Provider: Gemini CLI",
+    } },
   );
   try {
     assert.equal(status, 0, `exit ${status}: ${stderr}`);
     const record = JSON.parse(stdout);
     assert.equal(record.status, "completed");
+    assert.equal(record.review_metadata.prompt_contract_version, 1);
+    assert.equal(record.review_metadata.prompt_provider, "Gemini CLI");
+    assert.equal(record.review_metadata.raw_output.parsed_ok, true);
+    assert.match(record.review_metadata.audit_manifest.rendered_prompt_hash.value, /^[a-f0-9]{64}$/);
+    assert.equal(record.review_metadata.audit_manifest.request.model, record.model);
+    assert.match(record.review_metadata.audit_manifest.prompt_builder.plugin_commit, /^[a-f0-9]{40}$/);
+    assert.notEqual(
+      record.review_metadata.audit_manifest.prompt_builder.plugin_commit,
+      record.review_metadata.audit_manifest.git_identity.head_sha,
+      "plugin_commit must identify the plugin source, not the reviewed repository head"
+    );
+    assert.equal(record.review_metadata.audit_manifest.scope_resolution.scope, record.scope);
+    assert.equal(record.review_metadata.audit_manifest.selected_source.files.length > 0, true);
+    assert.equal(JSON.stringify(record.review_metadata.audit_manifest).includes("review: x=1"), false);
+    assert.equal(JSON.stringify(record.review_metadata.audit_manifest).includes("seed\\n"), false);
 
     const fx = readStdoutLog(dataDir, record.job_id);
     assert.equal(fx.t7_policy_loaded, true, "Gemini review must still pass bundled read-only policy");

--- a/tests/smoke/grok-web.smoke.test.mjs
+++ b/tests/smoke/grok-web.smoke.test.mjs
@@ -10,6 +10,56 @@ import assert from "node:assert/strict";
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
 const COMPANION = path.join(REPO_ROOT, "plugins/grok/scripts/grok-web-reviewer.mjs");
+const GROK_EXPECTED_KEYS = Object.freeze([
+  "id",
+  "job_id",
+  "target",
+  "provider",
+  "parent_job_id",
+  "claude_session_id",
+  "gemini_session_id",
+  "kimi_session_id",
+  "resume_chain",
+  "pid_info",
+  "mode",
+  "mode_profile_name",
+  "model",
+  "cwd",
+  "workspace_root",
+  "containment",
+  "scope",
+  "dispose_effective",
+  "scope_base",
+  "scope_paths",
+  "prompt_head",
+  "review_metadata",
+  "schema_spec",
+  "binary",
+  "status",
+  "started_at",
+  "ended_at",
+  "exit_code",
+  "error_code",
+  "error_message",
+  "error_summary",
+  "error_cause",
+  "suggested_action",
+  "external_review",
+  "disclosure_note",
+  "runtime_diagnostics",
+  "result",
+  "structured_output",
+  "permission_denials",
+  "mutations",
+  "cost_usd",
+  "usage",
+  "auth_mode",
+  "credential_ref",
+  "endpoint",
+  "http_status",
+  "raw_model",
+  "schema_version",
+]);
 
 function run(args, options = {}) {
   return spawnSync(process.execPath, [COMPANION, ...args], {
@@ -69,13 +119,31 @@ async function readJsonRequest(req) {
   return JSON.parse(body);
 }
 
-test("doctor reports subscription-backed local tunnel mode and checks reachability", async () => {
+test("doctor reports subscription-backed local tunnel mode and checks chat readiness", async () => {
   await withServer(async (req, res) => {
-    assert.equal(req.method, "GET");
-    assert.equal(req.url, "/api/models");
     assert.equal(req.headers.authorization, "Bearer secret-cookie-like-token");
     res.setHeader("content-type", "application/json");
-    res.end(JSON.stringify({ data: [{ id: "grok-4.20-fast" }] }));
+    if (req.url === "/api/models") {
+      assert.equal(req.method, "GET");
+      res.end(JSON.stringify({ data: [{ id: "grok-4.20-fast" }] }));
+      return;
+    }
+    if (req.url === "/api/chat/completions") {
+      assert.equal(req.method, "POST");
+      const body = await readJsonRequest(req);
+      assert.equal(body.model, "grok-4.20-fast");
+      assert.equal(body.stream, false);
+      assert.equal(body.messages.length, 1);
+      assert.match(body.messages[0].content, /Return exactly: ok/);
+      res.end(JSON.stringify({
+        id: "chatcmpl-doctor",
+        model: "grok-4.20-fast",
+        choices: [{ message: { content: "ok" } }],
+      }));
+      return;
+    }
+    res.writeHead(404);
+    res.end(JSON.stringify({ error: { message: "not found" } }));
   }, async (baseUrl) => {
     const result = await runAsync(["doctor"], {
       env: {
@@ -89,14 +157,175 @@ test("doctor reports subscription-backed local tunnel mode and checks reachabili
     assert.equal(parsed.provider, "grok-web");
     assert.equal(parsed.ready, true);
     assert.equal(parsed.reachable, true);
+    assert.equal(parsed.chat_ready, true);
     assert.equal(parsed.auth_mode, "subscription_web");
     assert.equal(parsed.endpoint, baseUrl);
     assert.equal(parsed.probe_endpoint, `${baseUrl}/models`);
+    assert.equal(parsed.chat_probe_endpoint, `${baseUrl}/chat/completions`);
+    assert.equal(parsed.chat_doctor_timeout_ms, 10000);
     assert.match(parsed.summary, /subscription-backed/i);
     assert.match(parsed.next_action, /Grok web review/i);
     assert.equal(parsed.credential_ref, "GROK_WEB_TUNNEL_API_KEY");
     assert.doesNotMatch(result.stdout, /secret-cookie-like-token/);
     assert.doesNotMatch(result.stdout, /api\.x\.ai/i);
+  });
+});
+
+test("rejects prototype-shaped option keys", () => {
+  const result = run(["doctor", "--constructor", "polluted"], {
+    env: {
+      GROK_WEB_TUNNEL_API_KEY: "secret-cookie-like-token",
+    },
+  });
+  const parsed = parseStdout(result);
+
+  assert.equal(result.status, 1);
+  assert.equal(parsed.ok, false);
+  assert.match(parsed.error, /unsupported option --constructor/);
+  assert.doesNotMatch(result.stdout, /secret-cookie-like-token/);
+});
+
+test("doctor points bad chat model 400s at GROK_WEB_MODEL", async () => {
+  await withServer(async (req, res) => {
+    res.setHeader("content-type", "application/json");
+    if (req.url === "/api/models") {
+      res.end(JSON.stringify({ data: [{ id: "grok-4.20-fast" }] }));
+      return;
+    }
+    if (req.url === "/api/chat/completions") {
+      const body = await readJsonRequest(req);
+      assert.equal(body.model, "grok-does-not-exist");
+      res.writeHead(400);
+      res.end(JSON.stringify({
+        error: { message: "Model not found: grok-does-not-exist", type: "invalid_request_error", code: "model_not_found" },
+      }));
+      return;
+    }
+    res.writeHead(404);
+    res.end(JSON.stringify({ error: { message: "not found" } }));
+  }, async (baseUrl) => {
+    const result = await runAsync(["doctor"], {
+      env: {
+        GROK_WEB_BASE_URL: baseUrl,
+        GROK_WEB_MODEL: "grok-does-not-exist",
+      },
+    });
+    const parsed = parseStdout(result);
+
+    assert.equal(result.status, 0);
+    assert.equal(parsed.reachable, true);
+    assert.equal(parsed.chat_ready, false);
+    assert.equal(parsed.error_code, "grok_chat_model_rejected");
+    assert.equal(parsed.chat_http_status, 400);
+    assert.match(parsed.error_message, /Model not found/);
+    assert.match(parsed.next_action, /GROK_WEB_MODEL/);
+  });
+});
+
+test("doctor does not classify quota 400s that mention model as model rejection", async () => {
+  await withServer(async (req, res) => {
+    res.setHeader("content-type", "application/json");
+    if (req.url === "/api/models") {
+      res.end(JSON.stringify({ data: [{ id: "grok-4.20-fast" }] }));
+      return;
+    }
+    if (req.url === "/api/chat/completions") {
+      const body = await readJsonRequest(req);
+      assert.equal(body.model, "grok-4.20-fast");
+      res.writeHead(400);
+      res.end(JSON.stringify({
+        error: { message: "invalid request: quota exceeded for model grok-4.20-fast" },
+      }));
+      return;
+    }
+    res.writeHead(404);
+    res.end(JSON.stringify({ error: { message: "not found" } }));
+  }, async (baseUrl) => {
+    const result = await runAsync(["doctor"], {
+      env: {
+        GROK_WEB_BASE_URL: baseUrl,
+      },
+    });
+    const parsed = parseStdout(result);
+
+    assert.equal(result.status, 0);
+    assert.equal(parsed.reachable, true);
+    assert.equal(parsed.chat_ready, false);
+    assert.equal(parsed.error_code, "models_ok_chat_400");
+    assert.equal(parsed.chat_http_status, 400);
+    assert.match(parsed.error_message, /quota exceeded/);
+    assert.doesNotMatch(parsed.next_action, /GROK_WEB_MODEL/);
+  });
+});
+
+test("doctor chat probe uses a separate configurable timeout", async () => {
+  await withServer(async (req, res) => {
+    res.setHeader("content-type", "application/json");
+    if (req.url === "/api/models") {
+      res.end(JSON.stringify({ data: [{ id: "grok-4.20-fast" }] }));
+      return;
+    }
+    if (req.url === "/api/chat/completions") {
+      await new Promise((resolve) => setTimeout(resolve, 120));
+      res.end(JSON.stringify({
+        id: "chatcmpl-doctor",
+        model: "grok-4.20-fast",
+        choices: [{ message: { content: "ok" } }],
+      }));
+      return;
+    }
+    res.writeHead(404);
+    res.end(JSON.stringify({ error: { message: "not found" } }));
+  }, async (baseUrl) => {
+    const result = await runAsync(["doctor"], {
+      env: {
+        GROK_WEB_BASE_URL: baseUrl,
+        GROK_WEB_DOCTOR_TIMEOUT_MS: "50",
+        GROK_WEB_CHAT_DOCTOR_TIMEOUT_MS: "10000",
+      },
+    });
+    const parsed = parseStdout(result);
+
+    assert.equal(result.status, 0);
+    assert.equal(parsed.ready, true);
+    assert.equal(parsed.doctor_timeout_ms, 50);
+    assert.equal(parsed.chat_doctor_timeout_ms, 10000);
+  });
+});
+
+test("doctor is not review-ready when models work but chat returns upstream 400", async () => {
+  await withServer(async (req, res) => {
+    res.setHeader("content-type", "application/json");
+    if (req.url === "/api/models") {
+      res.end(JSON.stringify({ data: [{ id: "grok-4.20-fast" }] }));
+      return;
+    }
+    if (req.url === "/api/chat/completions") {
+      await readJsonRequest(req);
+      res.writeHead(400);
+      res.end(JSON.stringify({
+        error: { message: "Chat upstream returned 400", type: "upstream_error", code: "upstream_error" },
+      }));
+      return;
+    }
+    res.writeHead(404);
+    res.end(JSON.stringify({ error: { message: "not found" } }));
+  }, async (baseUrl) => {
+    const result = await runAsync(["doctor"], {
+      env: { GROK_WEB_BASE_URL: baseUrl },
+    });
+    const parsed = parseStdout(result);
+
+    assert.equal(result.status, 0);
+    assert.equal(parsed.reachable, true);
+    assert.equal(parsed.chat_ready, false);
+    assert.equal(parsed.ready, false);
+    assert.equal(parsed.error_code, "models_ok_chat_400");
+    assert.equal(parsed.http_status, 200);
+    assert.equal(parsed.chat_http_status, 400);
+    assert.match(parsed.error_message, /Chat upstream returned 400/);
+    assert.match(parsed.summary, /models.*chat/i);
+    assert.match(parsed.next_action, /session|tunnel|rate-limit/i);
   });
 });
 
@@ -219,25 +448,42 @@ test("custom-review sends selected source to a local Grok web tunnel and persist
     const record = parseStdout(result);
 
     assert.equal(result.status, 0);
+    assert.deepEqual(Object.keys(record), [...GROK_EXPECTED_KEYS]);
     assert.equal(record.target, "grok-web");
     assert.equal(record.provider, "grok-web");
     assert.equal(record.auth_mode, "subscription_web");
     assert.equal(record.status, "completed");
     assert.equal(record.result, "Verdict: no findings 1.");
     assert.equal(record.schema_version, 10);
-    assert.deepEqual(record.review_metadata, {
-      prompt_contract_version: 1,
-      prompt_provider: "Grok Web",
-      scope: "custom",
-      scope_base: null,
-      scope_paths: ["review.js"],
-      raw_output: {
-        http_status: 200,
-        raw_model: "grok-4.20-fast",
-        parsed_ok: true,
-        result_chars: "Verdict: no findings 1.".length,
-      },
+    assert.equal(record.review_metadata.prompt_contract_version, 1);
+    assert.equal(record.review_metadata.prompt_provider, "Grok Web");
+    assert.equal(record.review_metadata.scope, "custom");
+    assert.deepEqual(record.review_metadata.scope_paths, ["review.js"]);
+    assert.deepEqual(record.review_metadata.raw_output, {
+      http_status: 200,
+      raw_model: "grok-4.20-fast",
+      parsed_ok: true,
+      result_chars: "Verdict: no findings 1.".length,
     });
+    assert.match(record.review_metadata.audit_manifest.rendered_prompt_hash.value, /^[a-f0-9]{64}$/);
+    assert.equal(record.review_metadata.audit_manifest.request.model, "grok-4.20-fast");
+    assert.equal(record.review_metadata.audit_manifest.request.temperature, 0);
+    assert.match(record.review_metadata.audit_manifest.prompt_builder.plugin_commit, /^[a-f0-9]{40}$/);
+    assert.notEqual(
+      record.review_metadata.audit_manifest.prompt_builder.plugin_commit,
+      record.review_metadata.audit_manifest.git_identity.head_sha,
+      "plugin_commit must identify the plugin source, not the reviewed repository head"
+    );
+    assert.equal(record.review_metadata.audit_manifest.provider_ids.session_id, "grok-web-session-1");
+    assert.deepEqual(record.review_metadata.audit_manifest.selected_source.files.map((file) => ({
+      path: file.path,
+      bytes: file.bytes,
+      hashOk: /^[a-f0-9]{64}$/.test(file.content_hash.value),
+    })), [
+      { path: "review.js", bytes: "export const value = 42;\n// ``` nested markdown fence\n".length, hashOk: true },
+    ]);
+    assert.equal(JSON.stringify(record.review_metadata.audit_manifest).includes("Check this file"), false);
+    assert.equal(JSON.stringify(record.review_metadata.audit_manifest).includes("export const value"), false);
     assert.equal(record.external_review.provider, "Grok Web");
     assert.equal(record.external_review.source_content_transmission, "sent");
     assert.match(record.disclosure_note, /subscription-backed web session/i);
@@ -1027,8 +1273,10 @@ test("review mode uses branch-diff scope with scrubbed git environment", async (
   assert.notEqual(tagObject, mainCommit);
   execFileSync("git", ["checkout", "-b", "feature"], { cwd, stdio: "ignore" });
   writeFileSync(path.join(cwd, "review.js"), "export const value = 2;\n");
-  execFileSync("git", ["add", "review.js"], { cwd });
+  writeFileSync(path.join(cwd, "extra.js"), "export const extra = true;\n");
+  execFileSync("git", ["add", "review.js", "extra.js"], { cwd });
   execFileSync("git", ["commit", "-m", "feature"], { cwd, stdio: "ignore" });
+  writeFileSync(path.join(cwd, "review.js"), "GROK_DIRTY_SELECTED_SECRET\n");
   writeFileSync(path.join(cwd, "local-config.txt"), "GROK_LOCAL_DIRTY_SECRET\n");
   writeFileSync(path.join(cwd, "untracked-secret.js"), "GROK_UNTRACKED_SECRET\n");
 
@@ -1037,9 +1285,12 @@ test("review mode uses branch-diff scope with scrubbed git environment", async (
     assert.equal(req.url, "/api/chat/completions");
     const body = await readJsonRequest(req);
     assert.match(body.messages[0].content, /review\.js/);
+    assert.doesNotMatch(body.messages[0].content, /extra\.js/);
+    assert.doesNotMatch(body.messages[0].content, /export const extra/);
     assert.match(body.messages[0].content, new RegExp(`Base commit: ${mainCommit}`));
     assert.doesNotMatch(body.messages[0].content, new RegExp(`Base commit: ${tagObject}`));
     assert.match(body.messages[0].content, /export const value = 2/);
+    assert.doesNotMatch(body.messages[0].content, /GROK_DIRTY_SELECTED_SECRET/);
     assert.doesNotMatch(body.messages[0].content, /local-config\.txt/);
     assert.doesNotMatch(body.messages[0].content, /GROK_LOCAL_DIRTY_SECRET/);
     assert.doesNotMatch(body.messages[0].content, /untracked-secret\.js/);
@@ -1055,6 +1306,7 @@ test("review mode uses branch-diff scope with scrubbed git environment", async (
       "--mode", "review",
       "--scope", "branch-diff",
       "--scope-base", "review-base",
+      "--scope-paths", "review.?s",
       "--foreground",
       "--prompt", "Review the branch diff.",
     ], {
@@ -1075,6 +1327,15 @@ test("review mode uses branch-diff scope with scrubbed git environment", async (
     assert.equal(record.mode, "review");
     assert.equal(record.scope, "branch-diff");
     assert.equal(record.scope_base, "review-base");
+    assert.deepEqual(record.scope_paths, ["review.js"]);
+    assert.deepEqual(
+      record.review_metadata.audit_manifest.selected_source.files.map((file) => file.path),
+      ["review.js"]
+    );
+    assert.equal(
+      record.review_metadata.audit_manifest.scope_resolution.reason,
+      "git diff -z --name-only review-base...HEAD -- filtered by explicit --scope-paths"
+    );
     assert.equal(record.result, "Verdict: branch diff reviewed.");
     assert.equal(existsSync(hostileGitMarker), false);
   });
@@ -1109,10 +1370,15 @@ test("custom-review keeps prompt delimiter exceptions as scope failures before t
 });
 
 test("scope file reads use canonical real paths after symlink boundary check", () => {
-  // Structural guard for the reviewed TOCTOU fix: later I/O must keep using the verified path.
+  // Structural guard for the reviewed TOCTOU fix: later I/O must keep using the verified path
+  // and must read through the bounded file-handle helper instead of unbounded readFile().
   const source = readFileSync(COMPANION, "utf8");
-  assert.match(source, /const info = await stat\(realAbs\);/);
-  assert.match(source, /const text = await readFile\(realAbs, "utf8"\);/);
+  assert.match(source, /const SCOPE_FILE_OPEN_FLAGS = fsConstants\.O_RDONLY \| \(fsConstants\.O_NOFOLLOW \?\? 0\);/);
+  assert.match(source, /const handle = await open\(filePath, SCOPE_FILE_OPEN_FLAGS\);/);
+  assert.match(source, /const info = await handle\.stat\(\);/);
+  assert.match(source, /const \{ bytesRead \} = await handle\.read\(buffer, 0, buffer\.length, null\);/);
+  assert.match(source, /const text = await readUtf8ScopeFileWithinLimit\(realAbs, normalizedRel\);/);
+  assert.doesNotMatch(source, /const text = await readFile\(realAbs, "utf8"\);/);
 });
 
 test("tunnel invocation catch is separated from prompt construction catch", () => {
@@ -1250,6 +1516,43 @@ test("custom-review rejects oversized selected files before contacting the tunne
   assert.equal(record.status, "failed");
   assert.equal(record.error_code, "scope_failed");
   assert.match(record.error_message, /scope_file_too_large:large\.js/);
+  assert.equal(record.external_review.source_content_transmission, "not_sent");
+});
+
+test("branch-diff rejects oversized committed files before contacting the tunnel", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "grok-web-branch-large-"));
+  execFileSync("git", ["init", "-b", "main"], { cwd, stdio: "ignore" });
+  execFileSync("git", ["config", "user.email", "test@example.com"], { cwd });
+  execFileSync("git", ["config", "user.name", "Test User"], { cwd });
+  writeFileSync(path.join(cwd, "large.js"), "export const value = 1;\n");
+  execFileSync("git", ["add", "large.js"], { cwd });
+  execFileSync("git", ["commit", "-m", "base"], { cwd, stdio: "ignore" });
+  execFileSync("git", ["checkout", "-b", "feature"], { cwd, stdio: "ignore" });
+  writeFileSync(path.join(cwd, "large.js"), `${"x".repeat(16 * 1024 * 1024 + 1)}\n`);
+  execFileSync("git", ["add", "large.js"], { cwd });
+  execFileSync("git", ["commit", "-m", "large"], { cwd, stdio: "ignore" });
+
+  const result = run([
+    "run",
+    "--mode", "review",
+    "--scope", "branch-diff",
+    "--scope-base", "main",
+    "--foreground",
+    "--prompt", "Review this large file.",
+  ], {
+    cwd,
+    env: {
+      GROK_WEB_BASE_URL: "http://127.0.0.1:9/api",
+      GROK_WEB_TUNNEL_API_KEY: "secret-cookie-like-token",
+    },
+  });
+  const record = parseStdout(result);
+
+  assert.equal(result.status, 1);
+  assert.equal(record.status, "failed");
+  assert.equal(record.error_code, "scope_failed");
+  assert.match(record.error_message, /scope_file_too_large:large\.js/);
+  assert.doesNotMatch(record.error_message, /ENOBUFS/);
   assert.equal(record.external_review.source_content_transmission, "not_sent");
 });
 

--- a/tests/smoke/invariants.test.mjs
+++ b/tests/smoke/invariants.test.mjs
@@ -571,6 +571,19 @@ test("M6-finding-10: every lib is importable and has a consumer (authoritative s
     "claude-companion.mjs must import at least one lib — §21.5 consumer check");
 });
 
+test("review audit source walkers skip symlinks before directory recursion", () => {
+  for (const rel of [
+    "plugins/claude/scripts/claude-companion.mjs",
+    "plugins/gemini/scripts/gemini-companion.mjs",
+    "plugins/kimi/scripts/kimi-companion.mjs",
+  ]) {
+    const source = readFileSync(path.join(REPO_ROOT, rel), "utf8");
+    assert.match(source, /lstatSync\(full\)/, `${rel} must inspect links without following them`);
+    assert.match(source, /isSymbolicLink\(\)\) continue;[\s\S]{0,120}isDirectory\(\)/,
+      `${rel} must skip symlinks before recursing into directories`);
+  }
+});
+
 // ---------------------------------------------------------------------------
 // Gap-coverage: behaviors the M6 mock couldn't exercise
 // ---------------------------------------------------------------------------

--- a/tests/smoke/kimi-companion.smoke.test.mjs
+++ b/tests/smoke/kimi-companion.smoke.test.mjs
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { chmodSync, existsSync, mkdtempSync, readdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -456,6 +456,16 @@ for (const mode of ["review", "adversarial-review", "custom-review"]) {
   }));
 }
 
+test("kimi adversarial prompt uses invocation mode, not profile name, for mode line", () => withRepo((cwd) => {
+  const result = runCompanion(kimiPromptAssertionArgs(cwd, "adversarial-review"), {
+    cwd,
+    env: {
+      KIMI_MOCK_ASSERT_PROMPT_INCLUDES: "You are performing an adversarial code review.",
+    },
+  });
+  assert.equal(result.status, 0, result.stderr);
+}));
+
 test("kimi foreground review timeout returns actionable JobRecord", () => withRepo((cwd) => {
   const result = runCompanion([
     "run",
@@ -538,6 +548,91 @@ test("kimi background run: launched event and terminal JobRecord carry external_
   } finally {
     await waitForProcessExit(launchedPid);
     rmSync(result.dataDir, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("kimi _run-worker: cancel marker removes prompt sidecar before target spawn", () => withRepo((cwd) => {
+  const dataDir = mkdtempSync(path.join(tmpdir(), "kimi-worker-cancel-data-"));
+  try {
+    const runRes = runCompanion([
+      "run",
+      "--mode",
+      "custom-review",
+      "--cwd",
+      cwd,
+      "--scope-paths",
+      "seed.txt",
+      "--foreground",
+      "--",
+      "Review this scope.",
+    ], { cwd, dataDir });
+    assert.equal(runRes.status, 0, runRes.stderr);
+    const { metaPath, record } = readOnlyJobRecord(dataDir);
+    writeFileSync(metaPath,
+      `${JSON.stringify({ ...record, status: "queued", pid_info: null }, null, 2)}\n`, "utf8");
+
+    const wsDir = path.dirname(metaPath);
+    const markerDir = path.join(wsDir, record.job_id);
+    mkdirSync(markerDir, { recursive: true });
+    const promptPath = path.join(markerDir, "prompt.txt");
+    writeFileSync(promptPath, "queued prompt with selected source\n", { mode: 0o600 });
+    const markerPath = path.join(markerDir, "cancel-requested.flag");
+    writeFileSync(markerPath, `${new Date().toISOString()}\n`);
+
+    const workerRes = spawnSync("node", [
+      COMPANION,
+      "_run-worker",
+      "--cwd",
+      cwd,
+      "--job",
+      record.job_id,
+    ], {
+      cwd,
+      encoding: "utf8",
+      env: { ...process.env, KIMI_BINARY: MOCK, KIMI_PLUGIN_DATA: dataDir },
+    });
+    assert.equal(workerRes.status, 0, workerRes.stderr);
+
+    const finalMeta = JSON.parse(readFileSync(metaPath, "utf8"));
+    assert.equal(finalMeta.status, "cancelled");
+    assert.equal(finalMeta.pid_info, null);
+    assert.equal(existsSync(markerPath), false,
+      "worker must consume queued cancel marker");
+    assert.equal(existsSync(promptPath), false,
+      "worker must remove prompt sidecar when queued cancel prevents target spawn");
+  } finally {
+    rmSync(dataDir, { recursive: true, force: true });
+  }
+}));
+
+test("kimi background worker spawn failure writes failed JobRecord instead of launched", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "kimi-bg-spawn-fail-runner-"));
+  const missingCwd = path.join(cwd, "missing-cwd");
+  const { stdout, stderr, status, dataDir } = runCompanion(
+    ["run", "--mode=rescue", "--background", "--model", "kimi-k2-0905",
+     "--cwd", missingCwd, "--", "background rescue task"],
+    { cwd },
+  );
+  try {
+    assert.notEqual(status, 0, "launcher must fail instead of emitting a false launched event");
+    const error = JSON.parse(stdout);
+    assert.equal(error.error, "spawn_failed");
+    assert.match(error.message, /background worker spawn failed/);
+    assert.match(stderr, /background worker spawn failed/);
+
+    const { metaPath, record } = readOnlyJobRecord(dataDir);
+    assert.equal(record.status, "failed");
+    assert.equal(record.cwd, missingCwd);
+    assert.match(record.error_message, /background worker spawn failed/);
+    assert.equal("prompt" in record, false, "full prompt must not appear on JobRecord");
+    assert.equal(
+      existsSync(path.join(path.dirname(metaPath), record.job_id, "prompt.txt")),
+      false,
+      "prompt sidecar must be removed when the worker never launches",
+    );
+  } finally {
+    rmSync(dataDir, { recursive: true, force: true });
     rmSync(cwd, { recursive: true, force: true });
   }
 });
@@ -1035,5 +1130,20 @@ for (const mode of ["review", "adversarial-review", "custom-review"]) {
       `Kimi review must run from a neutral temp cwd under ${tmpRoot}; got ${fx.t7_cwd}`);
     assert.equal(fx.t7_include_dirs.includes(fx.t7_cwd), false, "neutral cwd must not be the scoped include directory");
     assert.equal(existsSync(fx.t7_cwd), false, `neutral Kimi cwd must be cleaned after the run: ${fx.t7_cwd}`);
+    assert.equal(persisted.review_metadata.prompt_contract_version, 1);
+    assert.equal(persisted.review_metadata.prompt_provider, "Kimi");
+    assert.equal(persisted.review_metadata.raw_output.parsed_ok, true);
+    assert.match(persisted.review_metadata.audit_manifest.rendered_prompt_hash.value, /^[a-f0-9]{64}$/);
+    assert.equal(persisted.review_metadata.audit_manifest.request.model, persisted.model);
+    assert.match(persisted.review_metadata.audit_manifest.prompt_builder.plugin_commit, /^[a-f0-9]{40}$/);
+    assert.notEqual(
+      persisted.review_metadata.audit_manifest.prompt_builder.plugin_commit,
+      persisted.review_metadata.audit_manifest.git_identity.head_sha,
+      "plugin_commit must identify the plugin source, not the reviewed repository head"
+    );
+    assert.equal(persisted.review_metadata.audit_manifest.scope_resolution.scope, persisted.scope);
+    assert.equal(persisted.review_metadata.audit_manifest.selected_source.files.length > 0, true);
+    assert.equal(JSON.stringify(persisted.review_metadata.audit_manifest).includes("review: x=1"), false);
+    assert.equal(JSON.stringify(persisted.review_metadata.audit_manifest).includes("seed\\n"), false);
   }));
 }

--- a/tests/unit/docs-contracts.test.mjs
+++ b/tests/unit/docs-contracts.test.mjs
@@ -108,6 +108,18 @@ test("artifact cleanup inventory covers every provider, review mode, and owned a
   assert.match(doc, /starttime.*argv0/s);
 });
 
+test("README documents cache doctor automation for stale plugin skill discovery", () => {
+  const readme = readRepoFile("README.md");
+  const pkg = JSON.parse(readRepoFile("package.json"));
+
+  assert.match(pkg.scripts["doctor:cache"] ?? "", /codex-plugin-cache-doctor\.mjs/);
+  assert.match(readme, /npm run doctor:cache/);
+  assert.match(readme, /codex plugin marketplace upgrade codex-plugin-multi/);
+  assert.match(readme, /second-codex/i);
+  assert.match(readme, /restart/i);
+  assert.match(readme, /codex debug prompt-input 'list skills'/);
+});
+
 test("claude review command docs use current mutation schema fields", () => {
   const docs = [
     readRepoFile("plugins/claude/commands/claude-review.md"),

--- a/tests/unit/job-record.test.mjs
+++ b/tests/unit/job-record.test.mjs
@@ -68,7 +68,7 @@ function notSentSpawnFailed(provider) {
   return `Selected source content was not sent to ${provider}; the target process was not spawned.`;
 }
 
-test("JobRecord schema_version is bumped for delegated review metadata", () => {
+test("JobRecord schema_version is bumped for delegated review metadata and runtime diagnostics", () => {
   assert.equal(SCHEMA_VERSION, 10);
   assert.equal(GEMINI_SCHEMA_VERSION, 10);
   assert.equal(KIMI_SCHEMA_VERSION, 10);
@@ -94,7 +94,7 @@ function makeInvocation(overrides = {}) {
     scope_paths: null,
     prompt_head: "review: x=1",
     review_prompt_contract_version: 1,
-    review_prompt_provider: "Claude",
+    review_prompt_provider: "Claude Code",
     schema_spec: null,
     binary: "claude",
     started_at: "2026-04-24T12:00:00.000Z",
@@ -139,6 +139,7 @@ test("EXPECTED_KEYS is the spec §21.3 canonical list", () => {
     "prompt_head", "review_metadata", "schema_spec", "binary",
     "status", "started_at", "ended_at", "exit_code", "error_code", "error_message",
     "error_summary", "error_cause", "suggested_action", "external_review", "disclosure_note",
+    "runtime_diagnostics",
     "result", "structured_output", "permission_denials", "mutations",
     "cost_usd", "usage",
     "schema_version",
@@ -179,6 +180,20 @@ test("buildJobRecord: foreground success path has EXACTLY the expected keys", ()
   assert.deepEqual(rec.permission_denials, []);
   assert.deepEqual(rec.mutations, []);
   assert.equal(rec.prompt_head, "review: x=1");
+  assert.deepEqual(rec.review_metadata, {
+    prompt_contract_version: 1,
+    prompt_provider: "Claude Code",
+    scope: "working-tree",
+    scope_base: null,
+    scope_paths: null,
+    raw_output: {
+      stdout_bytes: 0,
+      stderr_bytes: 0,
+      parsed_ok: true,
+      result_chars: 4,
+    },
+    audit_manifest: null,
+  });
   assert.equal("prompt" in rec, false,
     "§21.3.1 forbids a full `prompt` field on persisted records");
   assert.equal(rec.claude_session_id, CLAUDE_UUID,
@@ -204,6 +219,38 @@ test("buildJobRecord: foreground success path has EXACTLY the expected keys", ()
   });
   assert.equal(rec.schema_version, SCHEMA_VERSION);
   assert.equal(rec.id, rec.job_id, "id is legacy alias for job_id");
+});
+
+test("buildJobRecord: review_metadata persists privacy-safe audit manifests for every companion", () => {
+  const auditManifest = Object.freeze({
+    schema_version: 1,
+    rendered_prompt_hash: { algorithm: "sha256", value: "a".repeat(64) },
+    selected_source: { files: [], totals: { files: 0, bytes: 0, lines: 0 } },
+  });
+  const parsed = { ok: true, result: "Verdict: approve", structured: null, denials: [] };
+  const providers = [
+    [
+      buildJobRecord,
+      makeInvocation(),
+      { parsed, pidInfo: makePidInfo(), claudeSessionId: CLAUDE_UUID, stdout: "ok", stderr: "" },
+    ],
+    [
+      buildGeminiJobRecord,
+      makeInvocation({ target: "gemini", binary: "gemini", review_prompt_provider: "Gemini CLI" }),
+      { parsed, pidInfo: makePidInfo(), geminiSessionId: GEMINI_UUID, stdout: "ok", stderr: "" },
+    ],
+    [
+      buildKimiJobRecord,
+      makeInvocation({ target: "kimi", binary: "kimi", review_prompt_provider: "Kimi Code" }),
+      { parsed, pidInfo: makePidInfo(), kimiSessionId: "kimi-session-123", stdout: "ok", stderr: "" },
+    ],
+  ];
+
+  for (const [providerBuildJobRecord, invocation, execution] of providers) {
+    const rec = providerBuildJobRecord(invocation, { ...execution, reviewAuditManifest: auditManifest }, []);
+    assert.equal(rec.review_metadata.audit_manifest, auditManifest);
+    assert.equal(JSON.stringify(rec).includes("full prompt text"), false);
+  }
 });
 
 test("buildJobRecord: queued/pre-run state (no execution)", () => {
@@ -302,6 +349,236 @@ test("buildJobRecord: running state preserves pid_info and has no end time", () 
   assert.equal(rec.result, null);
   assert.equal(rec.error_code, null);
   assert.equal(rec.error_message, null);
+  assert.equal(rec.runtime_diagnostics, null);
+});
+
+test("buildJobRecord: persists runtime diagnostics and classifies permission-denial targets", () => {
+  const addDir = "/tmp/claude-worktree-abc123";
+  const rec = buildJobRecord(makeInvocation({
+    scope: "custom",
+    scope_paths: ["PR23.diff"],
+  }), {
+    exitCode: 0,
+    parsed: {
+      ok: true,
+      result: "done",
+      structured: null,
+      denials: [
+        { tool: "Read", target: "/tmp/claude-worktree-abc123/PR23.diff" },
+        { name: "Read", path: "/tmp/claude-worktree-abc123/other.diff" },
+        "/tmp/claude-worktree-abc123",
+        { tool: "Read", target: "/tmp/src/private.log" },
+        { tool: "Read", file: "relative-private.log" },
+        { tool: "Bash", command: "pwd" },
+      ],
+      costUsd: null,
+      usage: null,
+    },
+    pidInfo: makePidInfo(),
+    claudeSessionId: CLAUDE_UUID,
+    runtimeDiagnostics: {
+      add_dir: addDir,
+      child_cwd: addDir,
+      scope_path_mappings: [{
+        original: "/tmp/src/PR23.diff",
+        contained: "/tmp/claude-worktree-abc123/PR23.diff",
+        relative: "PR23.diff",
+        inside_add_dir: true,
+      }],
+    },
+  }, []);
+
+  assert.deepEqual(rec.runtime_diagnostics.scope_path_mappings, [{
+    original: "/tmp/src/PR23.diff",
+    contained: "/tmp/claude-worktree-abc123/PR23.diff",
+    relative: "PR23.diff",
+    inside_add_dir: true,
+  }]);
+  assert.deepEqual(rec.runtime_diagnostics.permission_denials, [
+    {
+      tool: "Read",
+      target: "/tmp/claude-worktree-abc123/PR23.diff",
+      inside_add_dir: true,
+      relative_to_add_dir: "PR23.diff",
+    },
+    {
+      tool: "Read",
+      target: "/tmp/claude-worktree-abc123/other.diff",
+      inside_add_dir: true,
+      relative_to_add_dir: "other.diff",
+    },
+    {
+      tool: null,
+      target: "/tmp/claude-worktree-abc123",
+      inside_add_dir: true,
+      relative_to_add_dir: ".",
+    },
+    {
+      tool: "Read",
+      target: "/tmp/src/private.log",
+      inside_add_dir: false,
+      relative_to_add_dir: null,
+    },
+    {
+      tool: "Read",
+      target: "relative-private.log",
+      inside_add_dir: null,
+      relative_to_add_dir: null,
+    },
+    {
+      tool: "Bash",
+      target: null,
+      inside_add_dir: null,
+      relative_to_add_dir: null,
+    },
+  ]);
+});
+
+test("gemini buildJobRecord: persists runtime diagnostics and classifies permission-denial targets", () => {
+  const addDir = "/tmp/gemini-worktree-abc123";
+  const rec = buildGeminiJobRecord(makeInvocation({
+    target: "gemini",
+    binary: "gemini",
+    scope: "custom",
+    scope_paths: ["PR23.diff"],
+  }), {
+    exitCode: 0,
+    parsed: {
+      ok: true,
+      result: "done",
+      structured: null,
+      denials: [
+        { name: "Read", path: "/tmp/gemini-worktree-abc123/PR23.diff" },
+        "/tmp/src/private.log",
+      ],
+    },
+    pidInfo: makePidInfo(),
+    geminiSessionId: GEMINI_UUID,
+    runtimeDiagnostics: {
+      add_dir: addDir,
+      child_cwd: addDir,
+      scope_path_mappings: [{
+        original: "/tmp/src/PR23.diff",
+        contained: "/tmp/gemini-worktree-abc123/PR23.diff",
+        relative: "PR23.diff",
+        inside_add_dir: true,
+      }],
+    },
+  }, []);
+
+  assert.deepEqual(rec.runtime_diagnostics.permission_denials, [
+    {
+      tool: "Read",
+      target: "/tmp/gemini-worktree-abc123/PR23.diff",
+      inside_add_dir: true,
+      relative_to_add_dir: "PR23.diff",
+    },
+    {
+      tool: null,
+      target: "/tmp/src/private.log",
+      inside_add_dir: false,
+      relative_to_add_dir: null,
+    },
+  ]);
+});
+
+test("kimi buildJobRecord: persists runtime diagnostics and classifies permission-denial targets", () => {
+  const addDir = "/tmp/kimi-worktree-abc123";
+  const rec = buildKimiJobRecord(makeInvocation({
+    target: "kimi",
+    binary: "kimi",
+    scope: "custom",
+    scope_paths: ["PR23.diff"],
+  }), {
+    exitCode: 0,
+    parsed: {
+      ok: true,
+      result: "done",
+      structured: null,
+      denials: [
+        { tool: "Read", file_path: "/tmp/kimi-worktree-abc123/PR23.diff" },
+        { name: "Read", file: "/tmp/kimi-worktree-abc123" },
+        "/tmp/src/private.log",
+        { tool: "Bash", command: "pwd" },
+      ],
+    },
+    pidInfo: makePidInfo(),
+    kimiSessionId: "kimi-session-123",
+    runtimeDiagnostics: {
+      add_dir: addDir,
+      child_cwd: addDir,
+      scope_path_mappings: [{
+        original: "/tmp/src/PR23.diff",
+        contained: "/tmp/kimi-worktree-abc123/PR23.diff",
+        relative: "PR23.diff",
+        inside_add_dir: true,
+      }],
+    },
+  }, []);
+
+  assert.deepEqual(rec.runtime_diagnostics.permission_denials, [
+    {
+      tool: "Read",
+      target: "/tmp/kimi-worktree-abc123/PR23.diff",
+      inside_add_dir: true,
+      relative_to_add_dir: "PR23.diff",
+    },
+    {
+      tool: "Read",
+      target: "/tmp/kimi-worktree-abc123",
+      inside_add_dir: true,
+      relative_to_add_dir: ".",
+    },
+    {
+      tool: null,
+      target: "/tmp/src/private.log",
+      inside_add_dir: false,
+      relative_to_add_dir: null,
+    },
+    {
+      tool: "Bash",
+      target: null,
+      inside_add_dir: null,
+      relative_to_add_dir: null,
+    },
+  ]);
+});
+
+test("buildJobRecord: malformed runtime diagnostics normalize to privacy-safe empty diagnostics", () => {
+  const providers = [
+    [buildJobRecord, makeInvocation(), { claudeSessionId: CLAUDE_UUID }],
+    [
+      buildGeminiJobRecord,
+      makeInvocation({ target: "gemini", binary: "gemini" }),
+      { geminiSessionId: GEMINI_UUID },
+    ],
+    [
+      buildKimiJobRecord,
+      makeInvocation({ target: "kimi", binary: "kimi" }),
+      { kimiSessionId: "kimi-session-123" },
+    ],
+  ];
+
+  for (const [providerBuildJobRecord, invocation, sessionFields] of providers) {
+    const rec = providerBuildJobRecord(invocation, {
+      exitCode: 0,
+      parsed: { ok: true, result: "done", structured: null, denials: "not-an-array" },
+      pidInfo: makePidInfo(),
+      runtimeDiagnostics: {
+        add_dir: 42,
+        child_cwd: false,
+        scope_path_mappings: "not-an-array",
+      },
+      ...sessionFields,
+    }, []);
+
+    assert.deepEqual(rec.runtime_diagnostics, {
+      add_dir: null,
+      child_cwd: null,
+      scope_path_mappings: [],
+      permission_denials: [],
+    });
+  }
 });
 
 test("buildJobRecord: gemini success path stores gemini_session_id, not claude_session_id", () => {
@@ -749,6 +1026,31 @@ test("kimi buildJobRecord: step-limit exhaustion is actionable, not parse_error"
   assert.match(rec.error_summary, /step limit/i);
   assert.match(rec.suggested_action, /higher step budget/i);
   assert.match(rec.suggested_action, /narrower scope/i);
+});
+
+test("kimi buildJobRecord: usage limits are actionable and documented", () => {
+  const rec = buildKimiJobRecord(makeInvocation({ target: "kimi", binary: "kimi" }), {
+    exitCode: 1,
+    parsed: {
+      ok: false,
+      reason: "usage_limited",
+      error: "Credit limit exceeded. Usage will reset next billing cycle.",
+      result: null,
+      structured: null,
+      denials: [],
+    },
+    pidInfo: makePidInfo(),
+    kimiSessionId: null,
+  }, []);
+  assert.equal(rec.status, "failed");
+  assert.equal(rec.error_code, "usage_limited");
+  assert.equal(rec.error_message, "Credit limit exceeded. Usage will reset next billing cycle.");
+  assert.match(rec.error_summary, /usage limit/i);
+  assert.match(rec.error_cause, /quota|billing|usage/i);
+  assert.match(rec.suggested_action, /usage/i);
+  const skill = readFileSync(resolvePath("plugins/claude/skills/claude-result-handling/SKILL.md"), "utf8");
+  assert.match(skill, /"usage_limited"/);
+  assert.match(skill, /`usage_limited`/);
 });
 
 test("kimi buildJobRecord: timeout diagnostics use Claude target display name", () => {

--- a/tests/unit/kimi-dispatcher.test.mjs
+++ b/tests/unit/kimi-dispatcher.test.mjs
@@ -160,6 +160,18 @@ test("parseKimiResult: preserves embedded max-step text in successful JSON outpu
   assert.equal(parsed.sessionId, KIMI_SESSION_ID);
 });
 
+test("parseKimiResult: preserves successful review text that mentions quota", () => {
+  const parsed = parseKimiResult(
+    `{"content":"Verdict: PASS. Check quota and billing cycle handling.","session_id":"${KIMI_SESSION_ID}"}\n`,
+    "",
+    { exitCode: 0 },
+  );
+
+  assert.equal(parsed.ok, true);
+  assert.match(parsed.result, /quota and billing cycle/);
+  assert.equal(parsed.sessionId, KIMI_SESSION_ID);
+});
+
 test("parseKimiResult: tolerates null options argument", () => {
   const parsed = parseKimiResult(
     `{"content":"partial","session_id":"${KIMI_SESSION_ID}"}\nMax number of steps reached: 8\n`,
@@ -170,6 +182,32 @@ test("parseKimiResult: tolerates null options argument", () => {
   assert.equal(parsed.ok, true);
   assert.equal(parsed.result, "partial");
   assert.equal(parsed.sessionId, KIMI_SESSION_ID);
+});
+
+test("parseKimiResult: classifies plain-text usage limit failures before JSON parsing", () => {
+  const parsed = parseKimiResult(
+    "Error code: 403\nYou've reached your usage limit for this billing cycle.\n",
+    "",
+    { exitCode: 1 },
+  );
+
+  assert.equal(parsed.ok, false);
+  assert.equal(parsed.reason, "usage_limited");
+  assert.match(parsed.error, /usage limit/i);
+  assert.doesNotMatch(parsed.error, /not valid JSON|Unexpected token/);
+});
+
+test("parseKimiResult: classifies stderr-only usage limit failures", () => {
+  const parsed = parseKimiResult(
+    "",
+    "Error code: 403\nYou've reached your usage limit for this billing cycle.\n",
+    { exitCode: 1 },
+  );
+
+  assert.equal(parsed.ok, false);
+  assert.equal(parsed.reason, "usage_limited");
+  assert.match(parsed.error, /usage limit/i);
+  assert.equal(parsed.raw, "");
 });
 
 test("buildKimiArgs: review modes use safer max-step defaults and allow overrides", () => {

--- a/tests/unit/plugin-cache-doctor.test.mjs
+++ b/tests/unit/plugin-cache-doctor.test.mjs
@@ -1,0 +1,78 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const DOCTOR = path.join(REPO_ROOT, "scripts", "codex-plugin-cache-doctor.mjs");
+
+function writeSkill(root, plugin, skill) {
+  const dir = path.join(root, plugin, "skills", skill);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path.join(dir, "SKILL.md"), `---\nname: ${skill}\n---\n`, "utf8");
+}
+
+function writeCachedSkill(home, plugin, skill) {
+  const dir = path.join(home, "plugins", "cache", "codex-plugin-multi", plugin, "0.1.0", "skills", skill);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path.join(dir, "SKILL.md"), `---\nname: ${skill}\n---\n`, "utf8");
+}
+
+function writeConfig(home, plugin, enabled = true) {
+  mkdirSync(home, { recursive: true });
+  writeFileSync(
+    path.join(home, "config.toml"),
+    `[plugins."${plugin}@codex-plugin-multi"]\nenabled = ${enabled ? "true" : "false"}\n`,
+    "utf8",
+  );
+}
+
+test("codex plugin cache doctor reports stale cache, enablement, and restart guidance", () => {
+  const repo = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-repo-"));
+  const primary = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-primary-"));
+  const second = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-second-"));
+  const marketplace = path.join(primary, ".tmp", "marketplaces", "codex-plugin-multi", "plugins");
+
+  writeSkill(path.join(repo, "plugins"), "grok", "grok-review");
+  writeSkill(marketplace, "grok", "grok-review");
+  writeCachedSkill(primary, "grok", "grok-delegation");
+  writeCachedSkill(second, "grok", "grok-review");
+  writeConfig(primary, "grok", true);
+  writeConfig(second, "grok", false);
+
+  const stdout = execFileSync(process.execPath, [
+    DOCTOR,
+    "--repo", repo,
+    "--codex-home", primary,
+    "--second-codex-home", second,
+    "--plugin", "grok",
+  ], { encoding: "utf8" });
+  const report = JSON.parse(stdout);
+
+  assert.equal(report.ok, false);
+  assert.equal(report.marketplace.present, true);
+  assert.equal(report.profiles.primary.enabled, true);
+  assert.equal(report.profiles.primary.cache_in_sync, false);
+  assert.deepEqual(report.profiles.primary.missing_skills, ["grok-review"]);
+  assert.equal(report.profiles.second.enabled, false);
+  assert.equal(report.profiles.second.cache_in_sync, true);
+  assert.match(report.next_actions.join("\n"), /codex plugin marketplace upgrade codex-plugin-multi/);
+  assert.match(report.next_actions.join("\n"), /restart/i);
+  assert.match(report.next_actions.join("\n"), /codex debug prompt-input 'list skills'/);
+});
+
+test("codex plugin cache doctor rejects unsafe or missing option values", () => {
+  for (const args of [
+    ["--__proto__", "polluted"],
+    ["--constructor", "polluted"],
+    ["--repo"],
+    ["--plugin"],
+  ]) {
+    const result = spawnSync(process.execPath, [DOCTOR, ...args], { encoding: "utf8" });
+    assert.notEqual(result.status, 0, `${args.join(" ")} must fail`);
+    assert.equal({}.polluted, undefined);
+  }
+});

--- a/tests/unit/review-prompt.test.mjs
+++ b/tests/unit/review-prompt.test.mjs
@@ -5,8 +5,11 @@ import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
 import {
-  buildReviewPrompt,
+  REVIEW_AUDIT_MANIFEST_VERSION,
   REVIEW_PROMPT_CHECKLIST,
+  buildReviewAuditManifest,
+  buildReviewPrompt,
+  scopeResolutionReason,
 } from "../../scripts/lib/review-prompt.mjs";
 
 const REVIEW_PROMPT_MODULES = Object.freeze([
@@ -20,17 +23,17 @@ const REVIEW_PROMPT_MODULES = Object.freeze([
 
 test("review prompt packaging copies match the shared source byte-for-byte", () => {
   const shared = readFileSync(resolve("scripts/lib/review-prompt.mjs"), "utf8");
-  for (const [name, path] of REVIEW_PROMPT_MODULES.slice(1)) {
-    assert.equal(readFileSync(resolve(path), "utf8"), shared, `${name} review-prompt copy drifted`);
+  for (const [name, file] of REVIEW_PROMPT_MODULES.slice(1)) {
+    assert.equal(readFileSync(resolve(file), "utf8"), shared, `${name} review-prompt copy drifted`);
   }
 });
 
-for (const [name, path] of REVIEW_PROMPT_MODULES) {
-  test(`review prompt contract includes exact base/head/scope/checklist metadata (${name})`, async () => {
+for (const [name, file] of REVIEW_PROMPT_MODULES) {
+  test(`review prompt contract includes exact identity and checklist metadata (${name})`, async () => {
     const {
-      buildReviewPrompt: targetBuildReviewPrompt,
       REVIEW_PROMPT_CHECKLIST: targetChecklist,
-    } = await import(pathToFileURL(resolve(path)).href);
+      buildReviewPrompt: targetBuildReviewPrompt,
+    } = await import(pathToFileURL(resolve(file)).href);
     assert.deepEqual(targetChecklist, REVIEW_PROMPT_CHECKLIST);
     assertReviewPromptContract(targetBuildReviewPrompt, targetChecklist);
   });
@@ -38,7 +41,7 @@ for (const [name, path] of REVIEW_PROMPT_MODULES) {
 
 function assertReviewPromptContract(targetBuildReviewPrompt = buildReviewPrompt, targetChecklist = REVIEW_PROMPT_CHECKLIST) {
   const prompt = targetBuildReviewPrompt({
-    provider: "Gemini",
+    provider: "Gemini CLI",
     mode: "adversarial-review",
     repository: "seungpyoson/codex-plugin-multi",
     baseRef: "origin/main",
@@ -50,7 +53,7 @@ function assertReviewPromptContract(targetBuildReviewPrompt = buildReviewPrompt,
     userPrompt: "Focus on control-flow bugs.",
   });
 
-  assert.match(prompt, /Provider: Gemini/);
+  assert.match(prompt, /Provider: Gemini CLI/);
   assert.match(prompt, /Mode: adversarial-review/);
   assert.match(prompt, /Repository: seungpyoson\/codex-plugin-multi/);
   assert.match(prompt, /Base ref: origin\/main/);
@@ -67,4 +70,192 @@ function assertReviewPromptContract(targetBuildReviewPrompt = buildReviewPrompt,
   assert.match(prompt, /Blocking findings first/);
   assert.match(prompt, /Timed out, truncated, interrupted, blocked, or shallow output is NOT an approval/);
   assert.match(prompt, /User prompt:\nFocus on control-flow bugs\./);
+}
+
+for (const [name, file] of REVIEW_PROMPT_MODULES) {
+  test(`review audit manifest stores hashes and counts without prompt or source text (${name})`, async () => {
+    const {
+      REVIEW_AUDIT_MANIFEST_VERSION: targetManifestVersion,
+      buildReviewAuditManifest: targetBuildReviewAuditManifest,
+    } = await import(pathToFileURL(resolve(file)).href);
+    assertReviewAuditManifest(targetBuildReviewAuditManifest, targetManifestVersion);
+  });
+
+  test(`review audit manifest source hashes are byte-accurate for buffers (${name})`, async () => {
+    const {
+      buildReviewAuditManifest: targetBuildReviewAuditManifest,
+    } = await import(pathToFileURL(resolve(file)).href);
+    const manifest = targetBuildReviewAuditManifest({
+      prompt: "prompt",
+      sourceFiles: [
+        { path: "asset.bin", content: Buffer.from([0xff, 0x00, 0x0a, 0x41]) },
+      ],
+    });
+
+    assert.deepEqual(manifest.selected_source.files.map((file) => ({
+      path: file.path,
+      bytes: file.bytes,
+      lines: file.lines,
+      hash: file.content_hash.value,
+    })), [
+      {
+        path: "asset.bin",
+        bytes: 4,
+        lines: 2,
+        hash: "db8b50cdd33e826dfdbd1bc0a7f3650352a9f5f160a4be00104133360c2375ac",
+      },
+    ]);
+  });
+
+  test(`review audit manifest quality parser covers bounded token branches (${name})`, async () => {
+    const {
+      buildReviewAuditManifest: targetBuildReviewAuditManifest,
+    } = await import(pathToFileURL(resolve(file)).href);
+    const manifest = targetBuildReviewAuditManifest({
+      prompt: "prompt",
+      sourceFiles: [
+        { path: "crlf.txt", text: "one\rtwo\r\nthree\n" },
+      ],
+      result: [
+        "verdict missing colon",
+        "Summary : rejected after review",
+        "approved_by_cache should not count as a verdict token",
+        "- NOT REVIEWED item",
+        "* FAIL item",
+        "1) PASS item",
+        "2 PASS missing delimiter",
+        "3. PASS_THROUGH should not count",
+        "Blocking findings",
+        "Residual risks",
+      ].join("\r\n"),
+      status: "completed",
+    });
+
+    assert.deepEqual(manifest.selected_source.totals, { files: 1, bytes: 15, lines: 3 });
+    assert.equal(manifest.review_quality.has_verdict, true);
+    assert.equal(manifest.review_quality.has_blocking_section, true);
+    assert.equal(manifest.review_quality.has_non_blocking_section, true);
+    assert.equal(manifest.review_quality.checklist_items_seen, 3);
+  });
+}
+
+function assertReviewAuditManifest(
+  targetBuildReviewAuditManifest = buildReviewAuditManifest,
+  targetManifestVersion = REVIEW_AUDIT_MANIFEST_VERSION,
+) {
+  const manifest = targetBuildReviewAuditManifest({
+    prompt: "final rendered prompt with selected source",
+    sourceFiles: [
+      { path: "src/a.js", text: "one\ntwo\n" },
+      { path: "src/b.js", text: "" },
+    ],
+    git: {
+      remote: "git@github.com:seungpyoson/codex-plugin-multi.git",
+      branch: "fix/issues-76-77-reviewer-ux",
+      baseRef: "origin/main",
+      baseCommit: "a".repeat(40),
+      headRef: "feature",
+      headCommit: "b".repeat(40),
+      diffStat: "src/a.js | 2 ++",
+    },
+    promptBuilder: {
+      contractVersion: 1,
+      pluginVersion: "0.1.0",
+      pluginCommit: "b".repeat(40),
+    },
+    request: {
+      provider: "DeepSeek",
+      model: "deepseek-v4-pro",
+      timeoutMs: 120000,
+      maxTokens: 65536,
+      temperature: 0,
+    },
+    truncation: {
+      prompt: false,
+      source: false,
+      output: true,
+      outputAtChars: 1000,
+    },
+    providerIds: {
+      requestId: "req-123",
+      sessionId: "chatcmpl-123",
+    },
+    scope: {
+      name: "branch-diff",
+      base: "origin/main",
+      paths: ["src/a.js", "src/b.js"],
+      reason: "git diff -z --name-only origin/main...HEAD --",
+    },
+    result: "Verdict: reject\nBlocking findings\n- bug\nNon-blocking concerns\n- n/a\n1. PASS\n2. PASS\n3. FAIL",
+    status: "completed",
+    errorCode: null,
+  });
+
+  assert.equal(manifest.schema_version, targetManifestVersion);
+  assert.equal(manifest.rendered_prompt_hash.algorithm, "sha256");
+  assert.match(manifest.rendered_prompt_hash.value, /^[a-f0-9]{64}$/);
+  assert.deepEqual(manifest.selected_source.totals, { files: 2, bytes: 8, lines: 2 });
+  assert.deepEqual(manifest.selected_source.files.map((file) => ({
+    path: file.path,
+    bytes: file.bytes,
+    lines: file.lines,
+    hashOk: /^[a-f0-9]{64}$/.test(file.content_hash.value),
+  })), [
+    { path: "src/a.js", bytes: 8, lines: 2, hashOk: true },
+    { path: "src/b.js", bytes: 0, lines: 0, hashOk: true },
+  ]);
+  assert.equal(manifest.git_identity.head_sha, "b".repeat(40));
+  assert.equal(manifest.prompt_builder.contract_version, 1);
+  assert.equal(manifest.request.model, "deepseek-v4-pro");
+  assert.equal(manifest.truncation.output, true);
+  assert.equal(manifest.provider_ids.session_id, "chatcmpl-123");
+  assert.equal(manifest.scope_resolution.reason, "git diff -z --name-only origin/main...HEAD --");
+  assert.equal(manifest.review_quality.has_verdict, true);
+  assert.equal(manifest.review_quality.has_blocking_section, true);
+  assert.equal(manifest.review_quality.has_non_blocking_section, true);
+  assert.equal(manifest.review_quality.checklist_items_seen >= 3, true);
+  assert.equal(JSON.stringify(manifest).includes("final rendered prompt"), false);
+  assert.equal(JSON.stringify(manifest).includes("one\\ntwo"), false);
+}
+
+test("review quality verdict ignores incidental pass/fail prose", () => {
+  const manifest = buildReviewAuditManifest({
+    prompt: "rendered prompt",
+    sourceFiles: [],
+    result: "The unit test passes, but the network request may fail under timeout.",
+    status: "completed",
+  });
+
+  assert.equal(manifest.review_quality.has_verdict, false);
+});
+
+for (const [name, file] of REVIEW_PROMPT_MODULES) {
+  test(`scope resolution reason falls back to scope name without explicit paths (${name})`, async () => {
+    const {
+      scopeResolutionReason: targetScopeResolutionReason,
+    } = file === "scripts/lib/review-prompt.mjs"
+      ? { scopeResolutionReason }
+      : await import(pathToFileURL(resolve(file)).href);
+
+    assert.equal(targetScopeResolutionReason({
+      scope: "branch-diff",
+      scope_base: "origin/main",
+      scope_paths: [],
+    }), "git diff -z --name-only origin/main...HEAD --");
+    assert.equal(targetScopeResolutionReason({
+      scope: "branch-diff",
+      scope_base: "origin/main",
+      scope_paths: ["src/a.js"],
+    }), "git diff -z --name-only origin/main...HEAD -- filtered by explicit --scope-paths");
+    assert.equal(targetScopeResolutionReason({
+      scope: "custom",
+      scope_base: null,
+      scope_paths: ["src/a.js"],
+    }), "explicit --scope-paths");
+    assert.equal(targetScopeResolutionReason({
+      scope: "working-tree",
+      scope_base: null,
+      scope_paths: [],
+    }), "working-tree");
+  });
 }

--- a/tests/unit/scope.test.mjs
+++ b/tests/unit/scope.test.mjs
@@ -1464,6 +1464,35 @@ test("populateScope scope=branch-diff: copies files changed vs base, not unrelat
   }
 });
 
+test("populateScope scope=branch-diff: scopePaths narrow changed files", () => {
+  const src = seedRepo();
+  const tgt = mkTarget();
+  try {
+    writeFileSync(path.join(src, "base.txt"), "base\n");
+    git(src, "add", ".");
+    git(src, "commit", "-qm", "main");
+    git(src, "checkout", "-qb", "feature");
+    writeFileSync(path.join(src, "wanted.md"), "wanted\n");
+    writeFileSync(path.join(src, "extra.md"), "extra\n");
+    mkdirSync(path.join(src, "nested"));
+    writeFileSync(path.join(src, "nested", "wanted.txt"), "nested\n");
+    git(src, "add", ".");
+    git(src, "commit", "-qm", "feature");
+
+    populateScope(profile("branch-diff"), src, tgt, {
+      scopeBase: "main",
+      scopePaths: ["wanted.md", "nested/*.txt"],
+    });
+
+    assert.ok(existsSync(path.join(tgt, "wanted.md")), "wanted.md missing");
+    assert.ok(existsSync(path.join(tgt, "nested", "wanted.txt")), "nested/wanted.txt missing");
+    assert.equal(existsSync(path.join(tgt, "extra.md")), false,
+      "branch-diff --scope-paths leaked an unrequested changed file");
+  } finally {
+    cleanup(src, tgt);
+  }
+});
+
 test("populateScope scope=branch-diff: fails closed when diff selects no files", () => {
   const src = seedRepo();
   const tgt = mkTarget();


### PR DESCRIPTION
## Summary

Closes #76.
Closes #77.
Closes #79.

This PR expands the #76/#77 reviewer UX work into one implementation pass:

- Adds a read-only plugin cache doctor for marketplace/cache/runtime skill drift, with explicit refresh/restart guidance instead of live-worktree execution or silent cache mutation.
- Improves reviewer runtime debuggability across Claude, DeepSeek/GLM, Grok, and Kimi:
  - Claude auth/permission/runtime diagnostics include child cwd, add-dir, scope mappings, and API-key selection context.
  - Direct API reviewers persist timeout/request-size telemetry and provider request/session identifiers where available.
  - Grok doctor distinguishes `/models` health from `/chat/completions` readiness, including model-specific bad-request classification and separate chat-probe timeout guidance.
  - Kimi classifies quota/usage-limit failures without treating successful review text that mentions quota/billing as an infrastructure failure.
- Folds in PR #75 follow-ups for richer prompt identity and smoke parity across Claude/Gemini/Kimi/API/Grok.
- Adds a privacy-safe `review_metadata.audit_manifest`:
  - hashes the exact rendered prompt without storing prompt text,
  - records selected source paths, byte/line counts, and content hashes without storing source text,
  - captures git identity, prompt builder version, request settings, truncation flags, provider IDs, scope-resolution reason, and review-quality flags.
- Tightens scoped-review behavior:
  - Claude/Gemini/Kimi branch-diff containment intersects changed files with explicit `--scope-paths` when provided.
  - API/Grok branch-diff collection now uses `git diff -z --name-only <base>...HEAD`, honors the same minimal glob subset as companion scope (`*`, `**`, `?`), and reads committed `HEAD:<path>` blobs instead of dirty live worktree files.
  - API/Grok Git calls use the existing hardened reviewer pattern, executing `/usr/bin/git` with `PATH=/usr/bin:/bin` instead of resolving `git` from ambient caller `PATH`.
  - Grok branch-diff checks committed blob sizes with `git cat-file -s` before `git show`, so oversized blobs are classified before large buffering or tunnel transmission; smoke coverage uses a >16 MiB committed file and asserts no `ENOBUFS` leak.
  - Smoke/unit coverage proves unrequested or dirty changed files are not copied, prompted, or recorded in selected-source manifests.
- Addresses Greptile/Gemini/Sonar follow-ups on audit timeout semantics, prompt contract parity, Kimi usage-limit classification, safe git invocation, cache-doctor argument parsing, review-quality parsing, API/Grok scope narrowing, and Grok explicit-scope bounded file reads.

## Follow-up Split

#83 tracks the remaining oversized reviewer-scope UX gap: provider-aware prompt/source budget preflight, explicit split/narrowing guidance, and direct API prompt-size avoidance. It is intentionally not silently truncating or auto-sharding in this PR.

#84 tracks cost/quota/usage-tier diagnosis and any future explicit purchase/upgrade workflow. It is intentionally outside this PR and must not become automatic billing mutation.

#85 tracks the latest Gemini portability-vs-hardening concern for safe Git binary resolution. This PR keeps the narrow Greptile security fix consistent with the current reviewer stack; portable Git discovery across all providers is a separate platform-contract decision.

## Privacy/Safety Notes

The audit manifest intentionally does not persist full prompts, full source bundles, raw provider payloads, cookies, API keys, or secret values. Smoke tests assert representative prompt/source substrings are absent from persisted audit manifests.

## Verification

Local verification on latest head `29486a26bc1506b36f8afaa854961c5f2c241d17`:

- `node --check plugins/api-reviewers/scripts/api-reviewer.mjs` -> pass
- `node --test --test-name-pattern "branch-diff" tests/smoke/api-reviewers.smoke.test.mjs` -> 7 pass, 0 fail
- `node --test tests/smoke/api-reviewers.smoke.test.mjs` -> 66 pass, 0 fail
- `npm run lint:sync` -> pass
- `npm run lint` -> pass
- `git diff --check` -> pass
- `npm test` -> 934 tests total; 928 pass, 0 fail, 6 skipped
- Pre-commit reran `npm test` before final amend -> 934 tests total; 928 pass, 0 fail, 6 skipped

Hosted PR checks on `29486a26bc1506b36f8afaa854961c5f2c241d17`:

- lint -> pass
- test -> pass
- smoke (claude/gemini/kimi/grok/api-reviewers) -> pass
- SonarCloud Code Analysis -> pass

Latest-head external delta review on `29486a26bc1506b36f8afaa854961c5f2c241d17`:

- Claude Code: completed on the API reviewer hardening scope, no blockers. Claude explicitly recommended shipping the Greptile security fix in this PR and tracking portability as #85. Reported cost: `$1.7073105`.
- GLM: completed on the API reviewer hardening scope, no blockers.
- Gemini CLI: completed on the same scope and raised a portability blocker against hardcoded `/usr/bin/git`; tracked as follow-up #85 rather than silently expanding this PR.
- DeepSeek: selected source was sent, but the provider timed out after `300000ms`; no verdict. Telemetry: 2 files, 127,550 bytes, about 32,486 estimated tokens, `max_tokens=65536`.
- Kimi: selected source was sent, but the provider timed out after `180000ms`; no verdict.
- Grok Web: selected source was sent, but the local tunnel returned HTTP 400 from the chat endpoint; no verdict. Telemetry: prompt about 129,708 chars.

Earlier exact-head external review on the broader PR work found no blockers from Gemini/DeepSeek on the scoped #76/#77 fixes, and #83 records the remaining oversized-scope/provider-size failures. Later DeepSeek/Kimi/Grok failures are recorded as provider/runtime failures rather than counted as approvals.