### PR TITLE
Add configurable reviewer timeouts

### DIFF
--- a/docs/reviewer-timeouts.md
+++ b/docs/reviewer-timeouts.md
@@ -1,0 +1,70 @@
+# Reviewer Timeouts
+
+External review commands use an explicit review timeout contract so long-running
+reviews fail in a debuggable way instead of depending on provider-specific
+defaults.
+
+## Default
+
+The review timeout default is `600000` ms. This applies to:
+
+- Claude companion review runs.
+- Gemini companion review runs.
+- Kimi companion review runs.
+- DeepSeek and GLM direct API reviewer requests.
+- Grok Web tunnel review requests.
+
+Doctor and ping commands keep their own shorter readiness timeouts. Those
+timeouts test local setup and tunnel health; they are not the review request
+budget.
+
+## Overrides
+
+Use the foreground companion flag when invoking companion-backed reviewers:
+
+```sh
+node plugins/claude/scripts/claude-companion.mjs run --mode=review --foreground --timeout-ms 900000 -- "<prompt>"
+node plugins/gemini/scripts/gemini-companion.mjs run --mode=review --foreground --timeout-ms 900000 -- "<prompt>"
+node plugins/kimi/scripts/kimi-companion.mjs run --mode=review --foreground --timeout-ms 900000 -- "<prompt>"
+```
+
+The same flag is accepted by companion `continue --job <id>` paths.
+
+For non-interactive wrappers, these environment variables set the same review
+timeout:
+
+- `CLAUDE_REVIEW_TIMEOUT_MS`
+- `GEMINI_REVIEW_TIMEOUT_MS`
+- `KIMI_REVIEW_TIMEOUT_MS`
+- `API_REVIEWERS_TIMEOUT_MS`
+- `GROK_WEB_TIMEOUT_MS`
+
+When both are present on companion commands, `--timeout-ms` wins over the
+provider-specific environment variable.
+
+On companion `continue --job <id>` paths, timeout precedence is:
+
+1. `--timeout-ms`
+2. provider-specific review timeout environment variable
+3. prior job runtime sidecar or audit-manifest timeout
+4. default `600000` ms
+
+## Audit Trail
+
+Every completed external review JobRecord writes the effective timeout to:
+
+```text
+review_metadata.audit_manifest.request.timeout_ms
+```
+
+Timeout failures keep provider-specific classifications:
+
+- Companion wall-clock timeout: `error_code: "timeout"`.
+- Direct API provider timeout after source transmission: `error_code: "timeout"` with `external_review.source_content_transmission: "sent"`.
+- Grok tunnel review timeout: `error_code: "tunnel_timeout"`.
+- Grok doctor chat timeout: `error_code: "grok_chat_timeout"`.
+- Ping/doctor timeouts stay on ping/doctor JSON and do not imply source was sent.
+
+Do not silently retry, extend, truncate, shard, or mutate runtime configuration.
+If a review needs a larger budget, set the timeout explicitly and rely on the
+JobRecord audit manifest to confirm the effective value.

--- a/docs/reviewer-timeouts.md
+++ b/docs/reviewer-timeouts.md
@@ -30,6 +30,13 @@ node plugins/kimi/scripts/kimi-companion.mjs run --mode=review --foreground --ti
 
 The same flag is accepted by companion `continue --job <id>` paths.
 
+Kimi also has an independent model step budget. If Kimi sends selected source
+but returns `error_code: "step_limit_exceeded"`, increasing `--timeout-ms` is
+not enough; rerun with a higher `--max-steps-per-turn <n>` or a narrower
+scope. The timeout controls wall-clock runtime, while the step budget controls
+how many Kimi tool/model steps the companion allows before preserving a failed
+JobRecord.
+
 For non-interactive wrappers, these environment variables set the same review
 timeout:
 
@@ -63,6 +70,7 @@ Timeout failures keep provider-specific classifications:
 - Direct API provider timeout after source transmission: `error_code: "timeout"` with `external_review.source_content_transmission: "sent"`.
 - Grok tunnel review timeout: `error_code: "tunnel_timeout"`.
 - Grok doctor chat timeout: `error_code: "grok_chat_timeout"`.
+- Kimi model step exhaustion after source transmission: `error_code: "step_limit_exceeded"`; use `--max-steps-per-turn <n>` or reduce scope.
 - Ping/doctor timeouts stay on ping/doctor JSON and do not imply source was sent.
 
 Do not silently retry, extend, truncate, shard, or mutate runtime configuration.

--- a/plugins/api-reviewers/commands/deepseek-adversarial-review.md
+++ b/plugins/api-reviewers/commands/deepseek-adversarial-review.md
@@ -10,4 +10,5 @@ node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider deepseek --mo
 ```
 
 `$ARGUMENTS` may include an optional `--scope-base REF` followed by prompt text. If present, pass `--scope-base REF` before `--prompt` and pass only the remaining prompt text to `--prompt`.
+The review timeout default is 600000 ms; `API_REVIEWERS_TIMEOUT_MS` is the non-interactive fallback.
 Render the returned JobRecord. Render `external_review_launched` as soon as it appears. If `external_review` is present, render it before the review result. If the JobRecord failed, report `error_code`, `error_message`, `http_status` when present, and `suggested_action`. Do not print API-key values.

--- a/plugins/api-reviewers/commands/deepseek-custom-review.md
+++ b/plugins/api-reviewers/commands/deepseek-custom-review.md
@@ -10,4 +10,5 @@ node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider deepseek --mo
 ```
 
 `$ARGUMENTS` may include `--scope-paths <files>` followed by prompt text. Pass the files to `--scope-paths`. Replace `<file1>,<file2>` with comma- or newline-separated concrete relative paths, expand globs before running, and pass only the remaining prompt text to `--prompt`.
+The review timeout default is 600000 ms; `API_REVIEWERS_TIMEOUT_MS` is the non-interactive fallback.
 Render the returned JobRecord. Render `external_review_launched` as soon as it appears. If `external_review` is present, render it before the review result. If the JobRecord failed, report `error_code`, `error_message`, `http_status` when present, and `suggested_action`. Do not print API-key values.

--- a/plugins/api-reviewers/commands/deepseek-review.md
+++ b/plugins/api-reviewers/commands/deepseek-review.md
@@ -10,4 +10,5 @@ node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider deepseek --mo
 ```
 
 `$ARGUMENTS` may include an optional `--scope-base REF` followed by prompt text. If present, pass `--scope-base REF` before `--prompt` and pass only the remaining prompt text to `--prompt`.
+The review timeout default is 600000 ms; `API_REVIEWERS_TIMEOUT_MS` is the non-interactive fallback.
 Render the returned JobRecord. Render `external_review_launched` as soon as it appears. If `external_review` is present, render it before the review result. If the JobRecord failed, report `error_code`, `error_message`, `http_status` when present, and `suggested_action`. Do not print API-key values.

--- a/plugins/api-reviewers/commands/glm-adversarial-review.md
+++ b/plugins/api-reviewers/commands/glm-adversarial-review.md
@@ -10,4 +10,5 @@ node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider glm --mode ad
 ```
 
 `$ARGUMENTS` may include an optional `--scope-base REF` followed by prompt text. If present, pass `--scope-base REF` before `--prompt` and pass only the remaining prompt text to `--prompt`.
+The review timeout default is 600000 ms; `API_REVIEWERS_TIMEOUT_MS` is the non-interactive fallback.
 Render the returned JobRecord. Render `external_review_launched` as soon as it appears. If `external_review` is present, render it before the review result. If the JobRecord failed, report `error_code`, `error_message`, `http_status` when present, and `suggested_action`. Do not print API-key values.

--- a/plugins/api-reviewers/commands/glm-custom-review.md
+++ b/plugins/api-reviewers/commands/glm-custom-review.md
@@ -10,4 +10,5 @@ node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider glm --mode cu
 ```
 
 `$ARGUMENTS` may include `--scope-paths <files>` followed by prompt text. Pass the files to `--scope-paths`. Replace `<file1>,<file2>` with comma- or newline-separated concrete relative paths, expand globs before running, and pass only the remaining prompt text to `--prompt`.
+The review timeout default is 600000 ms; `API_REVIEWERS_TIMEOUT_MS` is the non-interactive fallback.
 Render the returned JobRecord. Render `external_review_launched` as soon as it appears. If `external_review` is present, render it before the review result. If the JobRecord failed, report `error_code`, `error_message`, `http_status` when present, and `suggested_action`. Do not print API-key values.

--- a/plugins/api-reviewers/commands/glm-review.md
+++ b/plugins/api-reviewers/commands/glm-review.md
@@ -10,4 +10,5 @@ node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider glm --mode re
 ```
 
 `$ARGUMENTS` may include an optional `--scope-base REF` followed by prompt text. If present, pass `--scope-base REF` before `--prompt` and pass only the remaining prompt text to `--prompt`.
+The review timeout default is 600000 ms; `API_REVIEWERS_TIMEOUT_MS` is the non-interactive fallback.
 Render the returned JobRecord. Render `external_review_launched` as soon as it appears. If `external_review` is present, render it before the review result. If the JobRecord failed, report `error_code`, `error_message`, `http_status` when present, and `suggested_action`. Do not print API-key values.

--- a/plugins/api-reviewers/scripts/api-reviewer.mjs
+++ b/plugins/api-reviewers/scripts/api-reviewer.mjs
@@ -629,7 +629,7 @@ function parseMaxTokensOverride(env = process.env) {
 
 function parseProviderTimeoutMs(env = process.env) {
   const parsed = parsePositiveIntegerEnv(env, "API_REVIEWERS_TIMEOUT_MS", "milliseconds");
-  return parsed.value === null ? { ok: true, value: 120000 } : parsed;
+  return parsed.value === null ? { ok: true, value: 600000 } : parsed;
 }
 
 function applyRequestDefaults(requestBody, requestDefaults = {}) {
@@ -1065,32 +1065,40 @@ function requestFieldMatches(actual, expected) {
 }
 
 function mockProviderExecution(cfg, prompt, credential, env, requestBody) {
+  const diagnostics = () => ({
+    configured_timeout_ms: parseProviderTimeoutMs(env).value,
+    prompt_chars: prompt.length,
+    request_defaults: summarizeRequestDefaults(cfg.request_defaults),
+    max_tokens: requestBody.max_tokens ?? null,
+    temperature: requestBody.temperature ?? null,
+  });
   const expectedPromptText = env.API_REVIEWERS_MOCK_ASSERT_PROMPT_INCLUDES;
   if (expectedPromptText && !prompt.includes(expectedPromptText)) {
-    return providerFailure("mock_assertion_failed", `prompt missing expected text: ${expectedPromptText}`, 200, null, false);
+    return providerFailureWithDiagnostics("mock_assertion_failed", `prompt missing expected text: ${expectedPromptText}`, 200, null, false, diagnostics());
   }
   if (env.API_REVIEWERS_MOCK_ASSERT_REQUEST_BODY) {
     const parsedExpected = parseJson(env.API_REVIEWERS_MOCK_ASSERT_REQUEST_BODY);
     if (!parsedExpected.ok || !parsedExpected.value || typeof parsedExpected.value !== "object" || Array.isArray(parsedExpected.value)) {
-      return providerFailure("mock_assertion_failed", "API_REVIEWERS_MOCK_ASSERT_REQUEST_BODY must be a JSON object", 200, null, false);
+      return providerFailureWithDiagnostics("mock_assertion_failed", "API_REVIEWERS_MOCK_ASSERT_REQUEST_BODY must be a JSON object", 200, null, false, diagnostics());
     }
     for (const [key, expected] of Object.entries(parsedExpected.value)) {
       if (!requestFieldMatches(requestBody[key], expected)) {
-        return providerFailure(
+        return providerFailureWithDiagnostics(
           "mock_assertion_failed",
           `request body field ${key} expected ${JSON.stringify(expected)} but got ${JSON.stringify(requestBody[key])}`,
           200,
           null,
-          false
+          false,
+          diagnostics()
         );
       }
     }
   }
   const parsed = parseJson(env.API_REVIEWERS_MOCK_RESPONSE);
-  if (!parsed.ok) return providerFailure("malformed_response", parsed.error, 200, null, false);
+  if (!parsed.ok) return providerFailureWithDiagnostics("malformed_response", parsed.error, 200, null, false, diagnostics());
   const content = parsed.value?.choices?.[0]?.message?.content;
   if (typeof content !== "string") {
-    return providerFailure("malformed_response", "response did not include choices[0].message.content", 200, parsed.value, false);
+    return providerFailureWithDiagnostics("malformed_response", "response did not include choices[0].message.content", 200, parsed.value, false, diagnostics());
   }
   return {
     exitCode: 0,
@@ -1104,13 +1112,7 @@ function mockProviderExecution(cfg, prompt, credential, env, requestBody) {
     http_status: 200,
     credential_ref: credential.keyName,
     endpoint: baseUrlFor(cfg),
-    diagnostics: {
-      configured_timeout_ms: parseProviderTimeoutMs(env).value,
-      prompt_chars: prompt.length,
-      request_defaults: summarizeRequestDefaults(cfg.request_defaults),
-      max_tokens: requestBody.max_tokens ?? null,
-      temperature: requestBody.temperature ?? null,
-    },
+    diagnostics: diagnostics(),
   };
 }
 
@@ -1126,13 +1128,26 @@ async function callProvider(provider, cfg, prompt, env = process.env) {
   };
   const defaultsResult = applyRequestDefaults(requestBody, cfg.request_defaults);
   if (!defaultsResult.ok) {
-    return providerFailure("bad_args", defaultsResult.error, null, null, false);
+    return providerFailureWithDiagnostics("bad_args", defaultsResult.error, null, null, false, {
+      configured_timeout_ms: timeoutMs.value,
+      prompt_chars: prompt.length,
+      request_defaults: summarizeRequestDefaults(cfg.request_defaults),
+      max_tokens: requestBody.max_tokens ?? null,
+      temperature: requestBody.temperature ?? null,
+    });
   }
   if (maxTokensOverride.value !== null) {
     requestBody.max_tokens = maxTokensOverride.value;
   } else if (!Object.hasOwn(requestBody, "max_tokens")) {
     requestBody.max_tokens = 4096;
   }
+  const diagnostics = () => ({
+    configured_timeout_ms: timeoutMs.value,
+    prompt_chars: prompt.length,
+    request_defaults: summarizeRequestDefaults(cfg.request_defaults),
+    max_tokens: requestBody.max_tokens ?? null,
+    temperature: requestBody.temperature ?? null,
+  });
   if (env.API_REVIEWERS_MOCK_RESPONSE) {
     return mockProviderExecution(cfg, prompt, credential, env, requestBody);
   }
@@ -1153,14 +1168,28 @@ async function callProvider(provider, cfg, prompt, env = process.env) {
     const text = await response.text();
     const parsed = parseJson(text);
     if (!response.ok) {
-      return providerFailure(classifyHttpFailure(response.status, parsed), providerErrorMessage(parsed, text, redact), response.status, parsed, true);
+      return providerFailureWithDiagnostics(
+        classifyHttpFailure(response.status, parsed),
+        providerErrorMessage(parsed, text, redact),
+        response.status,
+        parsed,
+        true,
+        diagnostics(),
+      );
     }
     if (!parsed.ok) {
-      return providerFailure("malformed_response", parsed.error, response.status, null, true);
+      return providerFailureWithDiagnostics("malformed_response", parsed.error, response.status, null, true, diagnostics());
     }
     const content = parsed.value?.choices?.[0]?.message?.content;
     if (typeof content !== "string") {
-      return providerFailure("malformed_response", "response did not include choices[0].message.content", response.status, parsed.value, true);
+      return providerFailureWithDiagnostics(
+        "malformed_response",
+        "response did not include choices[0].message.content",
+        response.status,
+        parsed.value,
+        true,
+        diagnostics(),
+      );
     }
     return {
       exitCode: 0,
@@ -1174,13 +1203,7 @@ async function callProvider(provider, cfg, prompt, env = process.env) {
       http_status: response.status,
       credential_ref: credential.keyName,
       endpoint: baseUrlFor(cfg),
-      diagnostics: {
-        configured_timeout_ms: timeoutMs.value,
-        prompt_chars: prompt.length,
-        request_defaults: summarizeRequestDefaults(cfg.request_defaults),
-        max_tokens: requestBody.max_tokens ?? null,
-        temperature: requestBody.temperature ?? null,
-      },
+      diagnostics: diagnostics(),
     };
   } catch (e) {
     const reason = e?.name === "AbortError" ? "timeout" : "provider_unavailable";
@@ -1191,12 +1214,8 @@ async function callProvider(provider, cfg, prompt, env = process.env) {
       null,
       payloadSentForProviderException(e),
       {
-        configured_timeout_ms: timeoutMs.value,
+        ...diagnostics(),
         elapsed_ms: Date.now() - started,
-        prompt_chars: prompt.length,
-        request_defaults: summarizeRequestDefaults(cfg.request_defaults),
-        max_tokens: requestBody.max_tokens ?? null,
-        temperature: requestBody.temperature ?? null,
       },
     );
   } finally {
@@ -1410,6 +1429,7 @@ function buildReviewMetadata(cfg, scopeInfo, execution = null) {
       timeoutMs: execution.diagnostics?.configured_timeout_ms ?? null,
       maxTokens: execution.diagnostics?.max_tokens ?? null,
       temperature: execution.diagnostics?.temperature ?? null,
+      stream: false,
     },
     truncation: {
       prompt: false,

--- a/plugins/api-reviewers/skills/deepseek-review/SKILL.md
+++ b/plugins/api-reviewers/skills/deepseek-review/SKILL.md
@@ -15,4 +15,5 @@ node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider deepseek --mo
 ```
 
 If the user provides a base ref, add `--scope-base REF` before `--prompt`. `<focus>` is the user's review prompt or focus area.
+The review timeout default is 600000 ms; `API_REVIEWERS_TIMEOUT_MS` is the non-interactive fallback.
 Render the returned JobRecord, render `external_review_launched` as soon as it appears, then render `external_review` before the review result when present. If the JobRecord failed, report `error_code`, `error_message`, `http_status` when present, and `suggested_action`. Never print API-key values.

--- a/plugins/claude/commands/claude-adversarial-review.md
+++ b/plugins/claude/commands/claude-adversarial-review.md
@@ -1,13 +1,13 @@
 ---
 description: Get Claude Code to adversarially challenge the current design. Not a linter — a "why will this break" pass.
-argument-hint: "[--scope-base REF] [focus area]"
+argument-hint: "[--scope-base REF] [--timeout-ms MS] [focus area]"
 ---
 
 Adversarial review via Claude Code. Assumes the author is wrong; looks for failure modes, hidden assumptions, missing edge cases.
 
 ## Arguments
 
-`$ARGUMENTS` — optional `--scope-base REF` followed by focus text (e.g., "error handling", "concurrency"). If present, pass `--scope-base REF` before `--`; pass the remaining focus text after `--`.
+`$ARGUMENTS` — optional `--scope-base REF` and `--timeout-ms MS` followed by focus text (e.g., "error handling", "concurrency"). If `--scope-base REF` is present, pass `--scope-base REF` before `--`. If `--timeout-ms MS` is present, pass it before `--`. Pass the remaining focus text after `--`.
 
 ## Workflow
 
@@ -17,6 +17,7 @@ Adversarial review via Claude Code. Assumes the author is wrong; looks for failu
    node "<plugin-root>/scripts/claude-companion.mjs" run --mode=adversarial-review --foreground --lifecycle-events jsonl -- "<focus text>"
    ```
    (Containment=worktree, scope=branch-diff, dispose=true all come from the profile — spec §21.4.)
+   Review timeout defaults to 600000 ms. Use `--timeout-ms <ms>` or `CLAUDE_REVIEW_TIMEOUT_MS`; the effective value is persisted in `review_metadata.audit_manifest.request.timeout_ms`.
    `branch-diff` is object-pure: checkout filters, replace refs, and grafts are ignored.
    For a pinned review bundle, run `preflight` and then use
    `run --mode=custom-review --scope-paths <g1,g2,...>` with prompt wording

--- a/plugins/claude/commands/claude-review.md
+++ b/plugins/claude/commands/claude-review.md
@@ -1,13 +1,13 @@
 ---
 description: Get Claude Code's read-only review of the current diff, files, or focus area. Runs in a disposable worktree (default).
-argument-hint: "[--scope-base REF] [focus area]"
+argument-hint: "[--scope-base REF] [--timeout-ms MS] [focus area]"
 ---
 
 Review via Claude Code. Read-only; changes detected post-hoc, never auto-reverted.
 
 ## Arguments
 
-`$ARGUMENTS` — optional `--scope-base REF` followed by focus text. If present, pass `--scope-base REF` before `--`; pass the remaining focus text after `--`.
+`$ARGUMENTS` — optional `--scope-base REF` and `--timeout-ms MS` followed by focus text. If `--scope-base REF` is present, pass `--scope-base REF` before `--`. If `--timeout-ms MS` is present, pass it before `--`. Pass the remaining focus text after `--`.
 
 ## Workflow
 
@@ -17,6 +17,7 @@ Review via Claude Code. Read-only; changes detected post-hoc, never auto-reverte
    node "<plugin-root>/scripts/claude-companion.mjs" run --mode=review --foreground --lifecycle-events jsonl -- "<focus text>"
    ```
    (Containment + scope + dispose are all carried by the review profile — spec §21.4.)
+   Review timeout defaults to 600000 ms. Use `--timeout-ms <ms>` or `CLAUDE_REVIEW_TIMEOUT_MS`; the effective value is persisted in `review_metadata.audit_manifest.request.timeout_ms`.
    For a pinned review bundle or hand-picked files, first run `preflight`, then use
    `run --mode=custom-review --scope-paths <g1,g2,...>` and refer to files by
    relative paths inside the selected scope.

--- a/plugins/claude/scripts/claude-companion.mjs
+++ b/plugins/claude/scripts/claude-companion.mjs
@@ -77,6 +77,7 @@ configureState({
 });
 
 const MODELS_CONFIG_PATH = resolvePath(PLUGIN_ROOT, "config/models.json");
+const DEFAULT_CLAUDE_REVIEW_TIMEOUT_MS = 600000;
 const CONTINUABLE_STATUSES = new Set(["completed", "failed", "cancelled", "stale"]);
 const RUN_MODES = Object.freeze(["review", "adversarial-review", "custom-review", "rescue"]);
 const PREFLIGHT_MODES = Object.freeze(["review", "adversarial-review", "custom-review"]);
@@ -92,6 +93,21 @@ function fail(code, message, details = {}) {
   process.stderr.write(`claude-companion: ${message}\n`);
   printJson({ ok: false, error: code, message, ...details });
   process.exit(1);
+}
+
+function parseReviewTimeoutMs(cliValue, env = process.env, fallback = DEFAULT_CLAUDE_REVIEW_TIMEOUT_MS) {
+  const raw = cliValue ?? env.CLAUDE_REVIEW_TIMEOUT_MS;
+  if (raw === undefined || raw === null || raw === "") return fallback;
+  if (typeof raw !== "string") {
+    const source = cliValue === undefined ? "CLAUDE_REVIEW_TIMEOUT_MS" : "--timeout-ms";
+    fail("bad_args", `${source} must be a positive integer number of milliseconds; got ${JSON.stringify(raw)}`);
+  }
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    const source = cliValue === undefined ? "CLAUDE_REVIEW_TIMEOUT_MS" : "--timeout-ms";
+    fail("bad_args", `${source} must be a positive integer number of milliseconds; got ${JSON.stringify(raw)}`);
+  }
+  return parsed;
 }
 
 function targetPromptFor(invocation, userPrompt) {
@@ -213,7 +229,7 @@ function reviewAuditManifest(invocation, prompt, containmentPath, execution) {
     request: {
       provider: invocation.review_prompt_provider ?? "Claude Code",
       model: invocation.model,
-      timeoutMs: null,
+      timeoutMs: invocation.timeout_ms ?? null,
       maxTokens: null,
       maxStepsPerTurn: null,
       temperature: null,
@@ -309,7 +325,44 @@ function mutationDetectionFailure(error) {
 // Project an invocation out of a JobRecord (used by the background worker
 // when it re-enters executeRun). Only the invocation-phase fields are
 // carried — lifecycle/result fields get re-derived from the fresh execution.
-function invocationFromRecord(record, fallbackAuthMode = "subscription") {
+function runtimeOptionsSidecarPath(workspaceRoot, jobId) {
+  return `${resolveJobsDir(workspaceRoot)}/${jobId}/runtime-options.json`;
+}
+
+function writeRuntimeOptionsSidecar(workspaceRoot, jobId, options) {
+  const dir = `${resolveJobsDir(workspaceRoot)}/${jobId}`;
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  try {
+    chmodSync(dir, 0o700);
+  } catch (err) {
+    if (process.platform !== "win32") throw err;
+  }
+  const file = runtimeOptionsSidecarPath(workspaceRoot, jobId);
+  const tmpFile = `${file}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    writeFileSync(tmpFile, `${JSON.stringify({ timeout_ms: options.timeout_ms }, null, 2)}\n`, { mode: 0o600, encoding: "utf8" });
+    try { chmodSync(tmpFile, 0o600); } catch { /* best-effort on non-POSIX */ }
+    renameSync(tmpFile, file);
+  } catch (e) {
+    try { unlinkSync(tmpFile); } catch { /* already gone */ }
+    throw e;
+  }
+}
+
+function readRuntimeOptionsSidecar(workspaceRoot, jobId) {
+  const file = runtimeOptionsSidecarPath(workspaceRoot, jobId);
+  if (!existsSync(file)) return {};
+  try {
+    const parsed = JSON.parse(_readFileSync(file, "utf8"));
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    const timeoutMs = parsed.timeout_ms;
+    return Number.isSafeInteger(timeoutMs) && timeoutMs > 0 ? { timeout_ms: timeoutMs } : {};
+  } catch {
+    return {};
+  }
+}
+
+function invocationFromRecord(record, fallbackAuthMode = "subscription", runtimeOptions = {}) {
   return Object.freeze({
     job_id: record.job_id,
     target: record.target,
@@ -332,6 +385,10 @@ function invocationFromRecord(record, fallbackAuthMode = "subscription") {
     run_kind: runKindFromRecord(record),
     auth_mode: record.auth_mode ?? fallbackAuthMode ?? "subscription",
     binary: record.binary,
+    timeout_ms:
+      runtimeOptions.timeout_ms ??
+      record.review_metadata?.audit_manifest?.request?.timeout_ms ??
+      DEFAULT_CLAUDE_REVIEW_TIMEOUT_MS,
     started_at: record.started_at,
   });
 }
@@ -495,7 +552,7 @@ function cmdPreflight(rest) {
 // ——— subcommand: run ———
 async function cmdRun(rest) {
   const { options, positionals } = parseArgs(rest, {
-    valueOptions: ["mode", "model", "cwd", "schema", "binary", "scope-base", "scope-paths", "override-dispose", "auth-mode", "lifecycle-events"],
+    valueOptions: ["mode", "model", "cwd", "schema", "binary", "scope-base", "scope-paths", "override-dispose", "auth-mode", "timeout-ms", "lifecycle-events"],
     booleanOptions: ["background", "foreground"],
     aliasMap: {},
   });
@@ -540,6 +597,7 @@ async function cmdRun(rest) {
   } catch (e) {
     fail("bad_args", e.message);
   }
+  const timeoutMs = parseReviewTimeoutMs(options["timeout-ms"]);
   const prompt = positionals.join(" ").trim();
   if (!prompt) {
     fail("bad_args", "prompt is required (pass after -- separator)");
@@ -573,6 +631,7 @@ async function cmdRun(rest) {
     prompt_head: prompt.slice(0, 200),          // §21.3.1 — no full prompt
     review_prompt_contract_version: profile.name === "rescue" ? null : REVIEW_PROMPT_CONTRACT_VERSION,
     review_prompt_provider: profile.name === "rescue" ? null : "Claude Code",
+    timeout_ms: timeoutMs,
     schema_spec: options.schema ?? null,
     binary: options.binary ?? process.env.CLAUDE_BINARY ?? "claude",
     run_kind: options.background ? "background" : "foreground",
@@ -593,6 +652,7 @@ async function cmdRun(rest) {
     // and deletes — prompt text does NOT live on the JobRecord.
     try {
       writePromptSidecar(resolveJobsDir(workspaceRoot), jobId, targetPrompt);
+      writeRuntimeOptionsSidecar(workspaceRoot, jobId, { timeout_ms: timeoutMs });
     } catch (error) {
       failBackgroundPromptSidecarWrite(workspaceRoot, invocation, error);
     }
@@ -765,7 +825,7 @@ async function spawnClaudeOrExit(invocation, profile, prompt, executionScope, mu
       binary: invocation.binary,
       jsonSchema: invocation.schema_spec,
       resumeId: options.resumeId,
-      timeoutMs: 0,
+      timeoutMs: invocation.timeout_ms,
       allowedApiKeyEnv: authSelection.allowed_env_credentials,
       onSpawn: (pidInfo) => writeRunningRecord(invocation, pidInfo, mutationContext.mutations, options.runtimeDiagnostics),
     });
@@ -950,7 +1010,8 @@ async function cmdRunWorker(rest) {
     fail("bad_state", "prompt sidecar missing for job " + options.job);
   }
 
-  const invocation = invocationFromRecord(meta, options["auth-mode"]);
+  const runtimeOptions = readRuntimeOptionsSidecar(workspaceRoot, options.job);
+  const invocation = invocationFromRecord(meta, options["auth-mode"], runtimeOptions);
   const authSelection = resolveAuthSelection(invocation.auth_mode);
   if (authSelection.selected_auth_path === "api_key_env_missing") {
     // The prompt sidecar was already consumed above, so auth refusal cannot leave it on disk.
@@ -968,7 +1029,7 @@ async function cmdRunWorker(rest) {
 // ——— subcommand: continue (resume a prior session with --resume) ———
 async function cmdContinue(rest) {
   const { options, positionals } = parseArgs(rest, {
-    valueOptions: ["job", "cwd", "model", "binary", "auth-mode", "lifecycle-events"],
+    valueOptions: ["job", "cwd", "model", "binary", "auth-mode", "timeout-ms", "lifecycle-events"],
     booleanOptions: ["background", "foreground"],
   });
   if (!options.job) fail("bad_args", "--job <id> is required");
@@ -1019,6 +1080,12 @@ async function cmdContinue(rest) {
   const priorModeName = prior.mode_profile_name ?? prior.mode;
   const priorProfile = resolveProfile(priorModeName);
   const priorResumeChain = Array.isArray(prior.resume_chain) ? prior.resume_chain : [];
+  const priorRuntimeOptions = readRuntimeOptionsSidecar(workspaceRoot, options.job);
+  const priorTimeoutMs =
+    priorRuntimeOptions.timeout_ms ??
+    prior.review_metadata?.audit_manifest?.request?.timeout_ms ??
+    DEFAULT_CLAUDE_REVIEW_TIMEOUT_MS;
+  const timeoutMs = parseReviewTimeoutMs(options["timeout-ms"], process.env, priorTimeoutMs);
   const authSelection = resolveAuthSelection(options["auth-mode"]);
   if (authSelection.selected_auth_path === "api_key_env_missing") {
     fail("not_authed", apiKeyMissingMessage(), apiKeyMissingFields(authSelection));
@@ -1048,6 +1115,7 @@ async function cmdContinue(rest) {
     prompt_head: prompt.slice(0, 200),    // §21.3.1 — no full prompt
     review_prompt_contract_version: priorProfile.name === "rescue" ? null : REVIEW_PROMPT_CONTRACT_VERSION,
     review_prompt_provider: priorProfile.name === "rescue" ? null : "Claude Code",
+    timeout_ms: timeoutMs,
     schema_spec: prior.schema_spec ?? prior.schema ?? null,
     binary: options.binary ?? process.env.CLAUDE_BINARY ?? "claude",
     run_kind: options.background ? "background" : "foreground",
@@ -1064,6 +1132,7 @@ async function cmdContinue(rest) {
     validateBackgroundExecutionScopeOrExit(invocation, lifecycleEvents);
     try {
       writePromptSidecar(resolveJobsDir(workspaceRoot), newJobId_, targetPrompt);
+      writeRuntimeOptionsSidecar(workspaceRoot, newJobId_, { timeout_ms: timeoutMs });
     } catch (error) {
       failBackgroundPromptSidecarWrite(workspaceRoot, invocation, error);
     }

--- a/plugins/claude/skills/claude-cli-runtime/SKILL.md
+++ b/plugins/claude/skills/claude-cli-runtime/SKILL.md
@@ -21,7 +21,12 @@ claude-companion.mjs run     --mode=review|adversarial-review|custom-review|resc
                              [--scope-base <ref>] [--scope-paths <g1,g2,…>]
                              [--override-dispose <true|false>]
                              [--schema <json>] [--binary <path>]
+                             [--timeout-ms <ms>]
                              -- <prompt>
+claude-companion.mjs continue --job <id> [--foreground|--background]
+                              [--model <full-id>] [--cwd <path>]
+                              [--binary <path>] [--timeout-ms <ms>]
+                              -- <prompt>
 
 claude-companion.mjs preflight --mode=review|adversarial-review|custom-review
                                [--cwd <path>] [--scope-base <ref>]
@@ -41,7 +46,7 @@ claude-companion.mjs cancel  --job <id> [--cwd <path>] [--force]
 - **Custom review**: use `--mode=custom-review --scope-paths <g1,g2,…>` for pinned bundles or hand-picked files. Prompts should refer to selected files by relative paths inside the granted scope, never by an absolute parent checkout path.
 - **Preflight**: run `preflight` before external review when disclosure or bundle scope is uncertain. It computes file count, byte count, and selected relative paths without launching Claude.
 - **Session IDs**: the companion mints a UUID v4 `job_id`, passes it to fresh Claude runs as `--session-id`, then persists `claude_session_id` from Claude's JSON stdout. Callers do not supply session IDs.
-- **Timeouts**: companion does not enforce a wall-clock timeout by default. Tests pass `--timeout-ms` to the process wrapper directly.
+- **Timeouts**: review run/continue paths default to `600000` ms, accept `--timeout-ms <ms>`, and fall back to `CLAUDE_REVIEW_TIMEOUT_MS` for non-interactive use. The effective value is persisted in `review_metadata.audit_manifest.request.timeout_ms`.
 - **Cancel scope**: `cancel` is for background jobs only. Foreground runs stay attached to the active terminal and should be interrupted with Ctrl+C.
 
 ## Flag-stack per mode (enforced by `lib/claude.mjs`)

--- a/plugins/claude/skills/claude-review/SKILL.md
+++ b/plugins/claude/skills/claude-review/SKILL.md
@@ -15,5 +15,7 @@ node "<plugin-root>/scripts/claude-companion.mjs" run --mode=review --foreground
 ```
 
 If the user provides a base ref, add `--scope-base REF` before `--`.
+If the user provides a review timeout, add `--timeout-ms MS` before `--`.
+The review default is 600000 ms; `CLAUDE_REVIEW_TIMEOUT_MS` is the non-interactive fallback.
 
 Render companion JSON according to `claude-result-handling`; render `external_review_launched` as soon as it appears, then render `external_review` before normal prose when present. Do not claim `/claude-review` is available in Codex builds that do not register plugin command files.

--- a/plugins/gemini/commands/gemini-adversarial-review.md
+++ b/plugins/gemini/commands/gemini-adversarial-review.md
@@ -1,13 +1,13 @@
 ---
 description: Get Gemini CLI to adversarially challenge the current design under read-only policy.
-argument-hint: "[--scope-base REF] [focus area]"
+argument-hint: "[--scope-base REF] [--timeout-ms MS] [focus area]"
 ---
 
 Adversarial review via Gemini CLI. Assumes the author is wrong; looks for failure modes, hidden assumptions, and missing edge cases.
 
 ## Arguments
 
-`$ARGUMENTS` — optional `--scope-base REF` followed by focus text. If present, pass `--scope-base REF` before `--`; pass the remaining focus text after `--`.
+`$ARGUMENTS` — optional `--scope-base REF` and `--timeout-ms MS` followed by focus text. If `--scope-base REF` is present, pass `--scope-base REF` before `--`. If `--timeout-ms MS` is present, pass it before `--`. Pass the remaining focus text after `--`.
 
 ## Workflow
 
@@ -15,6 +15,7 @@ Run:
 ```
 node "<plugin-root>/scripts/gemini-companion.mjs" run --mode=adversarial-review --foreground --lifecycle-events jsonl -- "<focus text>"
 ```
+Review timeout defaults to 600000 ms. Use `--timeout-ms <ms>` or `GEMINI_REVIEW_TIMEOUT_MS`; the effective value is persisted in `review_metadata.audit_manifest.request.timeout_ms`.
 `branch-diff` is object-pure: checkout filters, replace refs, and grafts are ignored.
 It reduces the selected review scope, but a successful run still sends those
 selected source files to Gemini. If a private-repo approval reviewer denies the

--- a/plugins/gemini/commands/gemini-review.md
+++ b/plugins/gemini/commands/gemini-review.md
@@ -1,13 +1,13 @@
 ---
 description: Get Gemini CLI's read-only review of the current diff, files, or focus area. Runs with TOML policy enforcement.
-argument-hint: "[--scope-base REF] [focus area]"
+argument-hint: "[--scope-base REF] [--timeout-ms MS] [focus area]"
 ---
 
 Review via Gemini CLI. Read-only policy is mandatory; changes detected post-hoc, never auto-reverted.
 
 ## Arguments
 
-`$ARGUMENTS` — optional `--scope-base REF` followed by focus text. If present, pass `--scope-base REF` before `--`; pass the remaining focus text after `--`.
+`$ARGUMENTS` — optional `--scope-base REF` and `--timeout-ms MS` followed by focus text. If `--scope-base REF` is present, pass `--scope-base REF` before `--`. If `--timeout-ms MS` is present, pass it before `--`. Pass the remaining focus text after `--`.
 
 ## Workflow
 
@@ -15,6 +15,8 @@ Run:
 ```
 node "<plugin-root>/scripts/gemini-companion.mjs" run --mode=review --foreground --lifecycle-events jsonl -- "<focus text>"
 ```
+
+Review timeout defaults to 600000 ms. Use `--timeout-ms <ms>` or `GEMINI_REVIEW_TIMEOUT_MS`; the effective value is persisted in `review_metadata.audit_manifest.request.timeout_ms`.
 
 For a pinned review bundle or selected files, first run `preflight`, then use
 `run --mode=custom-review --scope-paths <g1,g2,...>` and refer to files by

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -47,6 +47,7 @@ import { REVIEW_PROMPT_CONTRACT_VERSION, buildReviewAuditManifest, buildReviewPr
 const PLUGIN_ROOT = resolvePath(dirname(fileURLToPath(import.meta.url)), "..");
 const MODELS_CONFIG_PATH = resolvePath(PLUGIN_ROOT, "config/models.json");
 const READ_ONLY_POLICY = resolvePath(PLUGIN_ROOT, "policies/read-only.toml");
+const DEFAULT_GEMINI_REVIEW_TIMEOUT_MS = 600000;
 const CONTINUABLE_STATUSES = new Set(["completed", "failed", "cancelled", "stale"]);
 const RUN_MODES = Object.freeze(["review", "adversarial-review", "custom-review", "rescue"]);
 const PREFLIGHT_MODES = Object.freeze(["review", "adversarial-review", "custom-review"]);
@@ -67,6 +68,21 @@ function fail(code, message, details = {}) {
   process.stderr.write(`gemini-companion: ${message}\n`);
   printJson({ ok: false, error: code, message, ...details });
   process.exit(1);
+}
+
+function parseReviewTimeoutMs(cliValue, env = process.env, fallback = DEFAULT_GEMINI_REVIEW_TIMEOUT_MS) {
+  const raw = cliValue ?? env.GEMINI_REVIEW_TIMEOUT_MS;
+  if (raw === undefined || raw === null || raw === "") return fallback;
+  if (typeof raw !== "string") {
+    const source = cliValue === undefined ? "GEMINI_REVIEW_TIMEOUT_MS" : "--timeout-ms";
+    fail("bad_args", `${source} must be a positive integer number of milliseconds; got ${JSON.stringify(raw)}`);
+  }
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    const source = cliValue === undefined ? "GEMINI_REVIEW_TIMEOUT_MS" : "--timeout-ms";
+    fail("bad_args", `${source} must be a positive integer number of milliseconds; got ${JSON.stringify(raw)}`);
+  }
+  return parsed;
 }
 
 function targetPromptFor(invocation, userPrompt) {
@@ -188,7 +204,7 @@ function reviewAuditManifest(invocation, prompt, containmentPath, execution) {
     request: {
       provider: invocation.review_prompt_provider ?? "Gemini CLI",
       model: invocation.model,
-      timeoutMs: null,
+      timeoutMs: invocation.timeout_ms ?? null,
       maxTokens: null,
       maxStepsPerTurn: null,
       temperature: null,
@@ -250,7 +266,44 @@ function modelCandidatesForInvocation(profile, invocation) {
   return candidates.length > 0 ? candidates : [invocation.model];
 }
 
-function invocationFromRecord(record, fallbackAuthMode = "subscription") {
+function runtimeOptionsSidecarPath(workspaceRoot, jobId) {
+  return `${resolveJobsDir(workspaceRoot)}/${jobId}/runtime-options.json`;
+}
+
+function writeRuntimeOptionsSidecar(workspaceRoot, jobId, options) {
+  const dir = `${resolveJobsDir(workspaceRoot)}/${jobId}`;
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  try {
+    chmodSync(dir, 0o700);
+  } catch (err) {
+    if (process.platform !== "win32") throw err;
+  }
+  const file = runtimeOptionsSidecarPath(workspaceRoot, jobId);
+  const tmpFile = `${file}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    writeFileSync(tmpFile, `${JSON.stringify({ timeout_ms: options.timeout_ms }, null, 2)}\n`, { mode: 0o600, encoding: "utf8" });
+    try { chmodSync(tmpFile, 0o600); } catch { /* best-effort on non-POSIX */ }
+    renameSync(tmpFile, file);
+  } catch (e) {
+    try { unlinkSync(tmpFile); } catch { /* already gone */ }
+    throw e;
+  }
+}
+
+function readRuntimeOptionsSidecar(workspaceRoot, jobId) {
+  const file = runtimeOptionsSidecarPath(workspaceRoot, jobId);
+  if (!existsSync(file)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(file, "utf8"));
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    const timeoutMs = parsed.timeout_ms;
+    return Number.isSafeInteger(timeoutMs) && timeoutMs > 0 ? { timeout_ms: timeoutMs } : {};
+  } catch {
+    return {};
+  }
+}
+
+function invocationFromRecord(record, fallbackAuthMode = "subscription", runtimeOptions = {}) {
   return Object.freeze({
     job_id: record.job_id,
     target: record.target,
@@ -273,6 +326,10 @@ function invocationFromRecord(record, fallbackAuthMode = "subscription") {
     run_kind: runKindFromRecord(record),
     auth_mode: record.auth_mode ?? fallbackAuthMode ?? "subscription",
     binary: record.binary,
+    timeout_ms:
+      runtimeOptions.timeout_ms ??
+      record.review_metadata?.audit_manifest?.request?.timeout_ms ??
+      DEFAULT_GEMINI_REVIEW_TIMEOUT_MS,
     started_at: record.started_at,
   });
 }
@@ -415,7 +472,7 @@ function cmdPreflight(rest) {
 
 async function cmdRun(rest) {
   const { options, positionals } = parseArgs(rest, {
-    valueOptions: ["mode", "model", "cwd", "binary", "scope-base", "scope-paths", "override-dispose", "auth-mode", "lifecycle-events"],
+    valueOptions: ["mode", "model", "cwd", "binary", "scope-base", "scope-paths", "override-dispose", "auth-mode", "timeout-ms", "lifecycle-events"],
     booleanOptions: ["background", "foreground"],
   });
   const mode = options.mode;
@@ -448,6 +505,7 @@ async function cmdRun(rest) {
   } catch (e) {
     fail("bad_args", e.message);
   }
+  const timeoutMs = parseReviewTimeoutMs(options["timeout-ms"]);
   const authSelection = resolveAuthSelection(options["auth-mode"]);
   if (authSelection.selected_auth_path === "api_key_env_missing") {
     fail("not_authed", apiKeyMissingMessage(), apiKeyMissingFields(authSelection));
@@ -472,6 +530,7 @@ async function cmdRun(rest) {
     prompt_head: prompt.slice(0, 200),
     review_prompt_contract_version: profile.name === "rescue" ? null : REVIEW_PROMPT_CONTRACT_VERSION,
     review_prompt_provider: profile.name === "rescue" ? null : "Gemini CLI",
+    timeout_ms: timeoutMs,
     schema_spec: null,
     binary: options.binary ?? process.env.GEMINI_BINARY ?? "gemini",
     run_kind: options.background ? "background" : "foreground",
@@ -488,6 +547,7 @@ async function cmdRun(rest) {
     validateBackgroundExecutionScopeOrExit(invocation, lifecycleEvents);
     try {
       writePromptSidecar(resolveJobsDir(workspaceRoot), jobId, targetPrompt);
+      writeRuntimeOptionsSidecar(workspaceRoot, jobId, { timeout_ms: timeoutMs });
     } catch (error) {
       failBackgroundPromptSidecarWrite(workspaceRoot, invocation, error);
     }
@@ -672,6 +732,7 @@ function spawnOneGeminiAttempt(invocation, profile, prompt, executionScope, muta
     cwd: mutationContext.neutralCwd ?? executionScope.containment.path,
     binary: invocation.binary,
     resumeId: options.resumeId,
+    timeoutMs: invocation.timeout_ms,
     allowedApiKeyEnv: options.allowedApiKeyEnv,
     onSpawn: (pidInfo) => writeRunningRecord(invocation, pidInfo, mutationContext.mutations),
   });
@@ -873,7 +934,8 @@ async function cmdRunWorker(rest) {
     fail("bad_state", "prompt sidecar missing for job " + options.job);
   }
 
-  const invocation = invocationFromRecord(meta, options["auth-mode"]);
+  const runtimeOptions = readRuntimeOptionsSidecar(workspaceRoot, options.job);
+  const invocation = invocationFromRecord(meta, options["auth-mode"], runtimeOptions);
   const authSelection = resolveAuthSelection(invocation.auth_mode);
   if (authSelection.selected_auth_path === "api_key_env_missing") {
     // The prompt sidecar was already consumed above, so auth refusal cannot leave it on disk.
@@ -890,7 +952,7 @@ async function cmdRunWorker(rest) {
 
 async function cmdContinue(rest) {
   const { options, positionals } = parseArgs(rest, {
-    valueOptions: ["job", "cwd", "model", "binary", "auth-mode", "lifecycle-events"],
+    valueOptions: ["job", "cwd", "model", "binary", "auth-mode", "timeout-ms", "lifecycle-events"],
     booleanOptions: ["background", "foreground"],
   });
   if (!options.job) fail("bad_args", "--job <id> is required");
@@ -942,6 +1004,12 @@ async function cmdContinue(rest) {
   const priorModeName = prior.mode_profile_name ?? prior.mode;
   const priorProfile = resolveProfile(priorModeName);
   const priorResumeChain = Array.isArray(prior.resume_chain) ? prior.resume_chain : [];
+  const priorRuntimeOptions = readRuntimeOptionsSidecar(workspaceRoot, options.job);
+  const priorTimeoutMs =
+    priorRuntimeOptions.timeout_ms ??
+    prior.review_metadata?.audit_manifest?.request?.timeout_ms ??
+    DEFAULT_GEMINI_REVIEW_TIMEOUT_MS;
+  const timeoutMs = parseReviewTimeoutMs(options["timeout-ms"], process.env, priorTimeoutMs);
   const authSelection = resolveAuthSelection(options["auth-mode"]);
   if (authSelection.selected_auth_path === "api_key_env_missing") {
     fail("not_authed", apiKeyMissingMessage(), apiKeyMissingFields(authSelection));
@@ -964,6 +1032,7 @@ async function cmdContinue(rest) {
     prompt_head: prompt.slice(0, 200),
     review_prompt_contract_version: priorProfile.name === "rescue" ? null : REVIEW_PROMPT_CONTRACT_VERSION,
     review_prompt_provider: priorProfile.name === "rescue" ? null : "Gemini CLI",
+    timeout_ms: timeoutMs,
     schema_spec: prior.schema_spec ?? null,
     binary: options.binary ?? process.env.GEMINI_BINARY ?? "gemini",
     run_kind: options.background ? "background" : "foreground",
@@ -980,6 +1049,7 @@ async function cmdContinue(rest) {
     validateBackgroundExecutionScopeOrExit(invocation, lifecycleEvents);
     try {
       writePromptSidecar(resolveJobsDir(workspaceRoot), newJobId_, targetPrompt);
+      writeRuntimeOptionsSidecar(workspaceRoot, newJobId_, { timeout_ms: timeoutMs });
     } catch (error) {
       failBackgroundPromptSidecarWrite(workspaceRoot, invocation, error);
     }

--- a/plugins/gemini/skills/gemini-review/SKILL.md
+++ b/plugins/gemini/skills/gemini-review/SKILL.md
@@ -15,5 +15,7 @@ node "<plugin-root>/scripts/gemini-companion.mjs" run --mode=review --foreground
 ```
 
 If the user provides a base ref, add `--scope-base REF` before `--`.
+If the user provides a review timeout, add `--timeout-ms MS` before `--`.
+The review default is 600000 ms; `GEMINI_REVIEW_TIMEOUT_MS` is the non-interactive fallback.
 
 Render the returned JobRecord, render `external_review_launched` as soon as it appears, then render `external_review` before normal prose when present, and surface `mutations`. Do not claim `/gemini-review` is available in Codex builds that do not register plugin command files.

--- a/plugins/grok/commands/grok-adversarial-review.md
+++ b/plugins/grok/commands/grok-adversarial-review.md
@@ -15,3 +15,5 @@ present. If the JobRecord failed, report `error_code`, `error_message`,
 `http_status` when present, and `suggested_action`. Do not print session
 cookies, tunnel API keys, or bearer token values.
 Do not recommend direct xAI API keys as a fallback for subscription web mode.
+
+Review timeout defaults to 600000 ms. Use `GROK_WEB_TIMEOUT_MS=<ms>` to override it; the effective value is persisted in `review_metadata.audit_manifest.request.timeout_ms`. Doctor timeouts remain separate readiness checks.

--- a/plugins/grok/commands/grok-custom-review.md
+++ b/plugins/grok/commands/grok-custom-review.md
@@ -14,3 +14,5 @@ Parse `$ARGUMENTS` so `--scope-paths <files>` becomes the command's
 Replace `<file1>,<file2>` with comma- or newline-separated concrete relative paths; expand globs before running. Render the returned JobRecord, and render `external_review_launched` as soon as it appears, then render `external_review` before the review result when present. If the JobRecord failed, report `error_code`, `error_message`, `http_status` when present, and `suggested_action`. Do not print session
 cookies, tunnel API keys, or bearer token values. Do not recommend direct xAI
 API keys as a fallback for subscription web mode.
+
+Review timeout defaults to 600000 ms. Use `GROK_WEB_TIMEOUT_MS=<ms>` to override it; the effective value is persisted in `review_metadata.audit_manifest.request.timeout_ms`. Doctor timeouts remain separate readiness checks.

--- a/plugins/grok/commands/grok-review.md
+++ b/plugins/grok/commands/grok-review.md
@@ -15,3 +15,5 @@ present. If the JobRecord failed, report `error_code`, `error_message`,
 `http_status` when present, and `suggested_action`. Do not print session
 cookies, tunnel API keys, or bearer token values.
 Do not recommend direct xAI API keys as a fallback for subscription web mode.
+
+Review timeout defaults to 600000 ms. Use `GROK_WEB_TIMEOUT_MS=<ms>` to override it; the effective value is persisted in `review_metadata.audit_manifest.request.timeout_ms`. Doctor timeouts remain separate readiness checks.

--- a/plugins/grok/scripts/grok-web-reviewer.mjs
+++ b/plugins/grok/scripts/grok-web-reviewer.mjs
@@ -16,7 +16,7 @@ import {
 const VALID_MODES = new Set(["review", "adversarial-review", "custom-review"]);
 const DEFAULT_BASE_URL = "http://127.0.0.1:8000/v1";
 const DEFAULT_MODEL = "grok-4.20-fast";
-const DEFAULT_TIMEOUT_MS = 30000;
+const DEFAULT_TIMEOUT_MS = 600000;
 const DEFAULT_DOCTOR_TIMEOUT_MS = 2000;
 const DEFAULT_CHAT_DOCTOR_TIMEOUT_MS = 10000;
 const MAX_SCOPE_FILE_BYTES = 256 * 1024;
@@ -141,24 +141,30 @@ function normalizeBaseUrl(value) {
 }
 
 function config(env = process.env) {
+  const timeoutMs = parsePositiveIntegerEnv(env, "GROK_WEB_TIMEOUT_MS", DEFAULT_TIMEOUT_MS);
+  const doctorTimeoutMs = parsePositiveIntegerEnv(env, "GROK_WEB_DOCTOR_TIMEOUT_MS", DEFAULT_DOCTOR_TIMEOUT_MS);
+  const chatDoctorTimeoutMs = parsePositiveIntegerEnv(env, "GROK_WEB_CHAT_DOCTOR_TIMEOUT_MS", DEFAULT_CHAT_DOCTOR_TIMEOUT_MS);
   return {
     provider: "grok-web",
     display_name: "Grok Web",
     auth_mode: "subscription_web",
     base_url: normalizeBaseUrl(env.GROK_WEB_BASE_URL),
     model: env.GROK_WEB_MODEL || DEFAULT_MODEL,
-    timeout_ms: parsePositiveInteger(env.GROK_WEB_TIMEOUT_MS, DEFAULT_TIMEOUT_MS),
-    doctor_timeout_ms: parsePositiveInteger(env.GROK_WEB_DOCTOR_TIMEOUT_MS, DEFAULT_DOCTOR_TIMEOUT_MS),
-    chat_doctor_timeout_ms: parsePositiveInteger(env.GROK_WEB_CHAT_DOCTOR_TIMEOUT_MS, DEFAULT_CHAT_DOCTOR_TIMEOUT_MS),
+    timeout_ms: timeoutMs,
+    doctor_timeout_ms: doctorTimeoutMs,
+    chat_doctor_timeout_ms: chatDoctorTimeoutMs,
     credential_ref: env.GROK_WEB_TUNNEL_API_KEY ? "GROK_WEB_TUNNEL_API_KEY" : null,
     credential_value: env.GROK_WEB_TUNNEL_API_KEY || null,
   };
 }
 
-function parsePositiveInteger(value, fallback) {
+function parsePositiveIntegerEnv(env, name, fallback) {
+  const value = env[name];
   if (value === undefined || value === null || value === "") return fallback;
   const parsed = Number(value);
-  if (!Number.isSafeInteger(parsed) || parsed <= 0) return fallback;
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`bad_args: ${name} must be a positive integer number of milliseconds; got ${JSON.stringify(value)}`);
+  }
   return parsed;
 }
 
@@ -606,6 +612,7 @@ async function callGrokTunnel(cfg, prompt, env = process.env) {
   const redact = redactor(env);
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), cfg.timeout_ms);
+  const started = Date.now();
   try {
     const response = await fetch(endpoint, {
       method: "POST",
@@ -623,6 +630,8 @@ async function callGrokTunnel(cfg, prompt, env = process.env) {
         parsed.ok ? parsed.value : null,
         true,
         {
+          configured_timeout_ms: cfg.timeout_ms,
+          elapsed_ms: Date.now() - started,
           endpoint_class: "chat_completions",
           model: cfg.model,
           stream: false,
@@ -631,10 +640,30 @@ async function callGrokTunnel(cfg, prompt, env = process.env) {
         },
       );
     }
-    if (!parsed.ok) return providerFailure("malformed_response", parsed.error, response.status, null, true);
+    if (!parsed.ok) return providerFailureWithDiagnostic("malformed_response", parsed.error, response.status, null, true, {
+      configured_timeout_ms: cfg.timeout_ms,
+      elapsed_ms: Date.now() - started,
+      prompt_chars: prompt.length,
+      max_tokens: null,
+      temperature: requestBody.temperature ?? null,
+      stream: false,
+    });
     const content = parsed.value?.choices?.[0]?.message?.content;
     if (typeof content !== "string") {
-      return providerFailure("malformed_response", "response did not include choices[0].message.content", response.status, parsed.value, true);
+      return providerFailureWithDiagnostic(
+        "malformed_response",
+        "response did not include choices[0].message.content",
+        response.status,
+        parsed.value,
+        true,
+        {
+          configured_timeout_ms: cfg.timeout_ms,
+          prompt_chars: prompt.length,
+          max_tokens: null,
+          temperature: requestBody.temperature ?? null,
+          stream: false,
+        },
+      );
     }
     return {
       exitCode: 0,
@@ -658,7 +687,13 @@ async function callGrokTunnel(cfg, prompt, env = process.env) {
     };
   } catch (e) {
     const reason = e?.name === "AbortError" ? "tunnel_timeout" : "tunnel_unavailable";
-    return providerFailure(reason, tunnelTransportMessage(e, env, redact), null, null, payloadSentForFetchError(e));
+    return providerFailureWithDiagnostic(reason, tunnelTransportMessage(e, env, redact), null, null, payloadSentForFetchError(e), {
+      configured_timeout_ms: cfg.timeout_ms,
+      prompt_chars: prompt.length,
+      max_tokens: null,
+      temperature: requestBody.temperature ?? null,
+      stream: false,
+    });
   } finally {
     clearTimeout(timer);
   }
@@ -871,7 +906,7 @@ function buildReviewMetadata(cfg, scopeInfo, execution = null) {
     request: {
       provider: cfg.display_name,
       model: cfg.model,
-      timeoutMs: execution.diagnostics?.configured_timeout_ms ?? cfg.timeout_ms ?? null,
+      timeoutMs: execution.diagnostics?.configured_timeout_ms ?? null,
       maxTokens: execution.diagnostics?.max_tokens ?? null,
       temperature: execution.diagnostics?.temperature ?? null,
       stream: false,
@@ -1369,12 +1404,13 @@ async function cmdRun(options) {
       execution = await callGrokTunnel(cfg, prompt);
       execution.prompt = prompt;
     } catch (e) {
-      execution = providerFailure(
+      execution = providerFailureWithDiagnostic(
         e.message.startsWith("bad_args:") ? "bad_args" : "tunnel_error",
         redactor()(e.message),
         null,
         null,
         payloadSentForFetchError(e),
+        { configured_timeout_ms: cfg.timeout_ms },
       );
     }
   }

--- a/plugins/grok/skills/grok-review/SKILL.md
+++ b/plugins/grok/skills/grok-review/SKILL.md
@@ -18,6 +18,7 @@ node plugins/grok/scripts/grok-web-reviewer.mjs run --mode review --scope branch
 ```
 
 If the user provides a base ref, add `--scope-base REF` before `--prompt`.
+The review timeout default is 600000 ms; `GROK_WEB_TIMEOUT_MS` is the override.
 `<focus>` is the user's review prompt or focus area. Render the returned
 JobRecord, render `external_review_launched` as soon as it appears, then render
 `external_review` before the review result when present. If the JobRecord

--- a/plugins/kimi/commands/kimi-adversarial-review.md
+++ b/plugins/kimi/commands/kimi-adversarial-review.md
@@ -1,13 +1,13 @@
 ---
 description: Get Kimi Code CLI to adversarially challenge the current design under read-only policy.
-argument-hint: "[--scope-base REF] [--max-steps-per-turn N] [focus area]"
+argument-hint: "[--scope-base REF] [--timeout-ms MS] [--max-steps-per-turn N] [focus area]"
 ---
 
 Adversarial review via Kimi Code CLI. Assumes the author is wrong; looks for failure modes, hidden assumptions, and missing edge cases.
 
 ## Arguments
 
-`$ARGUMENTS` — optional `--scope-base REF` and `--max-steps-per-turn N` followed by focus text. If present, pass those flags before `--`; pass the remaining focus text after `--`.
+`$ARGUMENTS` — optional `--scope-base REF`, `--timeout-ms MS`, and `--max-steps-per-turn N` followed by focus text. If present, pass those flags before `--`; pass the remaining focus text after `--`.
 
 ## Workflow
 
@@ -15,6 +15,7 @@ Run:
 ```
 node "<plugin-root>/scripts/kimi-companion.mjs" run --mode=adversarial-review --foreground --lifecycle-events jsonl -- "<focus text>"
 ```
+Review timeout defaults to 600000 ms. Use `--timeout-ms <ms>` or `KIMI_REVIEW_TIMEOUT_MS`; the effective value is persisted in `review_metadata.audit_manifest.request.timeout_ms`.
 `branch-diff` is object-pure: checkout filters, replace refs, and grafts are ignored.
 It reduces the selected review scope, but a successful run still sends those
 selected source files to Kimi. If a private-repo approval reviewer denies the

--- a/plugins/kimi/commands/kimi-review.md
+++ b/plugins/kimi/commands/kimi-review.md
@@ -1,13 +1,13 @@
 ---
 description: Get Kimi Code CLI's read-only review of the current diff, files, or focus area.
-argument-hint: "[--scope-base REF] [--max-steps-per-turn N] [focus area]"
+argument-hint: "[--scope-base REF] [--timeout-ms MS] [--max-steps-per-turn N] [focus area]"
 ---
 
 Review via Kimi Code CLI. Runs in Kimi plan mode over disposable scoped input; changes are detected post-hoc and never auto-reverted.
 
 ## Arguments
 
-`$ARGUMENTS` — optional `--scope-base REF` and `--max-steps-per-turn N` followed by focus text. If present, pass those flags before `--`; pass the remaining focus text after `--`.
+`$ARGUMENTS` — optional `--scope-base REF`, `--timeout-ms MS`, and `--max-steps-per-turn N` followed by focus text. If present, pass those flags before `--`; pass the remaining focus text after `--`.
 
 ## Workflow
 
@@ -15,6 +15,8 @@ Run:
 ```
 node "<plugin-root>/scripts/kimi-companion.mjs" run --mode=review --foreground --lifecycle-events jsonl -- "<focus text>"
 ```
+
+Review timeout defaults to 600000 ms. Use `--timeout-ms <ms>` or `KIMI_REVIEW_TIMEOUT_MS`; the effective value is persisted in `review_metadata.audit_manifest.request.timeout_ms`.
 
 For a pinned review bundle or selected files, first run `preflight`, then use
 `run --mode=custom-review --scope-paths <g1,g2,...>` and refer to files by

--- a/plugins/kimi/scripts/kimi-companion.mjs
+++ b/plugins/kimi/scripts/kimi-companion.mjs
@@ -45,7 +45,7 @@ const MODELS_CONFIG_PATH = resolvePath(PLUGIN_ROOT, "config/models.json");
 const CONTINUABLE_STATUSES = new Set(["completed", "failed", "cancelled", "stale"]);
 const RUN_MODES = Object.freeze(["review", "adversarial-review", "custom-review", "rescue"]);
 const PREFLIGHT_MODES = Object.freeze(["review", "adversarial-review", "custom-review"]);
-const DEFAULT_KIMI_REVIEW_TIMEOUT_MS = 180000;
+const DEFAULT_KIMI_REVIEW_TIMEOUT_MS = 600000;
 const GIT_PROMPT_BINARY = "/usr/bin/git";
 const GIT_PROMPT_SAFE_PATH = "/usr/bin:/bin";
 
@@ -267,6 +267,10 @@ function runtimeOptionsSidecarPath(workspaceRoot, jobId) {
 function runtimeOptionsForRecord(record, runtimeOptions = {}) {
   const profile = resolveProfile(record.mode_profile_name ?? record.mode);
   return {
+    timeout_ms:
+      runtimeOptions.timeout_ms ??
+      record.review_metadata?.audit_manifest?.request?.timeout_ms ??
+      DEFAULT_KIMI_REVIEW_TIMEOUT_MS,
     max_steps_per_turn:
       runtimeOptions.max_steps_per_turn ??
       profile.max_steps_per_turn ??
@@ -285,6 +289,7 @@ function writeRuntimeOptionsSidecar(workspaceRoot, jobId, options) {
   const file = runtimeOptionsSidecarPath(workspaceRoot, jobId);
   const tmpFile = `${file}.${process.pid}.${Date.now()}.tmp`;
   const payload = {
+    timeout_ms: options.timeout_ms,
     max_steps_per_turn: options.max_steps_per_turn,
   };
   try {
@@ -303,10 +308,12 @@ function readRuntimeOptionsSidecar(workspaceRoot, jobId) {
   try {
     const parsed = JSON.parse(readFileSync(file, "utf8"));
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    const timeoutMs = parsed.timeout_ms;
     const maxSteps = parsed.max_steps_per_turn;
-    return Number.isInteger(maxSteps) && maxSteps > 0
-      ? { max_steps_per_turn: maxSteps }
-      : {};
+    const options = {};
+    if (Number.isSafeInteger(timeoutMs) && timeoutMs > 0) options.timeout_ms = timeoutMs;
+    if (Number.isSafeInteger(maxSteps) && maxSteps > 0) options.max_steps_per_turn = maxSteps;
+    return options;
   } catch {
     return {};
   }
@@ -334,17 +341,26 @@ function invocationFromRecord(record, runtimeOptions = {}) {
     review_prompt_provider: record.review_metadata?.prompt_provider ?? null,
     schema_spec: record.schema_spec ?? null,
     binary: record.binary,
+    timeout_ms: resolvedRuntimeOptions.timeout_ms,
     run_kind: runKindFromRecord(record),
     max_steps_per_turn: resolvedRuntimeOptions.max_steps_per_turn,
     started_at: record.started_at,
   };
 }
 
-function parsePositiveTimeoutMs(value, fallback) {
-  if (value === undefined || value === null || value === "") return fallback;
-  const parsed = Number(value);
-  if (parsed <= 0 || !Number.isInteger(parsed)) {
-    fail("bad_args", `--timeout-ms must be a positive integer number of milliseconds; got ${JSON.stringify(value)}`);
+function parsePositiveTimeoutMs(value, fallback, { envName = null } = {}) {
+  const raw = value === undefined || value === null || value === ""
+    ? (envName ? process.env[envName] : undefined)
+    : value;
+  if (raw === undefined || raw === null || raw === "") return fallback;
+  if (typeof raw !== "string") {
+    const source = value === undefined || value === null || value === "" ? envName : "--timeout-ms";
+    fail("bad_args", `${source} must be a positive integer number of milliseconds; got ${JSON.stringify(raw)}`);
+  }
+  const parsed = Number(raw);
+  if (parsed <= 0 || !Number.isSafeInteger(parsed)) {
+    const source = value === undefined || value === null || value === "" ? envName : "--timeout-ms";
+    fail("bad_args", `${source} must be a positive integer number of milliseconds; got ${JSON.stringify(raw)}`);
   }
   return parsed;
 }
@@ -352,7 +368,7 @@ function parsePositiveTimeoutMs(value, fallback) {
 function parsePositiveMaxStepsPerTurn(value, fallback) {
   if (value === undefined || value === null || value === "") return fallback;
   const parsed = Number(value);
-  if (parsed <= 0 || !Number.isInteger(parsed)) {
+  if (parsed <= 0 || !Number.isSafeInteger(parsed)) {
     fail("bad_args", `--max-steps-per-turn must be a positive integer; got ${JSON.stringify(value)}`);
   }
   return parsed;
@@ -528,7 +544,9 @@ async function cmdRun(rest) {
   } catch (e) {
     fail("bad_args", e.message);
   }
-  const timeoutMs = parsePositiveTimeoutMs(options["timeout-ms"], DEFAULT_KIMI_REVIEW_TIMEOUT_MS);
+  const timeoutMs = parsePositiveTimeoutMs(options["timeout-ms"], DEFAULT_KIMI_REVIEW_TIMEOUT_MS, {
+    envName: "KIMI_REVIEW_TIMEOUT_MS",
+  });
   const maxStepsPerTurn = parsePositiveMaxStepsPerTurn(
     options["max-steps-per-turn"],
     profile.max_steps_per_turn ?? 8,
@@ -562,7 +580,7 @@ async function cmdRun(rest) {
   });
 
   const queuedRecord = buildJobRecord(invocation, null, []);
-  writeRuntimeOptionsSidecar(workspaceRoot, jobId, { max_steps_per_turn: maxStepsPerTurn });
+  writeRuntimeOptionsSidecar(workspaceRoot, jobId, { timeout_ms: timeoutMs, max_steps_per_turn: maxStepsPerTurn });
   writeJobFile(workspaceRoot, jobId, queuedRecord);
   upsertJob(workspaceRoot, queuedRecord);
   const targetPrompt = targetPromptFor(profile, prompt, invocation);
@@ -680,7 +698,7 @@ async function executeRun(invocation, prompt, { foreground, lifecycleEvents = nu
         cwd: neutralCwd ?? containment.path,
         binary: invocation.binary,
         resumeId,
-        timeoutMs: foreground ? invocation.timeout_ms : 0,
+        timeoutMs: invocation.timeout_ms,
         maxStepsPerTurn: invocation.max_steps_per_turn,
         onSpawn: (pidInfo) => {
           const runningRecord = buildJobRecord(attemptInvocation, {
@@ -994,7 +1012,11 @@ async function cmdContinue(rest) {
   const priorProfile = resolveProfile(priorModeName);
   const priorResumeChain = Array.isArray(prior.resume_chain) ? prior.resume_chain : [];
   const priorRuntimeOptions = readRuntimeOptionsSidecar(workspaceRoot, options.job);
-  const timeoutMs = parsePositiveTimeoutMs(options["timeout-ms"], DEFAULT_KIMI_REVIEW_TIMEOUT_MS);
+  const priorTimeoutMs =
+    priorRuntimeOptions.timeout_ms ??
+    prior.review_metadata?.audit_manifest?.request?.timeout_ms ??
+    DEFAULT_KIMI_REVIEW_TIMEOUT_MS;
+  const timeoutMs = parsePositiveTimeoutMs(options["timeout-ms"], priorTimeoutMs, { envName: "KIMI_REVIEW_TIMEOUT_MS" });
   const maxStepsPerTurn = parsePositiveMaxStepsPerTurn(
     options["max-steps-per-turn"],
     priorRuntimeOptions.max_steps_per_turn ?? priorProfile.max_steps_per_turn ?? 8,
@@ -1026,7 +1048,7 @@ async function cmdContinue(rest) {
   });
 
   const queuedRecord = buildJobRecord(invocation, null, []);
-  writeRuntimeOptionsSidecar(workspaceRoot, newJobId_, { max_steps_per_turn: maxStepsPerTurn });
+  writeRuntimeOptionsSidecar(workspaceRoot, newJobId_, { timeout_ms: timeoutMs, max_steps_per_turn: maxStepsPerTurn });
   writeJobFile(workspaceRoot, newJobId_, queuedRecord);
   upsertJob(workspaceRoot, queuedRecord);
   const targetPrompt = targetPromptFor(priorProfile, prompt, invocation);

--- a/plugins/kimi/skills/kimi-review/SKILL.md
+++ b/plugins/kimi/skills/kimi-review/SKILL.md
@@ -14,7 +14,8 @@ Use the Kimi companion review workflow. Current Codex builds expose it as `kimi:
 node "<plugin-root>/scripts/kimi-companion.mjs" run --mode=review --foreground --lifecycle-events jsonl --cwd "<workspace>" -- "<focus>"
 ```
 
-If the user provides them, add `--scope-base REF` and/or
+If the user provides them, add `--scope-base REF`, `--timeout-ms MS`, and/or
 `--max-steps-per-turn N` before `--`; `N` must be a positive integer.
+The review timeout default is 600000 ms; `KIMI_REVIEW_TIMEOUT_MS` is the non-interactive fallback.
 
 Render the returned JobRecord, render `external_review_launched` as soon as it appears, then render `external_review` before normal prose when present, and surface `mutations`. Do not claim `/kimi-review` is available in Codex builds that do not register plugin command files.

--- a/tests/smoke/api-reviewers.smoke.test.mjs
+++ b/tests/smoke/api-reviewers.smoke.test.mjs
@@ -807,6 +807,7 @@ test("mock request-body assertion failures are marked not sent", async () => {
     cwd,
     env: {
       API_REVIEWERS_PLUGIN_DATA: dataDir,
+      API_REVIEWERS_TIMEOUT_MS: "234567",
       API_REVIEWERS_MOCK_RESPONSE: mockResponse("glm-5.1"),
       API_REVIEWERS_MOCK_ASSERT_REQUEST_BODY: JSON.stringify({
         model: "wrong-model",
@@ -821,6 +822,7 @@ test("mock request-body assertion failures are marked not sent", async () => {
   assert.equal(record.provider, "glm");
   assert.equal(record.error_code, "mock_assertion_failed");
   assert.match(record.error_message, /request body field model expected/);
+  assert.equal(record.review_metadata.audit_manifest.request.timeout_ms, 234567);
   assertDirectApiNotSent(record, "GLM");
   assert.doesNotMatch(result.stdout, /secret-test-value/);
 });
@@ -1176,6 +1178,7 @@ test("DeepSeek direct API custom-review completes and persists JobRecord", async
     cwd,
     env: {
       API_REVIEWERS_PLUGIN_DATA: dataDir,
+      API_REVIEWERS_TIMEOUT_MS: "123456",
       API_REVIEWERS_MOCK_RESPONSE: mockResponse("deepseek-v4-pro"),
       API_REVIEWERS_MOCK_ASSERT_PROMPT_INCLUDES: "Live verification context",
       DEEPSEEK_API_KEY: "secret-test-value",
@@ -1201,8 +1204,10 @@ test("DeepSeek direct API custom-review completes and persists JobRecord", async
     { path: "seed.txt", bytes: "hello from selected scope\n".length, hashOk: true },
   ]);
   assert.equal(record.review_metadata.audit_manifest.request.model, "deepseek-v4-pro");
+  assert.equal(record.review_metadata.audit_manifest.request.timeout_ms, 123456);
   assert.equal(record.review_metadata.audit_manifest.request.max_tokens, 65536);
   assert.equal(record.review_metadata.audit_manifest.request.temperature, 0);
+  assert.equal(record.review_metadata.audit_manifest.request.stream, false);
   assert.match(record.review_metadata.audit_manifest.prompt_builder.plugin_commit, /^[a-f0-9]{40}$/);
   assert.notEqual(
     record.review_metadata.audit_manifest.prompt_builder.plugin_commit,
@@ -1659,6 +1664,7 @@ test("direct API HTTP provider_unavailable under Codex does not recommend sandbo
       companion: path.join(pluginRoot, "scripts", "api-reviewer.mjs"),
       env: {
         API_REVIEWERS_PLUGIN_DATA: dataDir,
+        API_REVIEWERS_TIMEOUT_MS: "345678",
         CODEX_SANDBOX: "seatbelt",
         DEEPSEEK_API_KEY: "secret-test-value",
       },
@@ -1667,6 +1673,7 @@ test("direct API HTTP provider_unavailable under Codex does not recommend sandbo
     const record = parseJson(result.stdout);
     assert.equal(record.error_code, "provider_unavailable");
     assert.equal(record.http_status, 503);
+    assert.equal(record.review_metadata.audit_manifest.request.timeout_ms, 345678);
     assert.equal(record.external_review.source_content_transmission, "sent");
     assert.doesNotMatch(record.suggested_action, /network_access = true/);
     assert.doesNotMatch(record.suggested_action, /outside sandbox/);
@@ -1742,12 +1749,14 @@ test("direct API live malformed responses mark selected content as sent", async 
       companion: path.join(pluginRoot, "scripts", "api-reviewer.mjs"),
       env: {
         API_REVIEWERS_PLUGIN_DATA: dataDir,
+        API_REVIEWERS_TIMEOUT_MS: "456789",
         DEEPSEEK_API_KEY: "secret-test-value",
       },
     });
     assert.equal(result.status, 1);
     const record = parseJson(result.stdout);
     assert.equal(record.error_code, "malformed_response");
+    assert.equal(record.review_metadata.audit_manifest.request.timeout_ms, 456789);
     assert.equal(record.external_review.source_content_transmission, "sent");
     assert.equal(record.external_review.disclosure,
       "Selected source content was sent to DeepSeek through direct API auth, but the provider did not return a clean result.");

--- a/tests/smoke/claude-companion.smoke.test.mjs
+++ b/tests/smoke/claude-companion.smoke.test.mjs
@@ -130,7 +130,7 @@ test("run --mode=review --foreground: emits JobRecord with status=completed", ()
     assert.equal(result.review_metadata.raw_output.parsed_ok, true);
     assert.match(result.review_metadata.audit_manifest.rendered_prompt_hash.value, /^[a-f0-9]{64}$/);
     assert.equal(result.review_metadata.audit_manifest.request.model, "claude-haiku-4-5-20251001");
-    assert.equal(result.review_metadata.audit_manifest.request.timeout_ms, null);
+    assert.equal(result.review_metadata.audit_manifest.request.timeout_ms, 600000);
     assert.match(result.review_metadata.audit_manifest.prompt_builder.plugin_commit, /^[a-f0-9]{40}$/);
     assert.notEqual(
       result.review_metadata.audit_manifest.prompt_builder.plugin_commit,
@@ -185,6 +185,92 @@ test("run --mode=review --foreground lifecycle jsonl emits launch event before t
     });
     assert.equal(record.status, "completed");
     assert.equal(record.external_review.source_content_transmission, "sent");
+  } finally {
+    cleanup(dataDir);
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("run --mode=review --foreground: --timeout-ms overrides review timeout audit metadata", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "smoke-cwd-timeout-"));
+  seedMinimalRepo(cwd);
+  const { stdout, stderr, status, dataDir } = runCompanion(
+    ["run", "--mode=review", "--foreground", "--model", "claude-haiku-4-5-20251001",
+     "--cwd", cwd, "--timeout-ms", "123456", "--", "review timeout override"],
+    { cwd, env: { CLAUDE_MOCK_ASSERT_PROMPT_INCLUDES: "Provider: Claude Code" } }
+  );
+  try {
+    assert.equal(status, 0, `exit ${status}: stderr=${stderr}`);
+    const result = JSON.parse(stdout);
+    assert.equal(result.status, "completed");
+    assert.equal(result.review_metadata.audit_manifest.request.timeout_ms, 123456);
+    const { record: persisted } = readOnlyJobRecord(dataDir);
+    assert.equal(persisted.review_metadata.audit_manifest.request.timeout_ms, 123456);
+  } finally {
+    cleanup(dataDir);
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("run --mode=review rejects --timeout-ms without a value", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "smoke-cwd-timeout-missing-"));
+  seedMinimalRepo(cwd);
+  const { stdout, status, dataDir } = runCompanion(
+    ["run", "--mode=review", "--foreground", "--model", "claude-haiku-4-5-20251001",
+     "--cwd", cwd, "--timeout-ms", "--", "review timeout missing"],
+    { cwd }
+  );
+  try {
+    assert.equal(status, 1);
+    const result = JSON.parse(stdout);
+    assert.equal(result.error, "bad_args");
+    assert.match(result.message, /--timeout-ms must be a positive integer number of milliseconds/);
+  } finally {
+    cleanup(dataDir);
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("run --mode=review --foreground: CLAUDE_REVIEW_TIMEOUT_MS sets review timeout audit metadata", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "smoke-cwd-env-timeout-"));
+  seedMinimalRepo(cwd);
+  const { stdout, stderr, status, dataDir } = runCompanion(
+    ["run", "--mode=review", "--foreground", "--model", "claude-haiku-4-5-20251001",
+     "--cwd", cwd, "--", "review timeout env override"],
+    {
+      cwd,
+      env: {
+        CLAUDE_REVIEW_TIMEOUT_MS: "234567",
+        CLAUDE_MOCK_ASSERT_PROMPT_INCLUDES: "Provider: Claude Code",
+      },
+    }
+  );
+  try {
+    assert.equal(status, 0, `exit ${status}: stderr=${stderr}`);
+    const result = JSON.parse(stdout);
+    assert.equal(result.status, "completed");
+    assert.equal(result.review_metadata.audit_manifest.request.timeout_ms, 234567);
+    const { record: persisted } = readOnlyJobRecord(dataDir);
+    assert.equal(persisted.review_metadata.audit_manifest.request.timeout_ms, 234567);
+  } finally {
+    cleanup(dataDir);
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("run --mode=review rejects invalid CLAUDE_REVIEW_TIMEOUT_MS", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "smoke-cwd-env-timeout-invalid-"));
+  seedMinimalRepo(cwd);
+  const { stdout, status, dataDir } = runCompanion(
+    ["run", "--mode=review", "--foreground", "--model", "claude-haiku-4-5-20251001",
+     "--cwd", cwd, "--", "review invalid timeout env"],
+    { cwd, env: { CLAUDE_REVIEW_TIMEOUT_MS: "not-a-number" } }
+  );
+  try {
+    assert.equal(status, 1);
+    const result = JSON.parse(stdout);
+    assert.equal(result.error, "bad_args");
+    assert.match(result.message, /CLAUDE_REVIEW_TIMEOUT_MS must be a positive integer number of milliseconds/);
   } finally {
     cleanup(dataDir);
     rmSync(cwd, { recursive: true, force: true });
@@ -764,22 +850,26 @@ process.kill = (pid, signal) => {
 
 test("continue --job: resumes a prior session via --resume", () => {
   const cwd = mkdtempSync(path.join(tmpdir(), "smoke-continue-"));
+  writeFileSync(path.join(cwd, "seed.txt"), "continue timeout seed\n");
   const dataDir = mkdtempSync(path.join(tmpdir(), "continue-data-"));
+  const priorTimeoutMs = 777777;
   try {
     const runRes = spawnSync("node", [
       path.join(REPO_ROOT, "plugins/claude/scripts/claude-companion.mjs"),
-      "run", "--mode=rescue", "--foreground",
+      "run", "--mode=custom-review", "--foreground",
       "--model", "claude-haiku-4-5-20251001",
+      "--scope-paths", "seed.txt",
+      "--timeout-ms", String(priorTimeoutMs),
       "--cwd", cwd, "--", "seed",
     ], { cwd, encoding: "utf8",
-        env: { ...process.env, CLAUDE_BINARY: MOCK, CLAUDE_PLUGIN_DATA: dataDir } });
+        env: { ...process.env, CLAUDE_BINARY: MOCK, CLAUDE_PLUGIN_DATA: dataDir, CLAUDE_REVIEW_TIMEOUT_MS: "" } });
     const { job_id } = JSON.parse(runRes.stdout);
     const contRes = spawnSync("node", [
       path.join(REPO_ROOT, "plugins/claude/scripts/claude-companion.mjs"),
       "continue", "--job", job_id, "--foreground", "--lifecycle-events", "jsonl",
       "--cwd", cwd, "--", "follow-up",
     ], { cwd, encoding: "utf8",
-        env: { ...process.env, CLAUDE_BINARY: MOCK, CLAUDE_PLUGIN_DATA: dataDir } });
+        env: { ...process.env, CLAUDE_BINARY: MOCK, CLAUDE_PLUGIN_DATA: dataDir, CLAUDE_REVIEW_TIMEOUT_MS: "" } });
     assert.equal(contRes.status, 0, contRes.stderr);
     const lines = contRes.stdout.trim().split("\n").map((line) => JSON.parse(line));
     assert.equal(lines.length, 2);
@@ -790,6 +880,39 @@ test("continue --job: resumes a prior session via --resume", () => {
     // T7.4 (§21.3): foreground stdout is a JobRecord, not an ok-envelope.
     assert.equal(out.status, "completed");
     assert.equal(out.parent_job_id, job_id, "resume carries parent_job_id");
+    assert.equal(out.review_metadata.audit_manifest.request.timeout_ms, priorTimeoutMs);
+  } finally {
+    rmSync(dataDir, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("continue --job: --timeout-ms overrides prior timeout and env", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "smoke-continue-timeout-override-"));
+  writeFileSync(path.join(cwd, "seed.txt"), "continue timeout override seed\n");
+  const dataDir = mkdtempSync(path.join(tmpdir(), "continue-timeout-override-data-"));
+  try {
+    const runRes = spawnSync("node", [
+      path.join(REPO_ROOT, "plugins/claude/scripts/claude-companion.mjs"),
+      "run", "--mode=custom-review", "--foreground",
+      "--model", "claude-haiku-4-5-20251001",
+      "--scope-paths", "seed.txt",
+      "--timeout-ms", "777777",
+      "--cwd", cwd, "--", "seed",
+    ], { cwd, encoding: "utf8",
+        env: { ...process.env, CLAUDE_BINARY: MOCK, CLAUDE_PLUGIN_DATA: dataDir, CLAUDE_REVIEW_TIMEOUT_MS: "" } });
+    assert.equal(runRes.status, 0, runRes.stderr);
+    const { job_id } = JSON.parse(runRes.stdout);
+    const contRes = spawnSync("node", [
+      path.join(REPO_ROOT, "plugins/claude/scripts/claude-companion.mjs"),
+      "continue", "--job", job_id, "--foreground",
+      "--timeout-ms", "555555",
+      "--cwd", cwd, "--", "follow-up",
+    ], { cwd, encoding: "utf8",
+        env: { ...process.env, CLAUDE_BINARY: MOCK, CLAUDE_PLUGIN_DATA: dataDir, CLAUDE_REVIEW_TIMEOUT_MS: "999999" } });
+    assert.equal(contRes.status, 0, contRes.stderr);
+    const out = JSON.parse(contRes.stdout);
+    assert.equal(out.review_metadata.audit_manifest.request.timeout_ms, 555555);
   } finally {
     rmSync(dataDir, { recursive: true, force: true });
     rmSync(cwd, { recursive: true, force: true });

--- a/tests/smoke/gemini-companion.smoke.test.mjs
+++ b/tests/smoke/gemini-companion.smoke.test.mjs
@@ -144,12 +144,12 @@ test("gemini run api_key auth failure includes structured diagnostics before spa
   }
 });
 
-test("gemini rescue background: launched event and terminal JobRecord", async () => {
+test("gemini custom-review background: launched event and terminal JobRecord", async () => {
   const cwd = mkdtempSync(path.join(tmpdir(), "gemini-bg-cwd-"));
   seedMinimalRepo(cwd);
   const { stdout, stderr, status, dataDir } = runCompanion(
-    ["run", "--mode=rescue", "--background", "--model", "gemini-3-flash-preview",
-     "--cwd", cwd, "--", "background rescue task"],
+    ["run", "--mode=custom-review", "--background", "--model", "gemini-3-flash-preview",
+     "--scope-paths", "seed.txt", "--timeout-ms", "345678", "--cwd", cwd, "--", "background rescue task"],
     { cwd },
   );
   try {
@@ -166,10 +166,10 @@ test("gemini rescue background: launched event and terminal JobRecord", async ()
       job_id: launched.job_id,
       session_id: null,
       parent_job_id: null,
-      mode: "rescue",
-      scope: "working-tree",
+      mode: "custom-review",
+      scope: "custom",
       scope_base: null,
-      scope_paths: null,
+      scope_paths: ["seed.txt"],
       source_content_transmission: "may_be_sent",
       disclosure: "Selected source content may be sent to Gemini CLI for external review.",
     });
@@ -194,6 +194,7 @@ test("gemini rescue background: launched event and terminal JobRecord", async ()
 
     assert.ok(meta, "worker never wrote terminal meta");
     assert.equal(meta.status, "completed");
+    assert.equal(meta.review_metadata.audit_manifest.request.timeout_ms, 345678);
     assert.equal(meta.result, "Mock Gemini response.");
     assert.equal(meta.gemini_session_id, GEMINI_SESSION_ID);
     assert.deepEqual(meta.external_review, {
@@ -817,10 +818,13 @@ test("gemini background worker spawn failure writes failed JobRecord instead of 
 test("gemini continue foreground: resumes prior job session", () => {
   const cwd = mkdtempSync(path.join(tmpdir(), "gemini-continue-cwd-"));
   seedMinimalRepo(cwd);
+  writeFileSync(path.join(cwd, "seed.txt"), "continue timeout seed\n");
+  const priorTimeoutMs = 777777;
   const first = runCompanion(
-    ["run", "--mode=rescue", "--foreground", "--model", "gemini-3-flash-preview",
+    ["run", "--mode=custom-review", "--foreground", "--model", "gemini-3-flash-preview",
+     "--scope-paths", "seed.txt", "--timeout-ms", String(priorTimeoutMs),
      "--cwd", cwd, "--", "initial rescue task"],
-    { cwd },
+    { cwd, env: { GEMINI_REVIEW_TIMEOUT_MS: "" } },
   );
   try {
     assert.equal(first.status, 0, `exit ${first.status}: ${first.stderr}`);
@@ -830,7 +834,7 @@ test("gemini continue foreground: resumes prior job session", () => {
 
     const continued = runCompanion(
       ["continue", "--job", prior.job_id, "--foreground", "--cwd", cwd, "--", "continue rescue task"],
-      { cwd, dataDir: first.dataDir },
+      { cwd, dataDir: first.dataDir, env: { GEMINI_REVIEW_TIMEOUT_MS: "" } },
     );
     assert.equal(continued.status, 0, `exit ${continued.status}: ${continued.stderr}`);
     const record = JSON.parse(continued.stdout);
@@ -839,11 +843,40 @@ test("gemini continue foreground: resumes prior job session", () => {
     assert.equal(record.parent_job_id, prior.job_id);
     assert.deepEqual(record.resume_chain, [prior.gemini_session_id]);
     assert.equal(record.gemini_session_id, RESUMED_GEMINI_SESSION_ID);
+    assert.equal(record.review_metadata.audit_manifest.request.timeout_ms, priorTimeoutMs);
 
     const fx = readStdoutLog(first.dataDir, record.job_id);
     assert.equal(fx.t7_resume_id, prior.gemini_session_id);
     assert.equal(fx.t7_prompt_from_stdin, true, "Gemini continue prompt must arrive on stdin, not argv");
     assert.equal("prompt" in record, false, "full prompt must not appear on JobRecord");
+  } finally {
+    rmTree(first.dataDir);
+    rmTree(cwd);
+  }
+});
+
+test("gemini continue foreground: --timeout-ms overrides prior timeout and env", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "gemini-continue-timeout-override-cwd-"));
+  seedMinimalRepo(cwd);
+  writeFileSync(path.join(cwd, "seed.txt"), "continue timeout override seed\n");
+  const first = runCompanion(
+    ["run", "--mode=custom-review", "--foreground", "--model", "gemini-3-flash-preview",
+     "--scope-paths", "seed.txt", "--timeout-ms", "777777",
+     "--cwd", cwd, "--", "initial rescue task"],
+    { cwd, env: { GEMINI_REVIEW_TIMEOUT_MS: "" } },
+  );
+  try {
+    assert.equal(first.status, 0, `exit ${first.status}: ${first.stderr}`);
+    const prior = JSON.parse(first.stdout);
+
+    const continued = runCompanion(
+      ["continue", "--job", prior.job_id, "--foreground", "--timeout-ms", "555555",
+       "--cwd", cwd, "--", "continue rescue task"],
+      { cwd, dataDir: first.dataDir, env: { GEMINI_REVIEW_TIMEOUT_MS: "999999" } },
+    );
+    assert.equal(continued.status, 0, `exit ${continued.status}: ${continued.stderr}`);
+    const record = JSON.parse(continued.stdout);
+    assert.equal(record.review_metadata.audit_manifest.request.timeout_ms, 555555);
   } finally {
     rmTree(first.dataDir);
     rmTree(cwd);
@@ -1294,6 +1327,7 @@ test("gemini review foreground: omits native Gemini sandbox inside Codex sandbox
     assert.equal(record.review_metadata.raw_output.parsed_ok, true);
     assert.match(record.review_metadata.audit_manifest.rendered_prompt_hash.value, /^[a-f0-9]{64}$/);
     assert.equal(record.review_metadata.audit_manifest.request.model, record.model);
+    assert.equal(record.review_metadata.audit_manifest.request.timeout_ms, 600000);
     assert.match(record.review_metadata.audit_manifest.prompt_builder.plugin_commit, /^[a-f0-9]{40}$/);
     assert.notEqual(
       record.review_metadata.audit_manifest.prompt_builder.plugin_commit,
@@ -1310,6 +1344,91 @@ test("gemini review foreground: omits native Gemini sandbox inside Codex sandbox
     assert.equal(fx.t7_sandbox, false, "Gemini -s must be omitted under Codex to avoid nested sandbox-exec");
     assert.equal(fx.t7_skip_trust, true, "Gemini review must still pass --skip-trust");
     assert.equal(fx.t7_prompt_from_stdin, true, "Gemini prompt must arrive on stdin, not argv");
+  } finally {
+    rmTree(dataDir);
+    rmTree(cwd);
+  }
+});
+
+test("gemini review foreground: --timeout-ms overrides review timeout audit metadata", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "gemini-review-timeout-cwd-"));
+  seedMinimalRepo(cwd);
+  const { stdout, stderr, status, dataDir } = runCompanion(
+    ["run", "--mode=review", "--foreground", "--cwd", cwd, "--timeout-ms", "123456", "--", "review timeout override"],
+    { cwd, env: {
+      CODEX_SANDBOX: "seatbelt",
+      GEMINI_MOCK_ASSERT_FILE: "seed.txt",
+      GEMINI_MOCK_ASSERT_PROMPT_INCLUDES: "Provider: Gemini CLI",
+    } },
+  );
+  try {
+    assert.equal(status, 0, `exit ${status}: ${stderr}`);
+    const record = JSON.parse(stdout);
+    assert.equal(record.status, "completed");
+    assert.equal(record.review_metadata.audit_manifest.request.timeout_ms, 123456);
+    const { record: persisted } = readOnlyJobRecord(dataDir);
+    assert.equal(persisted.review_metadata.audit_manifest.request.timeout_ms, 123456);
+  } finally {
+    rmTree(dataDir);
+    rmTree(cwd);
+  }
+});
+
+test("gemini review foreground rejects --timeout-ms without a value", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "gemini-review-timeout-missing-cwd-"));
+  seedMinimalRepo(cwd);
+  const { stdout, status, dataDir } = runCompanion(
+    ["run", "--mode=review", "--foreground", "--cwd", cwd, "--timeout-ms", "--", "review timeout missing"],
+    { cwd },
+  );
+  try {
+    assert.equal(status, 1);
+    const result = JSON.parse(stdout);
+    assert.equal(result.error, "bad_args");
+    assert.match(result.message, /--timeout-ms must be a positive integer number of milliseconds/);
+  } finally {
+    rmTree(dataDir);
+    rmTree(cwd);
+  }
+});
+
+test("gemini review foreground: GEMINI_REVIEW_TIMEOUT_MS sets review timeout audit metadata", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "gemini-review-env-timeout-cwd-"));
+  seedMinimalRepo(cwd);
+  const { stdout, stderr, status, dataDir } = runCompanion(
+    ["run", "--mode=review", "--foreground", "--cwd", cwd, "--", "review timeout env override"],
+    { cwd, env: {
+      CODEX_SANDBOX: "seatbelt",
+      GEMINI_REVIEW_TIMEOUT_MS: "234567",
+      GEMINI_MOCK_ASSERT_FILE: "seed.txt",
+      GEMINI_MOCK_ASSERT_PROMPT_INCLUDES: "Provider: Gemini CLI",
+    } },
+  );
+  try {
+    assert.equal(status, 0, `exit ${status}: ${stderr}`);
+    const record = JSON.parse(stdout);
+    assert.equal(record.status, "completed");
+    assert.equal(record.review_metadata.audit_manifest.request.timeout_ms, 234567);
+    const { record: persisted } = readOnlyJobRecord(dataDir);
+    assert.equal(persisted.review_metadata.audit_manifest.request.timeout_ms, 234567);
+  } finally {
+    rmTree(dataDir);
+    rmTree(cwd);
+  }
+});
+
+test("gemini review foreground rejects invalid GEMINI_REVIEW_TIMEOUT_MS", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "gemini-review-env-timeout-invalid-cwd-"));
+  seedMinimalRepo(cwd);
+  const { stdout, status, dataDir } = runCompanion(
+    ["run", "--mode=review", "--foreground", "--cwd", cwd, "--", "review invalid timeout env"],
+    { cwd, env: { GEMINI_REVIEW_TIMEOUT_MS: "Infinity" } },
+  );
+  try {
+    assert.equal(status, 1);
+    const result = JSON.parse(stdout);
+    assert.equal(result.error, "bad_args");
+    assert.match(result.message, /GEMINI_REVIEW_TIMEOUT_MS must be a positive integer number of milliseconds/);
   } finally {
     rmTree(dataDir);
     rmTree(cwd);

--- a/tests/smoke/grok-web.smoke.test.mjs
+++ b/tests/smoke/grok-web.smoke.test.mjs
@@ -303,6 +303,52 @@ test("doctor chat probe uses a separate configurable timeout", async () => {
   });
 });
 
+for (const [name, envName] of [
+  ["review", "GROK_WEB_TIMEOUT_MS"],
+  ["models doctor", "GROK_WEB_DOCTOR_TIMEOUT_MS"],
+  ["chat doctor", "GROK_WEB_CHAT_DOCTOR_TIMEOUT_MS"],
+]) {
+  test(`rejects invalid ${name} timeout env`, () => {
+    const result = run(["doctor"], {
+      env: {
+        [envName]: "not-a-number",
+      },
+    });
+    const parsed = parseStdout(result);
+
+    assert.equal(result.status, 1);
+    assert.equal(parsed.error_code, "bad_args");
+    assert.match(parsed.error_message, new RegExp(`${envName} must be a positive integer number of milliseconds`));
+  });
+}
+
+test("custom-review rejects invalid GROK_WEB_TIMEOUT_MS env", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "grok-web-invalid-review-timeout-cwd-"));
+  try {
+    writeFileSync(path.join(cwd, "review.js"), "export const value = 42;\n");
+    const result = run([
+      "run",
+      "--mode", "custom-review",
+      "--scope", "custom",
+      "--scope-paths", "review.js",
+      "--foreground",
+      "--prompt", "Check this file.",
+    ], {
+      cwd,
+      env: {
+        GROK_WEB_TIMEOUT_MS: "not-a-number",
+      },
+    });
+    const parsed = parseStdout(result);
+
+    assert.equal(result.status, 1);
+    assert.equal(parsed.error_code, "bad_args");
+    assert.match(parsed.error_message, /GROK_WEB_TIMEOUT_MS must be a positive integer number of milliseconds/);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test("doctor is not review-ready when models work but chat returns upstream 400", async () => {
   await withServer(async (req, res) => {
     res.setHeader("content-type", "application/json");
@@ -452,6 +498,7 @@ test("custom-review sends selected source to a local Grok web tunnel and persist
       env: {
         GROK_WEB_BASE_URL: baseUrl,
         GROK_WEB_TUNNEL_API_KEY: "secret-cookie-like-token",
+        GROK_WEB_TIMEOUT_MS: "123456",
         GROK_PLUGIN_DATA: dataDir,
       },
     });
@@ -477,6 +524,7 @@ test("custom-review sends selected source to a local Grok web tunnel and persist
     });
     assert.match(record.review_metadata.audit_manifest.rendered_prompt_hash.value, /^[a-f0-9]{64}$/);
     assert.equal(record.review_metadata.audit_manifest.request.model, "grok-4.20-fast");
+    assert.equal(record.review_metadata.audit_manifest.request.timeout_ms, 123456);
     assert.equal(record.review_metadata.audit_manifest.request.temperature, 0);
     assert.match(record.review_metadata.audit_manifest.prompt_builder.plugin_commit, /^[a-f0-9]{40}$/);
     assert.notEqual(
@@ -1337,6 +1385,9 @@ test("custom-review marks stalled uploaded tunnel requests as unknown transmissi
     assert.equal(result.status, 1);
     assert.ok(receivedBytes > 0);
     assert.equal(record.error_code, "tunnel_timeout");
+    assert.equal(record.review_metadata.audit_manifest.request.timeout_ms, 1000);
+    assert.equal(typeof record.error_summary, "string");
+    assert.match(record.error_summary, /configured_timeout_ms=1000/);
     assert.equal(record.external_review.source_content_transmission, "unknown");
     assert.match(record.external_review.disclosure, /may have been sent/i);
   });
@@ -1645,6 +1696,8 @@ for (const { status, code } of [
       assert.equal(record.status, "failed");
       assert.equal(record.error_code, code);
       assert.equal(record.http_status, status);
+      assert.equal(record.review_metadata.audit_manifest.request.timeout_ms, 600000);
+      assert.match(record.error_summary, /configured_timeout_ms=600000/);
       assert.doesNotMatch(result.stdout, /secret-cookie-like-token/);
       assert.match(record.error_message, /\[REDACTED\]/);
     });
@@ -1678,6 +1731,7 @@ test("custom-review maps malformed tunnel responses", async () => {
     assert.equal(result.status, 1);
     assert.equal(record.status, "failed");
     assert.equal(record.error_code, "malformed_response");
+    assert.equal(record.review_metadata.audit_manifest.request.timeout_ms, 600000);
     assert.match(record.suggested_action, /unsupported response shape/i);
   });
 });
@@ -1706,6 +1760,7 @@ test("local tunnel connection failure is structured as not sent", () => {
   assert.equal(result.status, 1);
   assert.equal(record.status, "failed");
   assert.equal(record.error_code, "tunnel_unavailable");
+  assert.equal(record.review_metadata.audit_manifest.request.timeout_ms, 500);
   assert.equal(record.external_review.source_content_transmission, "not_sent");
   assert.match(record.suggested_action, /Start the local Grok web tunnel/i);
   assert.doesNotMatch(result.stdout, /secret-cookie-like-token/);

--- a/tests/smoke/kimi-companion.smoke.test.mjs
+++ b/tests/smoke/kimi-companion.smoke.test.mjs
@@ -424,6 +424,26 @@ test("kimi ping rejects fractional timeout milliseconds", () => {
   }
 });
 
+test("kimi run rejects --timeout-ms without a value", () => withRepo((cwd) => {
+  const result = runCompanion([
+    "run",
+    "--mode",
+    "custom-review",
+    "--cwd",
+    cwd,
+    "--scope-paths",
+    "seed.txt",
+    "--foreground",
+    "--timeout-ms",
+    "--",
+    "Review this scope.",
+  ], { cwd });
+  assert.equal(result.status, 1);
+  const parsed = parseJson(result.stdout);
+  assert.equal(parsed.error, "bad_args");
+  assert.match(parsed.message, /--timeout-ms must be a positive integer number of milliseconds/);
+}));
+
 for (const mode of ["review", "adversarial-review", "custom-review"]) {
   test(`kimi ${mode} prompt requires a self-contained final verdict`, () => withRepo((cwd) => {
     const result = runCompanion(kimiPromptAssertionArgs(cwd, mode), {
@@ -495,6 +515,71 @@ test("kimi foreground review timeout returns actionable JobRecord", () => withRe
   assert.equal(persisted.error_code, "timeout");
 }));
 
+test("kimi foreground review --timeout-ms overrides review timeout audit metadata", () => withRepo((cwd) => {
+  const result = runCompanion([
+    "run",
+    "--mode",
+    "custom-review",
+    "--cwd",
+    cwd,
+    "--scope-paths",
+    "seed.txt",
+    "--foreground",
+    "--timeout-ms",
+    "123456",
+    "--",
+    "Review this scope.",
+  ], { cwd });
+  assert.equal(result.status, 0, result.stderr);
+  const record = parseJson(result.stdout);
+  assert.equal(record.status, "completed");
+  assert.equal(record.review_metadata.audit_manifest.request.timeout_ms, 123456);
+  const { record: persisted } = readOnlyJobRecord(result.dataDir);
+  assert.equal(persisted.review_metadata.audit_manifest.request.timeout_ms, 123456);
+}));
+
+test("kimi foreground review KIMI_REVIEW_TIMEOUT_MS sets review timeout audit metadata", () => withRepo((cwd) => {
+  const result = runCompanion([
+    "run",
+    "--mode",
+    "custom-review",
+    "--cwd",
+    cwd,
+    "--scope-paths",
+    "seed.txt",
+    "--foreground",
+    "--",
+    "Review this scope.",
+  ], { cwd, env: { KIMI_REVIEW_TIMEOUT_MS: "234567" } });
+  assert.equal(result.status, 0, result.stderr);
+  const record = parseJson(result.stdout);
+  assert.equal(record.status, "completed");
+  assert.equal(record.review_metadata.audit_manifest.request.timeout_ms, 234567);
+  const { record: persisted } = readOnlyJobRecord(result.dataDir);
+  assert.equal(persisted.review_metadata.audit_manifest.request.timeout_ms, 234567);
+}));
+
+for (const invalidTimeoutEnv of ["-1", "9007199254740992"]) {
+  test(`kimi foreground review rejects invalid KIMI_REVIEW_TIMEOUT_MS ${invalidTimeoutEnv}`, () => withRepo((cwd) => {
+    const result = runCompanion([
+      "run",
+      "--mode",
+      "custom-review",
+      "--cwd",
+      cwd,
+      "--scope-paths",
+      "seed.txt",
+      "--foreground",
+      "--",
+      "Review this scope.",
+    ], { cwd, env: { KIMI_REVIEW_TIMEOUT_MS: invalidTimeoutEnv } });
+    assert.equal(result.status, 1);
+    const parsed = parseJson(result.stdout);
+    assert.equal(parsed.error, "bad_args");
+    assert.match(parsed.message, /KIMI_REVIEW_TIMEOUT_MS must be a positive integer number of milliseconds/);
+  }));
+}
+
 test("kimi background run: launched event and terminal JobRecord carry external_review", async () => {
   const cwd = mkdtempSync(path.join(tmpdir(), "kimi-bg-cwd-"));
   fixtureSeedRepo(cwd);
@@ -507,6 +592,8 @@ test("kimi background run: launched event and terminal JobRecord carry external_
     cwd,
     "--scope-paths",
     "seed.txt",
+    "--timeout-ms",
+    "345678",
     "--background",
     "--",
     "Review this scope.",
@@ -529,6 +616,7 @@ test("kimi background run: launched event and terminal JobRecord carry external_
 
     const meta = await waitForTerminalJob(result.dataDir, launched.job_id);
     assert.equal(meta.status, "completed");
+    assert.equal(meta.review_metadata.audit_manifest.request.timeout_ms, 345678);
     assert.equal(meta.result, "Mock Kimi response.");
     assert.equal(meta.kimi_session_id, KIMI_SESSION_ID);
     assert.deepEqual(meta.external_review, {
@@ -761,6 +849,26 @@ test("kimi run rejects invalid max-step budgets before target launch", () => wit
   assert.match(parsed.message, /--max-steps-per-turn/);
 }));
 
+test("kimi run rejects --max-steps-per-turn without a value", () => withRepo((cwd) => {
+  const result = runCompanion([
+    "run",
+    "--mode",
+    "custom-review",
+    "--cwd",
+    cwd,
+    "--scope-paths",
+    "seed.txt",
+    "--foreground",
+    "--max-steps-per-turn",
+    "--",
+    "Review this scope.",
+  ], { cwd });
+  assert.equal(result.status, 1);
+  const parsed = parseJson(result.stdout);
+  assert.equal(parsed.error, "bad_args");
+  assert.match(parsed.message, /--max-steps-per-turn/);
+}));
+
 test("kimi background review preserves configured max-step budget outside public JobRecord", () => withRepo((cwd) => {
   const dataDir = mkdtempSync(path.join(tmpdir(), "kimi-background-max-steps-data-"));
   const launched = runCompanion([
@@ -779,7 +887,7 @@ test("kimi background review preserves configured max-step budget outside public
   ], {
     cwd,
     dataDir,
-    env: { KIMI_MOCK_ASSERT_MAX_STEPS_PER_TURN: "48" },
+    env: { KIMI_REVIEW_TIMEOUT_MS: "", KIMI_MOCK_ASSERT_MAX_STEPS_PER_TURN: "48" },
   });
   assert.equal(launched.status, 0, launched.stderr);
   const payload = parseJson(launched.stdout);
@@ -831,6 +939,7 @@ test("kimi background review step-limit exhaustion preserves private max-step bu
 
 test("kimi continue reuses prior private max-step budget without JobRecord drift", () => withRepo((cwd) => {
   const dataDir = mkdtempSync(path.join(tmpdir(), "kimi-continue-max-steps-data-"));
+  const priorTimeoutMs = 900000;
   const first = runCompanion([
     "run",
     "--mode",
@@ -842,17 +951,20 @@ test("kimi continue reuses prior private max-step budget without JobRecord drift
     "--foreground",
     "--max-steps-per-turn",
     "48",
+    "--timeout-ms",
+    String(priorTimeoutMs),
     "--",
     "Review this scope.",
   ], {
     cwd,
     dataDir,
-    env: { KIMI_MOCK_ASSERT_MAX_STEPS_PER_TURN: "48" },
+    env: { KIMI_REVIEW_TIMEOUT_MS: "", KIMI_MOCK_ASSERT_MAX_STEPS_PER_TURN: "48" },
   });
   assert.equal(first.status, 0, first.stderr);
   const firstRecord = parseJson(first.stdout);
   assert.equal(firstRecord.status, "completed");
   assert.equal("max_steps_per_turn" in firstRecord, false);
+  assert.equal(firstRecord.review_metadata.audit_manifest.request.timeout_ms, priorTimeoutMs);
 
   const continued = runCompanion([
     "continue",
@@ -873,6 +985,95 @@ test("kimi continue reuses prior private max-step budget without JobRecord drift
   assert.equal(continuedRecord.status, "completed");
   assert.equal(continuedRecord.parent_job_id, firstRecord.job_id);
   assert.equal("max_steps_per_turn" in continuedRecord, false);
+  assert.equal(continuedRecord.review_metadata.audit_manifest.request.timeout_ms, priorTimeoutMs);
+}));
+
+test("kimi continue reuses audit timeout when runtime sidecar is missing", () => withRepo((cwd) => {
+  const dataDir = mkdtempSync(path.join(tmpdir(), "kimi-continue-timeout-audit-fallback-data-"));
+  const priorTimeoutMs = 888888;
+  const first = runCompanion([
+    "run",
+    "--mode",
+    "custom-review",
+    "--cwd",
+    cwd,
+    "--scope-paths",
+    "seed.txt",
+    "--foreground",
+    "--timeout-ms",
+    String(priorTimeoutMs),
+    "--",
+    "Review this scope.",
+  ], {
+    cwd,
+    dataDir,
+    env: { KIMI_REVIEW_TIMEOUT_MS: "" },
+  });
+  assert.equal(first.status, 0, first.stderr);
+  const firstRecord = parseJson(first.stdout);
+  rmSync(findJobPaths(dataDir, firstRecord.job_id).runtimeOptionsPath, { force: true });
+
+  const continued = runCompanion([
+    "continue",
+    "--job",
+    firstRecord.job_id,
+    "--cwd",
+    cwd,
+    "--foreground",
+    "--",
+    "Continue this review.",
+  ], {
+    cwd,
+    dataDir,
+    env: { KIMI_REVIEW_TIMEOUT_MS: "" },
+  });
+  assert.equal(continued.status, 0, continued.stderr);
+  const continuedRecord = parseJson(continued.stdout);
+  assert.equal(continuedRecord.review_metadata.audit_manifest.request.timeout_ms, priorTimeoutMs);
+}));
+
+test("kimi continue --timeout-ms overrides prior timeout and env", () => withRepo((cwd) => {
+  const dataDir = mkdtempSync(path.join(tmpdir(), "kimi-continue-timeout-override-data-"));
+  const first = runCompanion([
+    "run",
+    "--mode",
+    "custom-review",
+    "--cwd",
+    cwd,
+    "--scope-paths",
+    "seed.txt",
+    "--foreground",
+    "--timeout-ms",
+    "777777",
+    "--",
+    "Review this scope.",
+  ], {
+    cwd,
+    dataDir,
+    env: { KIMI_REVIEW_TIMEOUT_MS: "" },
+  });
+  assert.equal(first.status, 0, first.stderr);
+  const firstRecord = parseJson(first.stdout);
+
+  const continued = runCompanion([
+    "continue",
+    "--job",
+    firstRecord.job_id,
+    "--cwd",
+    cwd,
+    "--foreground",
+    "--timeout-ms",
+    "555555",
+    "--",
+    "Continue this review.",
+  ], {
+    cwd,
+    dataDir,
+    env: { KIMI_REVIEW_TIMEOUT_MS: "999999" },
+  });
+  assert.equal(continued.status, 0, continued.stderr);
+  const continuedRecord = parseJson(continued.stdout);
+  assert.equal(continuedRecord.review_metadata.audit_manifest.request.timeout_ms, 555555);
 }));
 
 test("kimi continue background: launched event and terminal JobRecord keep parent metadata", async () => {
@@ -1254,6 +1455,7 @@ for (const mode of ["review", "adversarial-review", "custom-review"]) {
     assert.equal(persisted.review_metadata.raw_output.parsed_ok, true);
     assert.match(persisted.review_metadata.audit_manifest.rendered_prompt_hash.value, /^[a-f0-9]{64}$/);
     assert.equal(persisted.review_metadata.audit_manifest.request.model, persisted.model);
+    assert.equal(persisted.review_metadata.audit_manifest.request.timeout_ms, 600000);
     assert.match(persisted.review_metadata.audit_manifest.prompt_builder.plugin_commit, /^[a-f0-9]{40}$/);
     assert.notEqual(
       persisted.review_metadata.audit_manifest.prompt_builder.plugin_commit,


### PR DESCRIPTION
## Summary

Closes #86.

- set reviewer timeout defaults to 600000 ms across API reviewers, Grok, Claude, Gemini, and Kimi
- add CLI/env timeout overrides for companion run/continue paths and preserve background-worker overrides through private runtime sidecars
- persist effective timeout values in review audit manifests, including API HTTP/malformed failure paths
- document the timeout contract and update command/skill docs
- document Kimi's separate step-budget failure mode so `step_limit_exceeded` is not mistaken for a timeout
- fix the Greptile P1 follow-up so Kimi `continue` reuses a prior job's custom `timeout_ms` when no new flag is supplied

## Verification

Current head: `9367d6aec9910d544fe575aaef29fa717123f043`.

Local verification after the latest doc update:

- `npm run lint` -> passed
- `npm run lint:sync` -> passed
- `git diff --check` -> passed
- `node --test tests/smoke/kimi-companion.smoke.test.mjs --test-name-pattern "step-limit|timeout"` -> 51 passed, 0 failed
- pre-commit reran `npm test` -> 996 total, 990 passed, 0 failed, 6 skipped

GitHub checks for the current head are pending after the latest push.

## External Review Evidence

Earlier external-review evidence on this branch:

- Kimi custom-review: source sent; no blockers on the earlier reviewed head.
- DeepSeek custom-review: source sent; found missing API error-path timeout diagnostics; fixed and targeted DeepSeek re-review confirmed no blockers for that path.
- Gemini custom-review: source sent, timed out before clean completion but surfaced background timeout override loss; fixed with background regression coverage.
- GLM custom-review: provider unavailable/fetch failed; source transmission unknown.
- Claude/Grok were not review-ready in doctor checks, so no source was sent to those providers.

Additional exact-head evidence from PR #91 is now recorded on #86: Kimi with `--timeout-ms 600000` failed with `step_limit_exceeded` at `max_steps_per_turn: 32`, which is why this PR now documents the separate Kimi step-budget knob alongside timeout configuration.

Greptile previously found one P1 issue on Kimi continuation timeout inheritance. It was fixed and covered by focused Kimi smoke coverage; the inline review thread was resolved before the current head.