### PR TITLE
Reject valueless reviewer prompts

### DIFF
--- a/plugins/api-reviewers/scripts/api-reviewer.mjs
+++ b/plugins/api-reviewers/scripts/api-reviewer.mjs
@@ -1042,7 +1042,11 @@ function promptFor(mode, userPrompt, scopeInfo, providerName = "Direct API revie
 }
 
 function hasPromptText(value) {
-  return String(value ?? "").trim().length > 0;
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function promptHead(value) {
+  return hasPromptText(value) ? value.slice(0, 200) : "";
 }
 
 function requestFieldMatches(actual, expected) {
@@ -1489,7 +1493,7 @@ function buildRecord({ provider, cfg, mode, options, scopeInfo, execution, start
     dispose_effective: false,
     scope_base: scopeInfo.scope_base ?? null,
     scope_paths: scopeInfo.scope_paths ?? null,
-    prompt_head: String(options.prompt ?? "").slice(0, 200),
+    prompt_head: promptHead(options.prompt),
     review_metadata: buildReviewMetadata(cfg, scopeInfo, execution),
     schema_spec: null,
     binary: null,

--- a/plugins/grok/scripts/grok-web-reviewer.mjs
+++ b/plugins/grok/scripts/grok-web-reviewer.mjs
@@ -509,7 +509,11 @@ function promptFor(mode, userPrompt, scopeInfo) {
 }
 
 function hasPromptText(value) {
-  return String(value ?? "").trim().length > 0;
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function promptHead(value) {
+  return hasPromptText(value) ? value.slice(0, 200) : "";
 }
 
 function parseJson(text) {
@@ -940,7 +944,7 @@ function buildRecord({ cfg, mode, options, scopeInfo, execution, startedAt, ende
     dispose_effective: false,
     scope_base: scopeInfo.scope_base ?? null,
     scope_paths: scopeInfo.scope_paths ?? null,
-    prompt_head: String(options.prompt ?? "").slice(0, 200),
+    prompt_head: promptHead(options.prompt),
     review_metadata: buildReviewMetadata(cfg, scopeInfo, execution),
     schema_spec: null,
     binary: null,

--- a/tests/smoke/api-reviewers.smoke.test.mjs
+++ b/tests/smoke/api-reviewers.smoke.test.mjs
@@ -2122,6 +2122,46 @@ test("direct API reviewers reject missing prompt before launch or source transmi
   assert.doesNotMatch(result.stdout, /secret-test-value/);
 });
 
+test("direct API reviewers reject blank or valueless prompt flags before launch", async () => {
+  for (const promptArgs of [
+    ["--prompt", ""],
+    ["--prompt", "   "],
+    ["--prompt"],
+    ["--prompt="],
+    ["--prompt=   "],
+    ["--prompt", "--unused-review-flag"],
+  ]) {
+    const cwd = makeWorkspace();
+    const result = await run([
+      "run",
+      "--provider", "deepseek",
+      "--mode", "custom-review",
+      "--scope", "custom",
+      "--scope-paths", "seed.txt",
+      "--foreground",
+      "--lifecycle-events", "jsonl",
+      ...promptArgs,
+    ], {
+      cwd,
+      env: {
+        API_REVIEWERS_MOCK_RESPONSE: mockResponse("deepseek-v4-pro"),
+        DEEPSEEK_API_KEY: "secret-test-value",
+      },
+    });
+    assert.equal(result.status, 1);
+    const lines = parseJsonLines(result.stdout);
+    assert.equal(lines.length, 1);
+    const [record] = lines;
+    assert.equal(record.status, "failed");
+    assert.equal(record.error_code, "bad_args");
+    assert.match(record.error_message, /prompt is required/);
+    assert.equal(record.prompt_head, "");
+    assertDirectApiNotSent(record, "DeepSeek");
+    assert.doesNotMatch(result.stdout, /external_review_launched/);
+    assert.doesNotMatch(result.stdout, /secret-test-value/);
+  }
+});
+
 test("direct API reviewers fail closed when no explicit API-key auth is available", async () => {
   const cwd = makeWorkspace();
   const result = await run([

--- a/tests/smoke/grok-web.smoke.test.mjs
+++ b/tests/smoke/grok-web.smoke.test.mjs
@@ -775,6 +775,52 @@ test("run rejects missing prompt before launch or source transmission", () => {
   }
 });
 
+test("run rejects blank or valueless prompt flags before launch", () => {
+  for (const promptArgs of [
+    ["--prompt", ""],
+    ["--prompt", "   "],
+    ["--prompt"],
+    ["--prompt="],
+    ["--prompt=   "],
+    ["--prompt", "--unused-review-flag"],
+  ]) {
+    const cwd = mkdtempSync(path.join(tmpdir(), "grok-web-workspace-"));
+    const dataDir = mkdtempSync(path.join(tmpdir(), "grok-web-data-"));
+    try {
+      writeFileSync(path.join(cwd, "review.js"), "export const value = 42;\n");
+
+      const result = run([
+        "run",
+        "--mode", "custom-review",
+        "--scope", "custom",
+        "--scope-paths", "review.js",
+        "--foreground",
+        "--lifecycle-events", "jsonl",
+        ...promptArgs,
+      ], {
+        cwd,
+        env: {
+          GROK_PLUGIN_DATA: dataDir,
+          GROK_WEB_BASE_URL: "http://127.0.0.1:9/api",
+        },
+      });
+      const lines = parseJsonLines(result);
+      assert.equal(result.status, 1);
+      assert.equal(lines.length, 1);
+      const [record] = lines;
+      assert.equal(record.status, "failed");
+      assert.equal(record.error_code, "bad_args");
+      assert.match(record.error_message, /prompt is required/);
+      assert.equal(record.prompt_head, "");
+      assert.equal(record.external_review.source_content_transmission, "not_sent");
+      assert.doesNotMatch(result.stdout, /external_review_launched/);
+    } finally {
+      rmTree(cwd);
+      rmTree(dataDir);
+    }
+  }
+});
+
 test("custom-review rejects aggregate selected source that exceeds the prompt cap before contacting the tunnel", () => {
   const cwd = mkdtempSync(path.join(tmpdir(), "grok-web-workspace-"));
   const files = [];


### PR DESCRIPTION
## Summary
- Tighten API reviewer and Grok prompt validation so only non-empty string prompts pass.
- Add smoke coverage for blank, whitespace-only, and bare valueless `--prompt` flags before lifecycle launch or source transmission.

## Test Plan
- `node --test --test-name-pattern "blank or valueless prompt" tests/smoke/api-reviewers.smoke.test.mjs tests/smoke/grok-web.smoke.test.mjs`