### PR TITLE
Classify Claude OAuth inference rejection

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ lets Claude Code delegate to Codex.
 
 - Codex with plugin marketplace support.
 - Git and Node.js available on `PATH`.
-- Claude Code installed and authenticated if you enable the Claude plugin.
+- Claude Code installed and OAuth-authenticated if you enable the Claude plugin.
+  `claude auth status` alone is not enough for review readiness; `/claude-setup`
+  also verifies OAuth-only non-interactive `claude -p` inference because status
+  can report logged-in while print-mode inference returns HTTP 401.
 - Gemini CLI installed and authenticated if you enable the Gemini plugin.
 - Kimi Code CLI installed and authenticated if you enable the Kimi plugin.
 - A local Grok web tunnel if you enable the Grok plugin. The default endpoint
@@ -280,7 +283,7 @@ command docs:
 
 | Command | Status | Behavior |
 |---|---|---|
-| `/claude-setup` / `/gemini-setup` / `/kimi-setup` | Packaged | Target CLI availability and OAuth readiness check. |
+| `/claude-setup` / `/gemini-setup` / `/kimi-setup` | Packaged | Target CLI availability and OAuth readiness check. Claude setup includes an OAuth-only non-interactive inference probe, not just `claude auth status`. |
 | `/deepseek-setup` / `/glm-setup` | Packaged | Direct API-key readiness check; reports key names only. |
 | `/grok-setup` | Packaged | Grok subscription-backed local tunnel readiness check; probes `/v1/models` by default and reports key names only. |
 | `/claude-review [focus]` / `/gemini-review [focus]` / `/kimi-review [focus]` | Packaged | Read-only review profile over the selected scope. |

--- a/plugins/api-reviewers/scripts/lib/external-review.mjs
+++ b/plugins/api-reviewers/scripts/lib/external-review.mjs
@@ -37,6 +37,7 @@ const CONTENT_RECEIVED_ERROR_CODES = Object.freeze(new Set([
   "gemini_error",
   "kimi_error",
   "parse_error",
+  "oauth_inference_rejected",
   "step_limit_exceeded",
   "usage_limited",
   "finalization_failed",
@@ -57,6 +58,7 @@ const NOT_SENT_DISCLOSURE_BY_STATUS = Object.freeze({
 const NOT_SENT_DISCLOSURE_BY_ERROR = Object.freeze({
   scope_failed: (provider) => `Selected source content was not sent to ${provider}; the review scope was rejected before the target process was started.`,
   spawn_failed: (provider) => `Selected source content was not sent to ${provider}; the target process was not spawned.`,
+  oauth_inference_rejected: (provider) => `Selected source content was not sent to ${provider}; OAuth inference readiness was rejected before the review target was started.`,
 });
 
 const UNKNOWN_DISCLOSURE_BY_STATUS = Object.freeze({
@@ -107,6 +109,9 @@ export function sourceContentTransmissionForExecution({ status, errorCode, pidIn
     return SOURCE_CONTENT_TRANSMISSION.UNKNOWN;
   }
   if (errorCode === "scope_failed" || errorCode === "spawn_failed") {
+    return SOURCE_CONTENT_TRANSMISSION.NOT_SENT;
+  }
+  if (errorCode === "oauth_inference_rejected" && !pidInfo) {
     return SOURCE_CONTENT_TRANSMISSION.NOT_SENT;
   }
   if (status === "cancelled") {

--- a/plugins/api-reviewers/scripts/lib/review-prompt.mjs
+++ b/plugins/api-reviewers/scripts/lib/review-prompt.mjs
@@ -236,6 +236,7 @@ export function buildReviewAuditManifest({
       scope_paths: Array.isArray(scope.paths) ? Object.freeze([...scope.paths]) : null,
       reason: scope.reason ?? null,
     }),
+    error_code: errorCode,
     review_quality: qualityFlags({ result, status, errorCode }),
   });
 }

--- a/plugins/api-reviewers/scripts/lib/review-prompt.mjs
+++ b/plugins/api-reviewers/scripts/lib/review-prompt.mjs
@@ -159,7 +159,7 @@ function qualityFlags({ result = "", status = null, errorCode = null } = {}) {
     ]),
     checklist_items_seen: checklistItemsSeen,
     looks_shallow: text.trim().length > 0 && text.trim().length < 500,
-    failed_review_slot: status !== "completed" || errorCode !== null,
+    failed_review_slot: status !== "preflight_failed" && (status !== "completed" || errorCode !== null),
   });
 }
 

--- a/plugins/claude/commands/claude-setup.md
+++ b/plugins/claude/commands/claude-setup.md
@@ -14,6 +14,9 @@ Setup readiness check for the Claude plugin.
    - Always show `summary`.
    - If `ready: true`, report that Claude Code is ready.
    - If `ready: false`, show `next_action` exactly.
+   - If `status: "oauth_inference_rejected"`, explain that OAuth status is
+     present but non-interactive `claude -p` inference failed; this is a failed
+     review slot, not a model verdict.
    - If `ignored_env_credentials` is present, explain that those env vars were intentionally ignored by plugin policy; never print values.
 3. Print a smoke-test hint: ask Codex to use the Claude delegation skill for a
    read-only review.
@@ -21,5 +24,7 @@ Setup readiness check for the Claude plugin.
 ## Guardrails
 
 - Never read or write `ANTHROPIC_API_KEY` or any `*_API_KEY` env var.
+- Never treat API-key fallback as a valid setup result for subscription/OAuth
+  review readiness unless the user explicitly asked for API-key mode.
 - Never persist credentials.
 - Never auto-install or auto-update Claude Code.

--- a/plugins/claude/scripts/claude-companion.mjs
+++ b/plugins/claude/scripts/claude-companion.mjs
@@ -43,6 +43,8 @@ import { newJobId, verifyPidInfo } from "./lib/identity.mjs";
 import { buildJobRecord, externalReviewForInvocation } from "./lib/job-record.mjs";
 import { reconcileActiveJobs } from "./lib/reconcile.mjs";
 import { cleanGitEnv } from "./lib/git-env.mjs";
+import { sanitizeTargetEnv } from "./lib/provider-env.mjs";
+import { runCommand } from "./lib/process.mjs";
 import {
   authDiagnosticFields,
   apiKeyMissingFields as buildApiKeyMissingFields,
@@ -78,6 +80,7 @@ configureState({
 
 const MODELS_CONFIG_PATH = resolvePath(PLUGIN_ROOT, "config/models.json");
 const DEFAULT_CLAUDE_REVIEW_TIMEOUT_MS = 600000;
+const CLAUDE_AUTH_STATUS_TIMEOUT_MS = 10000;
 const CONTINUABLE_STATUSES = new Set(["completed", "failed", "cancelled", "stale"]);
 const RUN_MODES = Object.freeze(["review", "adversarial-review", "custom-review", "rescue"]);
 const PREFLIGHT_MODES = Object.freeze(["review", "adversarial-review", "custom-review"]);
@@ -243,7 +246,9 @@ function reviewAuditManifest(invocation, prompt, containmentPath, execution) {
       reason: scopeResolutionReason(invocation),
     },
     result: execution?.parsed?.result ?? "",
-    status: execution?.exitCode === 0 && execution?.parsed?.ok === true ? "completed" : "failed",
+    status: execution?.preflight === true
+      ? "preflight_failed"
+      : (execution?.exitCode === 0 && execution?.parsed?.ok === true ? "completed" : "failed"),
     errorCode: execution?.parsed?.reason ?? null,
   });
 }
@@ -677,8 +682,14 @@ async function cmdRun(rest) {
 // prompt; background worker calls it after reading the prompt sidecar.
 // EXACTLY ONE buildJobRecord call per terminal state — §21.3.2 convergence.
 async function executeRun(invocation, prompt, { foreground, lifecycleEvents = null }) {
+  const authSelection = resolveAuthSelection(invocation.auth_mode);
+  invocation = Object.freeze({
+    ...invocation,
+    selected_auth_path: authSelection.selected_auth_path,
+  });
   const { job_id: jobId, workspace_root: workspaceRoot } = invocation;
   const profile = resolveProfile(invocation.mode_profile_name);
+
   const executionScope = setupExecutionScopeOrExit(invocation, profile, { foreground, lifecycleEvents });
   const mutationContext = prepareMutationContext(invocation, profile);
   const runtimeDiagnostics = buildRuntimeDiagnostics(
@@ -687,6 +698,24 @@ async function executeRun(invocation, prompt, { foreground, lifecycleEvents = nu
     mutationContext.neutralCwd ?? executionScope.childCwd,
   );
   const resumeId = latestResumeId(invocation);
+
+  const oauthPreflightExecution = await claudeOAuthInferencePreflight(invocation, authSelection);
+  if (oauthPreflightExecution) {
+    const finalRecord = buildClaudeFinalRecord(
+      invocation,
+      oauthPreflightExecution,
+      null,
+      mutationContext.mutations,
+      prompt,
+      executionScope.addDir,
+      runtimeDiagnostics,
+    );
+    commitJobRecord(workspaceRoot, jobId, finalRecord);
+    writeExecutionSidecars(workspaceRoot, jobId, oauthPreflightExecution);
+    cleanupExecutionResources(executionScope, mutationContext);
+    if (foreground) printLifecycleJson(finalRecord, lifecycleEvents);
+    process.exit(2);
+  }
 
   exitIfCancelledBeforeSpawn(invocation, executionScope, mutationContext, {
     foreground,
@@ -841,6 +870,37 @@ async function spawnClaudeOrExit(invocation, profile, prompt, executionScope, mu
     if (options.foreground) printLifecycleJson(errorRecord, options.lifecycleEvents);
     process.exit(2);
   }
+}
+
+async function claudeOAuthInferencePreflight(invocation, authSelection) {
+  if (authSelection.selected_auth_path !== "subscription_oauth") return null;
+  const profile = resolveProfile("ping");
+  let execution;
+  try {
+    execution = await spawnClaude(profile, {
+      model: invocation.model,
+      promptText: PING_PROMPT,
+      sessionId: newJobId(),
+      cwd: invocation.cwd,
+      binary: invocation.binary,
+      timeoutMs: Math.min(Number(invocation.timeout_ms ?? 15000), 15000),
+      allowedApiKeyEnv: authSelection.allowed_env_credentials,
+    });
+  } catch {
+    return null;
+  }
+  if (execution.parsed?.ok === true) return null;
+  const detail = pingFailureDetail(execution);
+  if (!PING_AUTH_RE.test(detail)) return null;
+  const oauthStatus = safeClaudeOAuthStatus(invocation.binary, authSelection);
+  if (oauthStatus?.logged_in !== true || !/401|invalid authentication credentials/i.test(detail)) return null;
+  return {
+    ...execution,
+    pidInfo: null,
+    claudeSessionId: null,
+    preflight: true,
+    errorMessage: `oauth_inference_rejected: ${detail}`,
+  };
 }
 
 function writeRunningRecord(invocation, pidInfo, mutations, runtimeDiagnostics = null) {
@@ -1237,6 +1297,62 @@ function pingErrorFields() {
   };
 }
 
+function oauthInferenceRejectedFields() {
+  return {
+    ready: false,
+    summary: "Claude Code OAuth login is present, but OAuth non-interactive inference is rejected.",
+    next_action: "Refresh Claude OAuth in a normal terminal with `claude auth login`, then verify OAuth-only `claude -p` inference works.",
+  };
+}
+
+function safeClaudeOAuthStatus(binary, authSelection) {
+  if (authSelection.selected_auth_path !== "subscription_oauth") return null;
+  const env = sanitizeTargetEnv(process.env, { allowedApiKeyEnv: authSelection.allowed_env_credentials });
+  const result = runCommand(binary, ["auth", "status", "--json"], {
+    cwd: process.cwd(),
+    env,
+    maxBuffer: 1024 * 1024,
+    timeout: CLAUDE_AUTH_STATUS_TIMEOUT_MS,
+  });
+  if (result.error) {
+    const detail = result.error.code === "ENOENT"
+      ? "not_found"
+      : (result.error.code === "ETIMEDOUT" ? "timeout" : "error");
+    return { checked: true, available: false, detail };
+  }
+  if (result.status !== 0) {
+    return { checked: true, available: false, detail: "status_failed" };
+  }
+  try {
+    const parsed = parseJsonObjectOutput(result.stdout);
+    return {
+      checked: true,
+      available: true,
+      logged_in: parsed.loggedIn === true,
+      auth_method: typeof parsed.authMethod === "string" ? parsed.authMethod : null,
+      api_provider: typeof parsed.apiProvider === "string" ? parsed.apiProvider : null,
+      subscription_type: typeof parsed.subscriptionType === "string" ? parsed.subscriptionType : null,
+    };
+  } catch {
+    return { checked: true, available: false, detail: "status_parse_failed" };
+  }
+}
+
+function parseJsonObjectOutput(stdout) {
+  const text = String(stdout ?? "").trim();
+  if (!text) return {};
+  try {
+    return JSON.parse(text);
+  } catch {
+    const start = text.indexOf("{");
+    const end = text.lastIndexOf("}");
+    if (start >= 0 && end >= start) {
+      return JSON.parse(text.slice(start, end + 1));
+    }
+    throw new Error("no_json_object");
+  }
+}
+
 function pingFailureDetail(execution) {
   const raw = execution?.parsed?.raw;
   const rawText = typeof raw === "string"
@@ -1302,7 +1418,7 @@ async function cmdPing(rest) {
     process.exit(2);
   }
   // Classify. Real Claude error texts change per version; match on signals only.
-  if (execution.parsed.ok && (execution.parsed.result || execution.parsed.structured)) {
+  if (execution.parsed?.ok === true) {
     // T7.4: drop the legacy `.sessionId` alias. Ping uses claudeSessionId
     // (Claude's echo) with sessionIdSent fallback when the mock short-circuits.
     const payload = { status: "ok", ...pingOkFields(), ...authDiagnosticFields(authSelection), model: model ?? null,
@@ -1318,8 +1434,16 @@ async function cmdPing(rest) {
       process.exit(2);
     }
     if (PING_AUTH_RE.test(detail)) {
+      const oauthStatus = safeClaudeOAuthStatus(binary, authSelection);
+      if (oauthStatus?.logged_in === true && /401|invalid authentication credentials/i.test(detail)) {
+        printJson({ status: "oauth_inference_rejected", ...oauthInferenceRejectedFields(), detail,
+          ...authDiagnosticFields(authSelection),
+          oauth_status: oauthStatus });
+        process.exit(2);
+      }
       printJson({ status: "not_authed", ...pingNotAuthedFields(), detail,
         ...authDiagnosticFields(authSelection),
+        ...(oauthStatus ? { oauth_status: oauthStatus } : {}),
         hint: authSelection.selected_auth_path === "api_key_env"
           ? "Claude was launched with explicit API-key auth. Check the provider key and CLI support."
           : "Run `claude` interactively to complete OAuth. API-key env vars are ignored by subscription-mode policy." });

--- a/plugins/claude/scripts/claude-companion.mjs
+++ b/plugins/claude/scripts/claude-companion.mjs
@@ -213,6 +213,9 @@ function scopeResolutionReason(invocation) {
 function reviewAuditManifest(invocation, prompt, containmentPath, execution) {
   if (!invocation.review_prompt_contract_version || invocation.mode_profile_name === "rescue") return null;
   const meta = promptMetadata(invocation);
+  const errorCode = String(execution?.errorMessage ?? "").startsWith("oauth_inference_rejected:")
+    ? "oauth_inference_rejected"
+    : (execution?.parsed?.reason ?? null);
   return buildReviewAuditManifest({
     prompt,
     sourceFiles: auditSourceFiles(containmentPath),
@@ -249,7 +252,7 @@ function reviewAuditManifest(invocation, prompt, containmentPath, execution) {
     status: execution?.preflight === true
       ? "preflight_failed"
       : (execution?.exitCode === 0 && execution?.parsed?.ok === true ? "completed" : "failed"),
-    errorCode: execution?.parsed?.reason ?? null,
+    errorCode,
   });
 }
 
@@ -1325,6 +1328,7 @@ function safeClaudeOAuthStatus(binary, authSelection) {
   }
   try {
     const parsed = parseJsonObjectOutput(result.stdout);
+    // Explicit allowlist: do not add user, email, org, or account fields here.
     return {
       checked: true,
       available: true,

--- a/plugins/claude/scripts/lib/external-review.mjs
+++ b/plugins/claude/scripts/lib/external-review.mjs
@@ -37,6 +37,7 @@ const CONTENT_RECEIVED_ERROR_CODES = Object.freeze(new Set([
   "gemini_error",
   "kimi_error",
   "parse_error",
+  "oauth_inference_rejected",
   "step_limit_exceeded",
   "usage_limited",
   "finalization_failed",
@@ -57,6 +58,7 @@ const NOT_SENT_DISCLOSURE_BY_STATUS = Object.freeze({
 const NOT_SENT_DISCLOSURE_BY_ERROR = Object.freeze({
   scope_failed: (provider) => `Selected source content was not sent to ${provider}; the review scope was rejected before the target process was started.`,
   spawn_failed: (provider) => `Selected source content was not sent to ${provider}; the target process was not spawned.`,
+  oauth_inference_rejected: (provider) => `Selected source content was not sent to ${provider}; OAuth inference readiness was rejected before the review target was started.`,
 });
 
 const UNKNOWN_DISCLOSURE_BY_STATUS = Object.freeze({
@@ -107,6 +109,9 @@ export function sourceContentTransmissionForExecution({ status, errorCode, pidIn
     return SOURCE_CONTENT_TRANSMISSION.UNKNOWN;
   }
   if (errorCode === "scope_failed" || errorCode === "spawn_failed") {
+    return SOURCE_CONTENT_TRANSMISSION.NOT_SENT;
+  }
+  if (errorCode === "oauth_inference_rejected" && !pidInfo) {
     return SOURCE_CONTENT_TRANSMISSION.NOT_SENT;
   }
   if (status === "cancelled") {

--- a/plugins/claude/scripts/lib/job-record.mjs
+++ b/plugins/claude/scripts/lib/job-record.mjs
@@ -113,7 +113,7 @@ function buildReviewMetadata(invocation, execution = null, parsed = null) {
 }
 
 export function externalReviewForInvocation(invocation, execution = null) {
-  const { status, error_code } = classifyExecution(execution);
+  const { status, error_code } = classifyExecution(execution, invocation);
   const sourceContentTransmission = sourceContentTransmissionForExecution({
     status,
     errorCode: error_code,
@@ -149,6 +149,10 @@ export function externalReviewForInvocation(invocation, execution = null) {
  *                         with missing-binary errors. PR #21 review HIGH 1.
  *   parse_error     — parsed.ok === false with reason starting "json_parse"/"empty_stdout".
  *   timeout         — execution.timedOut === true (companion's wall-clock kill).
+ *   oauth_inference_rejected — subscription/OAuth review inference returned
+ *                     HTTP 401 even though CLI auth status may still report
+ *                     logged-in. This must not be hidden as generic
+ *                     claude_error.
  *   claude_error    — exitCode !== 0 with parseable JSON (target's is_error=true).
  *                     Also covers exitCode === 0 but parsed.ok === false with
  *                     is_error semantics.
@@ -157,8 +161,18 @@ export function externalReviewForInvocation(invocation, execution = null) {
  */
 const CANCEL_SIGNALS = new Set(["SIGTERM", "SIGKILL", "SIGINT", "SIGHUP"]);
 const FINALIZATION_FAILED_PREFIX = "finalization_failed:";
+const OAUTH_INFERENCE_REJECTED_PREFIX = "oauth_inference_rejected:";
 
-function classifyExecution(execution) {
+function isOAuthInferenceRejected(execution, invocation = null) {
+  if (invocation?.selected_auth_path && invocation.selected_auth_path !== "subscription_oauth") return false;
+  if (!invocation?.selected_auth_path && invocation?.auth_mode === "api_key") return false;
+  const raw = execution?.parsed?.raw;
+  const status = raw && typeof raw === "object" ? raw.api_error_status : null;
+  const result = String(execution?.parsed?.result ?? "");
+  return status === 401 && /invalid authentication credentials|failed to authenticate/i.test(result);
+}
+
+function classifyExecution(execution, invocation = null) {
   if (!execution) {
     return {
       status: "queued",
@@ -196,6 +210,13 @@ function classifyExecution(execution) {
     };
   }
   if (execution.errorMessage) {
+    if (String(execution.errorMessage).startsWith(OAUTH_INFERENCE_REJECTED_PREFIX)) {
+      return {
+        status: "failed",
+        error_code: "oauth_inference_rejected",
+        error_message: String(execution.errorMessage).slice(OAUTH_INFERENCE_REJECTED_PREFIX.length).trim(),
+      };
+    }
     if (isScopeFailure(execution.errorMessage)) {
       return {
         status: "failed",
@@ -243,6 +264,13 @@ function classifyExecution(execution) {
         error_message: parsed.error ?? reason,
       };
     }
+    if (isOAuthInferenceRejected(execution, invocation)) {
+      return {
+        status: "failed",
+        error_code: "oauth_inference_rejected",
+        error_message: parsed.result ?? parsed.error ?? null,
+      };
+    }
     return {
       status: "failed",
       error_code: "claude_error",
@@ -280,7 +308,21 @@ function buildErrorDiagnostic(invocation, status, error_code, error_message) {
     suggested_action: null,
     disclosure_note: null,
   };
-  if (status !== "failed" || error_code !== "scope_failed" || !error_message) {
+  if (status !== "failed") {
+    return empty;
+  }
+  if (error_code === "oauth_inference_rejected") {
+    return {
+      error_summary: "Claude OAuth non-interactive inference was rejected.",
+      error_cause:
+        "Claude Code reported HTTP 401 while the companion was using subscription/OAuth mode. " +
+        "`claude auth status` can still report logged in; when detected by preflight, the review source is not sent.",
+      suggested_action:
+        "Run `/claude-setup`, refresh Claude OAuth in a normal terminal if needed, and verify OAuth-only `claude -p` inference works before retrying the review.",
+      disclosure_note: null,
+    };
+  }
+  if (error_code !== "scope_failed" || !error_message) {
     return empty;
   }
 
@@ -518,7 +560,7 @@ export function buildJobRecord(invocation, execution, mutations) {
   if (!Array.isArray(mutations)) {
     throw new Error("buildJobRecord: mutations must be an array (empty ok)");
   }
-  const { status, error_code, error_message } = classifyExecution(execution);
+  const { status, error_code, error_message } = classifyExecution(execution, invocation);
   const diagnostic = buildErrorDiagnostic(invocation, status, error_code, error_message);
 
   const parsed = execution?.parsed ?? null;

--- a/plugins/claude/scripts/lib/process.mjs
+++ b/plugins/claude/scripts/lib/process.mjs
@@ -8,6 +8,8 @@ export function runCommand(command, args = [], options = {}) {
     encoding: "utf8",
     input: options.input,
     maxBuffer: options.maxBuffer,
+    timeout: options.timeout,
+    killSignal: options.killSignal,
     stdio: options.stdio ?? "pipe",
     shell: process.platform === "win32" ? (process.env.SHELL || true) : false,
     windowsHide: true

--- a/plugins/claude/scripts/lib/review-prompt.mjs
+++ b/plugins/claude/scripts/lib/review-prompt.mjs
@@ -236,6 +236,7 @@ export function buildReviewAuditManifest({
       scope_paths: Array.isArray(scope.paths) ? Object.freeze([...scope.paths]) : null,
       reason: scope.reason ?? null,
     }),
+    error_code: errorCode,
     review_quality: qualityFlags({ result, status, errorCode }),
   });
 }

--- a/plugins/claude/scripts/lib/review-prompt.mjs
+++ b/plugins/claude/scripts/lib/review-prompt.mjs
@@ -159,7 +159,7 @@ function qualityFlags({ result = "", status = null, errorCode = null } = {}) {
     ]),
     checklist_items_seen: checklistItemsSeen,
     looks_shallow: text.trim().length > 0 && text.trim().length < 500,
-    failed_review_slot: status !== "completed" || errorCode !== null,
+    failed_review_slot: status !== "preflight_failed" && (status !== "completed" || errorCode !== null),
   });
 }
 

--- a/plugins/claude/skills/claude-result-handling/SKILL.md
+++ b/plugins/claude/skills/claude-result-handling/SKILL.md
@@ -59,7 +59,7 @@ comes back to you.
   "started_at":          "<iso-8601>",
   "ended_at":            null | "<iso-8601>",
   "exit_code":           null | 0 | 1 | 2,
-  "error_code":          null | "scope_failed" | "spawn_failed" | "claude_error" | "gemini_error" | "kimi_error" | "parse_error" | "step_limit_exceeded" | "usage_limited" | "finalization_failed" | "timeout" | "stale_active_job",
+  "error_code":          null | "scope_failed" | "spawn_failed" | "claude_error" | "gemini_error" | "kimi_error" | "parse_error" | "oauth_inference_rejected" | "step_limit_exceeded" | "usage_limited" | "finalization_failed" | "timeout" | "stale_active_job",
   "error_message":       null | "<human>",
   "error_summary":       null | "<short operator-facing summary>",
   "error_cause":         null | "<why this happened>",
@@ -213,6 +213,11 @@ from short-lived index contention.
   target CLI or external provider.
 - `claude_error` — Claude ran but returned `is_error: true`. `result` may
   still contain partial text worth showing.
+- `oauth_inference_rejected` — Claude Code returned an HTTP 401 authentication
+  rejection from non-interactive inference while the companion was using
+  subscription/OAuth mode. Treat this as a failed review slot, not a model
+  verdict or approval. Tell the user to run `/claude-setup`; `claude auth
+  status` may be a false positive for review readiness.
 - `gemini_error` / `kimi_error` — the corresponding external CLI ran but
   returned a target-level failure. `result` may contain partial text worth
   showing if present; otherwise use the structured diagnostic fields.

--- a/plugins/claude/skills/claude-setup/SKILL.md
+++ b/plugins/claude/skills/claude-setup/SKILL.md
@@ -14,4 +14,4 @@ Use the Claude companion setup workflow. Current Codex builds expose it as `clau
 node "<plugin-root>/scripts/claude-companion.mjs" doctor
 ```
 
-Show `summary`, `ready`, and `next_action` exactly. Never print secret values or suggest Claude API keys for subscription/OAuth setup.
+Show `summary`, `ready`, and `next_action` exactly. If `status` is `oauth_inference_rejected`, report that Claude OAuth status is present but non-interactive `claude -p` inference failed, so Claude review slots are not ready. Never print secret values or suggest Claude API keys for subscription/OAuth setup.

--- a/plugins/gemini/scripts/lib/external-review.mjs
+++ b/plugins/gemini/scripts/lib/external-review.mjs
@@ -37,6 +37,7 @@ const CONTENT_RECEIVED_ERROR_CODES = Object.freeze(new Set([
   "gemini_error",
   "kimi_error",
   "parse_error",
+  "oauth_inference_rejected",
   "step_limit_exceeded",
   "usage_limited",
   "finalization_failed",
@@ -57,6 +58,7 @@ const NOT_SENT_DISCLOSURE_BY_STATUS = Object.freeze({
 const NOT_SENT_DISCLOSURE_BY_ERROR = Object.freeze({
   scope_failed: (provider) => `Selected source content was not sent to ${provider}; the review scope was rejected before the target process was started.`,
   spawn_failed: (provider) => `Selected source content was not sent to ${provider}; the target process was not spawned.`,
+  oauth_inference_rejected: (provider) => `Selected source content was not sent to ${provider}; OAuth inference readiness was rejected before the review target was started.`,
 });
 
 const UNKNOWN_DISCLOSURE_BY_STATUS = Object.freeze({
@@ -107,6 +109,9 @@ export function sourceContentTransmissionForExecution({ status, errorCode, pidIn
     return SOURCE_CONTENT_TRANSMISSION.UNKNOWN;
   }
   if (errorCode === "scope_failed" || errorCode === "spawn_failed") {
+    return SOURCE_CONTENT_TRANSMISSION.NOT_SENT;
+  }
+  if (errorCode === "oauth_inference_rejected" && !pidInfo) {
     return SOURCE_CONTENT_TRANSMISSION.NOT_SENT;
   }
   if (status === "cancelled") {

--- a/plugins/gemini/scripts/lib/process.mjs
+++ b/plugins/gemini/scripts/lib/process.mjs
@@ -8,6 +8,8 @@ export function runCommand(command, args = [], options = {}) {
     encoding: "utf8",
     input: options.input,
     maxBuffer: options.maxBuffer,
+    timeout: options.timeout,
+    killSignal: options.killSignal,
     stdio: options.stdio ?? "pipe",
     shell: process.platform === "win32" ? (process.env.SHELL || true) : false,
     windowsHide: true

--- a/plugins/gemini/scripts/lib/review-prompt.mjs
+++ b/plugins/gemini/scripts/lib/review-prompt.mjs
@@ -236,6 +236,7 @@ export function buildReviewAuditManifest({
       scope_paths: Array.isArray(scope.paths) ? Object.freeze([...scope.paths]) : null,
       reason: scope.reason ?? null,
     }),
+    error_code: errorCode,
     review_quality: qualityFlags({ result, status, errorCode }),
   });
 }

--- a/plugins/gemini/scripts/lib/review-prompt.mjs
+++ b/plugins/gemini/scripts/lib/review-prompt.mjs
@@ -159,7 +159,7 @@ function qualityFlags({ result = "", status = null, errorCode = null } = {}) {
     ]),
     checklist_items_seen: checklistItemsSeen,
     looks_shallow: text.trim().length > 0 && text.trim().length < 500,
-    failed_review_slot: status !== "completed" || errorCode !== null,
+    failed_review_slot: status !== "preflight_failed" && (status !== "completed" || errorCode !== null),
   });
 }
 

--- a/plugins/grok/scripts/lib/external-review.mjs
+++ b/plugins/grok/scripts/lib/external-review.mjs
@@ -37,6 +37,7 @@ const CONTENT_RECEIVED_ERROR_CODES = Object.freeze(new Set([
   "gemini_error",
   "kimi_error",
   "parse_error",
+  "oauth_inference_rejected",
   "step_limit_exceeded",
   "usage_limited",
   "finalization_failed",
@@ -57,6 +58,7 @@ const NOT_SENT_DISCLOSURE_BY_STATUS = Object.freeze({
 const NOT_SENT_DISCLOSURE_BY_ERROR = Object.freeze({
   scope_failed: (provider) => `Selected source content was not sent to ${provider}; the review scope was rejected before the target process was started.`,
   spawn_failed: (provider) => `Selected source content was not sent to ${provider}; the target process was not spawned.`,
+  oauth_inference_rejected: (provider) => `Selected source content was not sent to ${provider}; OAuth inference readiness was rejected before the review target was started.`,
 });
 
 const UNKNOWN_DISCLOSURE_BY_STATUS = Object.freeze({
@@ -107,6 +109,9 @@ export function sourceContentTransmissionForExecution({ status, errorCode, pidIn
     return SOURCE_CONTENT_TRANSMISSION.UNKNOWN;
   }
   if (errorCode === "scope_failed" || errorCode === "spawn_failed") {
+    return SOURCE_CONTENT_TRANSMISSION.NOT_SENT;
+  }
+  if (errorCode === "oauth_inference_rejected" && !pidInfo) {
     return SOURCE_CONTENT_TRANSMISSION.NOT_SENT;
   }
   if (status === "cancelled") {

--- a/plugins/grok/scripts/lib/review-prompt.mjs
+++ b/plugins/grok/scripts/lib/review-prompt.mjs
@@ -236,6 +236,7 @@ export function buildReviewAuditManifest({
       scope_paths: Array.isArray(scope.paths) ? Object.freeze([...scope.paths]) : null,
       reason: scope.reason ?? null,
     }),
+    error_code: errorCode,
     review_quality: qualityFlags({ result, status, errorCode }),
   });
 }

--- a/plugins/grok/scripts/lib/review-prompt.mjs
+++ b/plugins/grok/scripts/lib/review-prompt.mjs
@@ -159,7 +159,7 @@ function qualityFlags({ result = "", status = null, errorCode = null } = {}) {
     ]),
     checklist_items_seen: checklistItemsSeen,
     looks_shallow: text.trim().length > 0 && text.trim().length < 500,
-    failed_review_slot: status !== "completed" || errorCode !== null,
+    failed_review_slot: status !== "preflight_failed" && (status !== "completed" || errorCode !== null),
   });
 }
 

--- a/plugins/kimi/scripts/lib/external-review.mjs
+++ b/plugins/kimi/scripts/lib/external-review.mjs
@@ -37,6 +37,7 @@ const CONTENT_RECEIVED_ERROR_CODES = Object.freeze(new Set([
   "gemini_error",
   "kimi_error",
   "parse_error",
+  "oauth_inference_rejected",
   "step_limit_exceeded",
   "usage_limited",
   "finalization_failed",
@@ -57,6 +58,7 @@ const NOT_SENT_DISCLOSURE_BY_STATUS = Object.freeze({
 const NOT_SENT_DISCLOSURE_BY_ERROR = Object.freeze({
   scope_failed: (provider) => `Selected source content was not sent to ${provider}; the review scope was rejected before the target process was started.`,
   spawn_failed: (provider) => `Selected source content was not sent to ${provider}; the target process was not spawned.`,
+  oauth_inference_rejected: (provider) => `Selected source content was not sent to ${provider}; OAuth inference readiness was rejected before the review target was started.`,
 });
 
 const UNKNOWN_DISCLOSURE_BY_STATUS = Object.freeze({
@@ -107,6 +109,9 @@ export function sourceContentTransmissionForExecution({ status, errorCode, pidIn
     return SOURCE_CONTENT_TRANSMISSION.UNKNOWN;
   }
   if (errorCode === "scope_failed" || errorCode === "spawn_failed") {
+    return SOURCE_CONTENT_TRANSMISSION.NOT_SENT;
+  }
+  if (errorCode === "oauth_inference_rejected" && !pidInfo) {
     return SOURCE_CONTENT_TRANSMISSION.NOT_SENT;
   }
   if (status === "cancelled") {

--- a/plugins/kimi/scripts/lib/process.mjs
+++ b/plugins/kimi/scripts/lib/process.mjs
@@ -8,6 +8,8 @@ export function runCommand(command, args = [], options = {}) {
     encoding: "utf8",
     input: options.input,
     maxBuffer: options.maxBuffer,
+    timeout: options.timeout,
+    killSignal: options.killSignal,
     stdio: options.stdio ?? "pipe",
     shell: process.platform === "win32" ? (process.env.SHELL || true) : false,
     windowsHide: true

--- a/plugins/kimi/scripts/lib/review-prompt.mjs
+++ b/plugins/kimi/scripts/lib/review-prompt.mjs
@@ -236,6 +236,7 @@ export function buildReviewAuditManifest({
       scope_paths: Array.isArray(scope.paths) ? Object.freeze([...scope.paths]) : null,
       reason: scope.reason ?? null,
     }),
+    error_code: errorCode,
     review_quality: qualityFlags({ result, status, errorCode }),
   });
 }

--- a/plugins/kimi/scripts/lib/review-prompt.mjs
+++ b/plugins/kimi/scripts/lib/review-prompt.mjs
@@ -159,7 +159,7 @@ function qualityFlags({ result = "", status = null, errorCode = null } = {}) {
     ]),
     checklist_items_seen: checklistItemsSeen,
     looks_shallow: text.trim().length > 0 && text.trim().length < 500,
-    failed_review_slot: status !== "completed" || errorCode !== null,
+    failed_review_slot: status !== "preflight_failed" && (status !== "completed" || errorCode !== null),
   });
 }
 

--- a/scripts/ci/sync-external-review.mjs
+++ b/scripts/ci/sync-external-review.mjs
@@ -12,6 +12,7 @@ const COPIES = [
     path.join(REPO_ROOT, `plugins/${plugin}/scripts/lib/external-review.mjs`)
   ),
   path.join(REPO_ROOT, "plugins/api-reviewers/scripts/lib/external-review.mjs"),
+  path.join(REPO_ROOT, "plugins/grok/scripts/lib/external-review.mjs"),
 ];
 
 const checkOnly = process.argv.includes("--check");

--- a/scripts/lib/external-review.mjs
+++ b/scripts/lib/external-review.mjs
@@ -37,6 +37,7 @@ const CONTENT_RECEIVED_ERROR_CODES = Object.freeze(new Set([
   "gemini_error",
   "kimi_error",
   "parse_error",
+  "oauth_inference_rejected",
   "step_limit_exceeded",
   "usage_limited",
   "finalization_failed",
@@ -57,6 +58,7 @@ const NOT_SENT_DISCLOSURE_BY_STATUS = Object.freeze({
 const NOT_SENT_DISCLOSURE_BY_ERROR = Object.freeze({
   scope_failed: (provider) => `Selected source content was not sent to ${provider}; the review scope was rejected before the target process was started.`,
   spawn_failed: (provider) => `Selected source content was not sent to ${provider}; the target process was not spawned.`,
+  oauth_inference_rejected: (provider) => `Selected source content was not sent to ${provider}; OAuth inference readiness was rejected before the review target was started.`,
 });
 
 const UNKNOWN_DISCLOSURE_BY_STATUS = Object.freeze({
@@ -107,6 +109,9 @@ export function sourceContentTransmissionForExecution({ status, errorCode, pidIn
     return SOURCE_CONTENT_TRANSMISSION.UNKNOWN;
   }
   if (errorCode === "scope_failed" || errorCode === "spawn_failed") {
+    return SOURCE_CONTENT_TRANSMISSION.NOT_SENT;
+  }
+  if (errorCode === "oauth_inference_rejected" && !pidInfo) {
     return SOURCE_CONTENT_TRANSMISSION.NOT_SENT;
   }
   if (status === "cancelled") {

--- a/scripts/lib/review-prompt.mjs
+++ b/scripts/lib/review-prompt.mjs
@@ -236,6 +236,7 @@ export function buildReviewAuditManifest({
       scope_paths: Array.isArray(scope.paths) ? Object.freeze([...scope.paths]) : null,
       reason: scope.reason ?? null,
     }),
+    error_code: errorCode,
     review_quality: qualityFlags({ result, status, errorCode }),
   });
 }

--- a/scripts/lib/review-prompt.mjs
+++ b/scripts/lib/review-prompt.mjs
@@ -159,7 +159,7 @@ function qualityFlags({ result = "", status = null, errorCode = null } = {}) {
     ]),
     checklist_items_seen: checklistItemsSeen,
     looks_shallow: text.trim().length > 0 && text.trim().length < 500,
-    failed_review_slot: status !== "completed" || errorCode !== null,
+    failed_review_slot: status !== "preflight_failed" && (status !== "completed" || errorCode !== null),
   });
 }
 

--- a/tests/smoke/claude-companion.smoke.test.mjs
+++ b/tests/smoke/claude-companion.smoke.test.mjs
@@ -1782,6 +1782,7 @@ process.exit(1);
     assert.equal(record.external_review.source_content_transmission, "not_sent");
     assert.match(record.external_review.disclosure, /not sent/);
     assert.equal(record.pid_info, null);
+    assert.equal(record.review_metadata.audit_manifest.error_code, "oauth_inference_rejected");
     assert.equal(record.review_metadata.audit_manifest.review_quality.failed_review_slot, false);
     assert.doesNotMatch(stdout, /user@example.com/);
   } finally {

--- a/tests/smoke/claude-companion.smoke.test.mjs
+++ b/tests/smoke/claude-companion.smoke.test.mjs
@@ -91,14 +91,14 @@ function seedMinimalRepo(cwd) {
 test("run: api_key auth failure includes structured diagnostics before spawn", () => {
   const cwd = mkdtempSync(path.join(tmpdir(), "smoke-run-api-key-missing-"));
   const missingBinary = path.join(cwd, "missing-claude-binary");
-  const { stdout, status, dataDir } = runCompanion(
+  const { stdout, stderr, status, dataDir } = runCompanion(
     ["run", "--mode=rescue", "--foreground", "--auth-mode", "api_key",
      "--model", "claude-haiku-4-5-20251001", "--binary", missingBinary,
      "--cwd", cwd, "--", "auth missing"],
     { cwd, env: { ANTHROPIC_API_KEY: "", CLAUDE_API_KEY: "" } },
   );
   try {
-    assert.equal(status, 1);
+    assert.equal(status, 1, `status=${status} stdout=${stdout}`);
     assertClaudeApiKeyMissingError(JSON.parse(stdout));
   } finally {
     cleanup(dataDir);
@@ -1491,6 +1491,32 @@ test("ping: returns status=ok with the mock claude binary", () => {
   }
 });
 
+test("ping: treats empty successful result as ok", () => {
+  const tmp = mkdtempSync(path.join(tmpdir(), "claude-ping-empty-ok-"));
+  const binary = writeExecutable(tmp, "claude-empty-ok", `#!/usr/bin/env node
+process.stdout.write(JSON.stringify({
+  type: "result",
+  is_error: false,
+  result: "",
+  session_id: "33333333-3333-4333-8333-333333333333"
+}) + "\\n");
+`);
+  const { stdout, status, dataDir } = runCompanion(
+    ["ping", "--binary", binary, "--model", "claude-haiku-4-5-20251001"],
+    { cwd: tmpdir() },
+  );
+  try {
+    assert.equal(status, 0);
+    const result = JSON.parse(stdout);
+    assert.equal(result.status, "ok");
+    assert.equal(result.ready, true);
+    assert.equal(result.session_id, "33333333-3333-4333-8333-333333333333");
+  } finally {
+    cleanup(dataDir);
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test("ping: explicit api_key auth allows Claude provider key by name only", () => {
   const tmp = mkdtempSync(path.join(tmpdir(), "claude-ping-api-key-mode-"));
   const binary = writeExecutable(tmp, "claude-api-key-mode", `#!/usr/bin/env node
@@ -1657,6 +1683,156 @@ process.exit(1);
     assert.equal(result.detail, "Not logged in · Please run /login");
   } finally {
     cleanup(dataDir);
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("doctor: OAuth status success but non-interactive inference 401 is classified distinctly", () => {
+  const tmp = mkdtempSync(path.join(tmpdir(), "claude-doctor-oauth-print-401-"));
+  const binary = writeExecutable(tmp, "claude-oauth-print-401", `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "auth" && args[1] === "status") {
+  process.stdout.write("claude notice: auth cache refreshed\\n");
+  process.stdout.write(JSON.stringify({
+    loggedIn: true,
+    authMethod: "claude.ai",
+    apiProvider: "firstParty",
+    email: "user@example.com",
+    subscriptionType: "max"
+  }, null, 2) + "\\n");
+  process.exit(0);
+}
+process.stdout.write(JSON.stringify({
+  type: "result",
+  is_error: true,
+  api_error_status: 401,
+  result: "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+  session_id: "33333333-3333-4333-8333-333333333333",
+  usage: { input_tokens: 0, output_tokens: 0 }
+}) + "\\n");
+process.exit(1);
+`);
+  const { stdout, status, dataDir } = runCompanion(
+    ["doctor", "--binary", binary, "--model", "claude-haiku-4-5-20251001"],
+    { cwd: tmpdir(), env: { ANTHROPIC_API_KEY: "", CLAUDE_API_KEY: "" } },
+  );
+  try {
+    assert.equal(status, 2);
+    const result = JSON.parse(stdout);
+    assert.equal(result.status, "oauth_inference_rejected");
+    assert.equal(result.ready, false);
+    assert.equal(result.auth_mode, "subscription");
+    assert.equal(result.selected_auth_path, "subscription_oauth");
+    assert.equal(result.oauth_status?.logged_in, true);
+    assert.equal(result.oauth_status?.auth_method, "claude.ai");
+    assert.equal(result.oauth_status?.subscription_type, "max");
+    assert.equal(result.detail, "Failed to authenticate. API Error: 401 Invalid authentication credentials");
+    assert.match(result.summary, /OAuth.*non-interactive/i);
+    assert.match(result.next_action, /claude auth login|OAuth/i);
+    assert.doesNotMatch(stdout, /user@example.com/);
+  } finally {
+    cleanup(dataDir);
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("run: OAuth inference 401 is rejected before launch, not recorded as a failed review slot", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "claude-run-oauth-print-401-cwd-"));
+  seedMinimalRepo(cwd);
+  const tmp = mkdtempSync(path.join(tmpdir(), "claude-run-oauth-print-401-bin-"));
+  const binary = writeExecutable(tmp, "claude-oauth-print-401", `#!/usr/bin/env node
+if (process.argv.slice(2).join(" ") === "auth status --json") {
+  process.stdout.write(JSON.stringify({
+    loggedIn: true,
+    authMethod: "claude.ai",
+    apiProvider: "firstParty",
+    subscriptionType: "max",
+    email: "user@example.com"
+  }) + "\\n");
+  process.exit(0);
+}
+process.stdout.write(JSON.stringify({
+  type: "result",
+  is_error: true,
+  api_error_status: 401,
+  result: "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+  session_id: "33333333-3333-4333-8333-333333333333",
+  usage: { input_tokens: 0, output_tokens: 0 }
+}) + "\\n");
+process.exit(1);
+`);
+  const { stdout, status, dataDir } = runCompanion(
+    ["run", "--mode=review", "--foreground", "--lifecycle-events", "jsonl", "--binary", binary,
+     "--model", "claude-haiku-4-5-20251001", "--cwd", cwd, "--", "review this change"],
+    { cwd, env: { ANTHROPIC_API_KEY: "", CLAUDE_API_KEY: "" } },
+  );
+  try {
+    assert.equal(status, 2);
+    const lines = stdout.trim().split("\n").map((line) => JSON.parse(line));
+    assert.equal(lines.length, 1, "OAuth preflight rejection must not emit external_review_launched");
+    const [record] = lines;
+    assert.equal(record.status, "failed");
+    assert.equal(record.error_code, "oauth_inference_rejected");
+    assert.match(record.error_summary, /OAuth non-interactive inference was rejected/);
+    assert.match(record.suggested_action, /claude-setup|claude -p/);
+    assert.doesNotMatch(record.suggested_action, /API[- ]?key|ANTHROPIC_API_KEY|CLAUDE_API_KEY/i);
+    assert.match(record.result, /Invalid authentication credentials/);
+    assert.equal(record.usage.input_tokens, 0);
+    assert.equal(record.usage.output_tokens, 0);
+    assert.equal(record.external_review.source_content_transmission, "not_sent");
+    assert.match(record.external_review.disclosure, /not sent/);
+    assert.equal(record.pid_info, null);
+    assert.equal(record.review_metadata.audit_manifest.review_quality.failed_review_slot, false);
+    assert.doesNotMatch(stdout, /user@example.com/);
+  } finally {
+    cleanup(dataDir);
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("run: auto auth without API keys classifies OAuth inference 401 distinctly", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "claude-run-auto-oauth-print-401-cwd-"));
+  seedMinimalRepo(cwd);
+  const tmp = mkdtempSync(path.join(tmpdir(), "claude-run-auto-oauth-print-401-bin-"));
+  const binary = writeExecutable(tmp, "claude-auto-oauth-print-401", `#!/usr/bin/env node
+if (process.argv.slice(2).join(" ") === "auth status --json") {
+  process.stdout.write(JSON.stringify({
+    loggedIn: true,
+    authMethod: "claude.ai",
+    apiProvider: "firstParty",
+    subscriptionType: "max",
+    email: "user@example.com"
+  }) + "\\n");
+  process.exit(0);
+}
+process.stdout.write(JSON.stringify({
+  type: "result",
+  is_error: true,
+  api_error_status: 401,
+  result: "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+  session_id: "33333333-3333-4333-8333-333333333333",
+  usage: { input_tokens: 0, output_tokens: 0 }
+}) + "\\n");
+process.exit(1);
+`);
+  const { stdout, status, dataDir } = runCompanion(
+    ["run", "--mode=review", "--foreground", "--auth-mode", "auto", "--binary", binary,
+     "--model", "claude-haiku-4-5-20251001", "--cwd", cwd, "--", "review this change"],
+    { cwd, env: { ANTHROPIC_API_KEY: "", CLAUDE_API_KEY: "" } },
+  );
+  try {
+    assert.equal(status, 2);
+    const record = JSON.parse(stdout);
+    assert.equal(record.status, "failed");
+    assert.equal(record.error_code, "oauth_inference_rejected");
+    assert.equal(record.external_review.source_content_transmission, "not_sent");
+    assert.equal(record.pid_info, null);
+    assert.equal(record.review_metadata.audit_manifest.review_quality.failed_review_slot, false);
+    assert.doesNotMatch(stdout, /user@example.com/);
+  } finally {
+    cleanup(dataDir);
+    rmSync(cwd, { recursive: true, force: true });
     rmSync(tmp, { recursive: true, force: true });
   }
 });

--- a/tests/smoke/claude-mock.mjs
+++ b/tests/smoke/claude-mock.mjs
@@ -14,6 +14,7 @@ import { readFileSync, existsSync, realpathSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createHash } from "node:crypto";
+import { PING_PROMPT } from "../../plugins/claude/scripts/lib/companion-common.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const FIXTURE_DIR = resolve(HERE, "fixtures/claude");
@@ -208,7 +209,7 @@ if (process.env.CLAUDE_MOCK_LIST_ADDDIR && addDir) {
 // (worktree containment). Keeps the hook additive: leaving the env unset
 // is identical to pre-T7.6 behavior.
 const mutateRel = process.env.CLAUDE_MOCK_MUTATE_FILE;
-const isPingPrompt = prompt === "reply with exactly: pong. Do not use any tools, do not read files, and do not explore the workspace.";
+const isPingPrompt = prompt === PING_PROMPT;
 if (mutateRel && !isPingPrompt) {
   const { writeFileSync: wf, mkdirSync: mk } = await import("node:fs");
   const { isAbsolute, dirname: dn } = await import("node:path");

--- a/tests/smoke/claude-mock.mjs
+++ b/tests/smoke/claude-mock.mjs
@@ -208,7 +208,8 @@ if (process.env.CLAUDE_MOCK_LIST_ADDDIR && addDir) {
 // (worktree containment). Keeps the hook additive: leaving the env unset
 // is identical to pre-T7.6 behavior.
 const mutateRel = process.env.CLAUDE_MOCK_MUTATE_FILE;
-if (mutateRel) {
+const isPingPrompt = prompt === "reply with exactly: pong. Do not use any tools, do not read files, and do not explore the workspace.";
+if (mutateRel && !isPingPrompt) {
   const { writeFileSync: wf, mkdirSync: mk } = await import("node:fs");
   const { isAbsolute, dirname: dn } = await import("node:path");
   let target;

--- a/tests/unit/companion-common.test.mjs
+++ b/tests/unit/companion-common.test.mjs
@@ -441,6 +441,10 @@ test("external-review shared helper covers disclosure and transmission branches"
       "Selected source content was not sent to Provider; the target process was not spawned.",
     );
     assert.equal(
+      mod.externalReviewDisclosure("Provider", "failed", T.NOT_SENT, "oauth_inference_rejected"),
+      "Selected source content was not sent to Provider; OAuth inference readiness was rejected before the review target was started.",
+    );
+    assert.equal(
       mod.externalReviewDisclosure("Provider", "failed", T.NOT_SENT, "unknown_pre_spawn"),
       "Selected source content was not sent to Provider; the target process was not started.",
     );
@@ -483,6 +487,16 @@ test("external-review shared helper covers disclosure and transmission branches"
       errorCode: "spawn_failed",
       pidInfo: null,
     }), T.NOT_SENT);
+    assert.equal(mod.sourceContentTransmissionForExecution({
+      status: "failed",
+      errorCode: "oauth_inference_rejected",
+      pidInfo: null,
+    }), T.NOT_SENT);
+    assert.equal(mod.sourceContentTransmissionForExecution({
+      status: "failed",
+      errorCode: "oauth_inference_rejected",
+      pidInfo: { pid: 1 },
+    }), T.SENT);
     assert.equal(mod.sourceContentTransmissionForExecution({
       status: "cancelled",
       errorCode: null,

--- a/tests/unit/job-record.test.mjs
+++ b/tests/unit/job-record.test.mjs
@@ -620,6 +620,62 @@ test("buildJobRecord: failure path — claude exited non-zero", () => {
   assert.equal(rec.external_review.disclosure, sentButNoCleanResult("Claude Code"));
 });
 
+test("buildJobRecord: OAuth inference 401 is distinct from generic claude_error", () => {
+  const rec = buildJobRecord(makeInvocation({
+    auth_mode: "auto",
+    selected_auth_path: "subscription_oauth",
+  }), {
+    exitCode: 1,
+    parsed: {
+      ok: false,
+      reason: "is_error",
+      result: "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+      raw: { api_error_status: 401 },
+      structured: null,
+      denials: [],
+      costUsd: null,
+      usage: null,
+    },
+    pidInfo: makePidInfo(),
+    claudeSessionId: null,
+    stdout: "", stderr: "",
+  }, []);
+  assert.equal(rec.status, "failed");
+  assert.equal(rec.error_code, "oauth_inference_rejected");
+  assert.match(rec.error_summary, /OAuth non-interactive inference was rejected/i);
+  assert.match(rec.error_cause, /HTTP 401/i);
+  assert.match(rec.error_cause, /review source is not sent/i);
+  assert.match(rec.suggested_action, /\/claude-setup/);
+  assert.match(rec.suggested_action, /OAuth-only `claude -p` inference/i);
+  assert.equal(rec.external_review.source_content_transmission, "sent");
+  assert.equal(rec.external_review.disclosure, sentButNoCleanResult("Claude Code"));
+});
+
+test("buildJobRecord: API-key 401 is not classified as OAuth inference rejection", () => {
+  const rec = buildJobRecord(makeInvocation({
+    auth_mode: "api_key",
+    selected_auth_path: "api_key_env",
+  }), {
+    exitCode: 1,
+    parsed: {
+      ok: false,
+      reason: "is_error",
+      result: "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+      raw: { api_error_status: 401 },
+      structured: null,
+      denials: [],
+      costUsd: null,
+      usage: null,
+    },
+    pidInfo: makePidInfo(),
+    claudeSessionId: null,
+    stdout: "", stderr: "",
+  }, []);
+  assert.equal(rec.status, "failed");
+  assert.equal(rec.error_code, "claude_error");
+  assert.equal(rec.external_review.source_content_transmission, "sent");
+});
+
 test("gemini buildJobRecord: failure path uses gemini_error, not claude_error", () => {
   const rec = buildGeminiJobRecord(makeInvocation({
     target: "gemini",

--- a/tests/unit/process.test.mjs
+++ b/tests/unit/process.test.mjs
@@ -25,6 +25,16 @@ test("runCommand: captures stdout, stderr, status, and command metadata", () => 
   assert.equal(result.error, null);
 });
 
+test("runCommand: supports bounded spawnSync timeouts", () => {
+  const result = runCommand(process.execPath, [
+    "-e",
+    "setTimeout(() => {}, 1000)",
+  ], { timeout: 50 });
+
+  assert.equal(result.status, 0);
+  assert.equal(result.error?.code, "ETIMEDOUT");
+});
+
 test("runCommandChecked: returns successful result and throws formatted failures", () => {
   const ok = runCommandChecked(process.execPath, ["-e", "process.stdout.write('ok')"]);
   assert.equal(ok.stdout, "ok");


### PR DESCRIPTION
## Summary

- classify Claude subscription/OAuth print-mode HTTP 401 as `oauth_inference_rejected` instead of generic `claude_error`
- make `claude-companion doctor` cross-check `claude auth status --json` when OAuth inference fails, while sanitizing email/org values from output
- document that `claude auth status` can be a false positive for plugin review readiness and that API-key fallback is not valid for OAuth-only setup
- keep external-review source transmission accurate for this post-spawn failed review slot and fix `sync-external-review.mjs` so Grok is synced too

Closes #93.

## Verification

- `env -u ANTHROPIC_API_KEY -u CLAUDE_API_KEY claude auth status --json | node -e ...` confirmed the real sanitized field shape: `loggedIn`, `authMethod`, `apiProvider`, `subscriptionType`
- `git diff --check`
- `npm run lint:sync`
- `node --test tests/smoke/claude-companion.smoke.test.mjs`
- `npm test` -> 1000 tests, 994 pass, 0 fail, 6 skipped
- pre-commit `npm test` -> 1000 tests, 994 pass, 0 fail, 6 skipped
