### PR TITLE
Preserve Grok audit timeout fallback

### DIFF
--- a/plugins/grok/scripts/grok-web-reviewer.mjs
+++ b/plugins/grok/scripts/grok-web-reviewer.mjs
@@ -1074,7 +1074,7 @@ function buildReviewMetadata(cfg, scopeInfo, execution = null) {
     request: {
       provider: cfg.display_name,
       model: cfg.model,
-      timeoutMs: execution.diagnostics?.configured_timeout_ms ?? null,
+      timeoutMs: execution.diagnostics?.configured_timeout_ms ?? cfg.timeout_ms ?? null,
       maxTokens: execution.diagnostics?.max_tokens ?? null,
       temperature: execution.diagnostics?.temperature ?? null,
       stream: false,

--- a/plugins/grok/scripts/grok-web-reviewer.mjs
+++ b/plugins/grok/scripts/grok-web-reviewer.mjs
@@ -1667,6 +1667,7 @@ async function runCli() {
 }
 
 export {
+  buildReviewMetadata,
   readUtf8ScopeFileWithinLimit,
   releaseStateLock,
   sameFileIdentity,

--- a/tests/smoke/grok-web.smoke.test.mjs
+++ b/tests/smoke/grok-web.smoke.test.mjs
@@ -1924,6 +1924,7 @@ test("tunnel invocation catch is separated from prompt construction catch", () =
   const source = readFileSync(COMPANION, "utf8");
   assert.match(source, /prompt = promptFor\(/);
   assert.match(source, /providerFailure\(e\.message\.startsWith\("bad_args:"\) \? "bad_args" : "scope_failed"/);
+  assert.match(source, /timeoutMs: execution\.diagnostics\?\.configured_timeout_ms \?\? cfg\.timeout_ms \?\? null/);
   assert.match(source, /execution = await callGrokTunnel\(cfg, prompt\)/);
   assert.match(source, /"tunnel_error"/);
   assert.match(source, /payloadSentForFetchError\(e\)/);

--- a/tests/smoke/grok-web.smoke.test.mjs
+++ b/tests/smoke/grok-web.smoke.test.mjs
@@ -1924,10 +1924,38 @@ test("tunnel invocation catch is separated from prompt construction catch", () =
   const source = readFileSync(COMPANION, "utf8");
   assert.match(source, /prompt = promptFor\(/);
   assert.match(source, /providerFailure\(e\.message\.startsWith\("bad_args:"\) \? "bad_args" : "scope_failed"/);
-  assert.match(source, /timeoutMs: execution\.diagnostics\?\.configured_timeout_ms \?\? cfg\.timeout_ms \?\? null/);
   assert.match(source, /execution = await callGrokTunnel\(cfg, prompt\)/);
   assert.match(source, /"tunnel_error"/);
   assert.match(source, /payloadSentForFetchError\(e\)/);
+});
+
+test("audit manifest timeout falls back to configured Grok timeout", async () => {
+  const { buildReviewMetadata } = await import(`file://${COMPANION}`);
+  const metadata = buildReviewMetadata({
+    display_name: "Grok Web",
+    model: "grok-test",
+    timeout_ms: 777777,
+  }, {
+    scope: "custom",
+    scope_base: "HEAD~1",
+    scope_paths: ["review.js"],
+    files: [{ path: "review.js", text: "export const value = 1;\n" }],
+    repository: "owner/repo",
+    head_ref: "feature/audit-timeout",
+    base_commit: "base-sha",
+    head_commit: "head-sha",
+  }, {
+    prompt: "Review this selected source.",
+    parsed: { ok: true, result: "Verdict: no findings." },
+    exitCode: 0,
+    session_id: "grok-test-session",
+  });
+
+  assert.equal(metadata.audit_manifest.request.timeout_ms, 777777);
+  assert.equal(metadata.audit_manifest.request.model, "grok-test");
+  assert.equal(metadata.audit_manifest.provider_ids.session_id, "grok-test-session");
+  assert.equal(JSON.stringify(metadata.audit_manifest).includes("Review this selected source."), false);
+  assert.equal(JSON.stringify(metadata.audit_manifest).includes("export const value = 1"), false);
 });
 
 for (const { status, code, quotaBody = false } of [


### PR DESCRIPTION
## Summary
- restores the Grok audit-manifest timeout fallback to the configured review timeout when an execution record has no diagnostics
- adds a regression guard for the fallback in the Grok smoke suite

## Context
- Addresses Greptile's #88 review comment after #88 was merged externally before the fix could land there.
- #88 merged at 9367d6a / merge commit 8a0309b; this PR is based on current origin/main.

## Verification
- Internal adversarial review: no blocker found; the change is limited to audit metadata fallback and preserves diagnostic precedence.
- node --test tests/smoke/grok-web.smoke.test.mjs: 60 pass, 0 fail
- Pre-commit on the original cherry-picked commit also ran npm test: 996 total, 990 pass, 0 fail, 6 skipped

Do not merge without explicit approval.