### PR TITLE
Preflight reviewer scope budgets

### DIFF
--- a/docs/grok-subscription-tunnel.md
+++ b/docs/grok-subscription-tunnel.md
@@ -135,6 +135,12 @@ works but `/chat/completions` rejects the configured model, the doctor reports
 `grok_chat_model_rejected` and points at `GROK_WEB_MODEL` instead of session
 refresh guidance.
 
+Review runs also preflight the rendered prompt length. Prompts above
+`GROK_WEB_MAX_PROMPT_CHARS` (default 400000) fail before tunnel launch with
+`source_content_transmission: "not_sent"`. Narrow the scope or split the review
+into explicit custom-review shards; raise the limit only after confirming the
+local tunnel and selected Grok model accept larger prompts.
+
 Live E2E:
 
 ```sh

--- a/plugins/api-reviewers/commands/deepseek-adversarial-review.md
+++ b/plugins/api-reviewers/commands/deepseek-adversarial-review.md
@@ -10,5 +10,6 @@ node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider deepseek --mo
 ```
 
 `$ARGUMENTS` may include an optional `--scope-base REF` followed by prompt text. If present, pass `--scope-base REF` before `--prompt` and pass only the remaining prompt text to `--prompt`.
-The review timeout default is 600000 ms; `API_REVIEWERS_TIMEOUT_MS` is the non-interactive fallback.
+`branch-diff` is committed-only and does not include dirty working-tree edits. If the target changes are uncommitted, do not use adversarial branch-diff as the review evidence; run `deepseek-custom-review` with explicit `--scope-paths` instead.
+The review timeout default is 600000 ms; `API_REVIEWERS_TIMEOUT_MS` is the non-interactive fallback. Rendered prompts above the provider `max_prompt_chars` budget fail before launch with `source_content_transmission: "not_sent"`; use narrower scope shards or override `API_REVIEWERS_MAX_PROMPT_CHARS` only after confirming the provider accepts larger prompts.
 Render the returned JobRecord. Render `external_review_launched` as soon as it appears. If `external_review` is present, render it before the review result. If the JobRecord failed, report `error_code`, `error_message`, `http_status` when present, and `suggested_action`. Do not print API-key values.

--- a/plugins/api-reviewers/commands/deepseek-custom-review.md
+++ b/plugins/api-reviewers/commands/deepseek-custom-review.md
@@ -10,5 +10,5 @@ node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider deepseek --mo
 ```
 
 `$ARGUMENTS` may include `--scope-paths <files>` followed by prompt text. Pass the files to `--scope-paths`. Replace `<file1>,<file2>` with comma- or newline-separated concrete relative paths, expand globs before running, and pass only the remaining prompt text to `--prompt`.
-The review timeout default is 600000 ms; `API_REVIEWERS_TIMEOUT_MS` is the non-interactive fallback.
+The review timeout default is 600000 ms; `API_REVIEWERS_TIMEOUT_MS` is the non-interactive fallback. Rendered prompts above the provider `max_prompt_chars` budget fail before launch with `source_content_transmission: "not_sent"`; use narrower scope shards or override `API_REVIEWERS_MAX_PROMPT_CHARS` only after confirming the provider accepts larger prompts.
 Render the returned JobRecord. Render `external_review_launched` as soon as it appears. If `external_review` is present, render it before the review result. If the JobRecord failed, report `error_code`, `error_message`, `http_status` when present, and `suggested_action`. Do not print API-key values.

--- a/plugins/api-reviewers/commands/deepseek-review.md
+++ b/plugins/api-reviewers/commands/deepseek-review.md
@@ -10,5 +10,5 @@ node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider deepseek --mo
 ```
 
 `$ARGUMENTS` may include an optional `--scope-base REF` followed by prompt text. If present, pass `--scope-base REF` before `--prompt` and pass only the remaining prompt text to `--prompt`.
-The review timeout default is 600000 ms; `API_REVIEWERS_TIMEOUT_MS` is the non-interactive fallback.
+The review timeout default is 600000 ms; `API_REVIEWERS_TIMEOUT_MS` is the non-interactive fallback. Rendered prompts above the provider `max_prompt_chars` budget fail before launch with `source_content_transmission: "not_sent"`; use narrower scope shards or override `API_REVIEWERS_MAX_PROMPT_CHARS` only after confirming the provider accepts larger prompts.
 Render the returned JobRecord. Render `external_review_launched` as soon as it appears. If `external_review` is present, render it before the review result. If the JobRecord failed, report `error_code`, `error_message`, `http_status` when present, and `suggested_action`. Do not print API-key values.

--- a/plugins/api-reviewers/commands/glm-adversarial-review.md
+++ b/plugins/api-reviewers/commands/glm-adversarial-review.md
@@ -10,5 +10,6 @@ node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider glm --mode ad
 ```
 
 `$ARGUMENTS` may include an optional `--scope-base REF` followed by prompt text. If present, pass `--scope-base REF` before `--prompt` and pass only the remaining prompt text to `--prompt`.
-The review timeout default is 600000 ms; `API_REVIEWERS_TIMEOUT_MS` is the non-interactive fallback.
+`branch-diff` is committed-only and does not include dirty working-tree edits. If the target changes are uncommitted, do not use adversarial branch-diff as the review evidence; run `glm-custom-review` with explicit `--scope-paths` instead.
+The review timeout default is 600000 ms; `API_REVIEWERS_TIMEOUT_MS` is the non-interactive fallback. Rendered prompts above the provider `max_prompt_chars` budget fail before launch with `source_content_transmission: "not_sent"`; use narrower scope shards or override `API_REVIEWERS_MAX_PROMPT_CHARS` only after confirming the provider accepts larger prompts.
 Render the returned JobRecord. Render `external_review_launched` as soon as it appears. If `external_review` is present, render it before the review result. If the JobRecord failed, report `error_code`, `error_message`, `http_status` when present, and `suggested_action`. Do not print API-key values.

--- a/plugins/api-reviewers/commands/glm-custom-review.md
+++ b/plugins/api-reviewers/commands/glm-custom-review.md
@@ -10,5 +10,5 @@ node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider glm --mode cu
 ```
 
 `$ARGUMENTS` may include `--scope-paths <files>` followed by prompt text. Pass the files to `--scope-paths`. Replace `<file1>,<file2>` with comma- or newline-separated concrete relative paths, expand globs before running, and pass only the remaining prompt text to `--prompt`.
-The review timeout default is 600000 ms; `API_REVIEWERS_TIMEOUT_MS` is the non-interactive fallback.
+The review timeout default is 600000 ms; `API_REVIEWERS_TIMEOUT_MS` is the non-interactive fallback. Rendered prompts above the provider `max_prompt_chars` budget fail before launch with `source_content_transmission: "not_sent"`; use narrower scope shards or override `API_REVIEWERS_MAX_PROMPT_CHARS` only after confirming the provider accepts larger prompts.
 Render the returned JobRecord. Render `external_review_launched` as soon as it appears. If `external_review` is present, render it before the review result. If the JobRecord failed, report `error_code`, `error_message`, `http_status` when present, and `suggested_action`. Do not print API-key values.

--- a/plugins/api-reviewers/commands/glm-review.md
+++ b/plugins/api-reviewers/commands/glm-review.md
@@ -10,5 +10,5 @@ node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider glm --mode re
 ```
 
 `$ARGUMENTS` may include an optional `--scope-base REF` followed by prompt text. If present, pass `--scope-base REF` before `--prompt` and pass only the remaining prompt text to `--prompt`.
-The review timeout default is 600000 ms; `API_REVIEWERS_TIMEOUT_MS` is the non-interactive fallback.
+The review timeout default is 600000 ms; `API_REVIEWERS_TIMEOUT_MS` is the non-interactive fallback. Rendered prompts above the provider `max_prompt_chars` budget fail before launch with `source_content_transmission: "not_sent"`; use narrower scope shards or override `API_REVIEWERS_MAX_PROMPT_CHARS` only after confirming the provider accepts larger prompts.
 Render the returned JobRecord. Render `external_review_launched` as soon as it appears. If `external_review` is present, render it before the review result. If the JobRecord failed, report `error_code`, `error_message`, `http_status` when present, and `suggested_action`. Do not print API-key values.

--- a/plugins/api-reviewers/config/providers.json
+++ b/plugins/api-reviewers/config/providers.json
@@ -5,6 +5,7 @@
     "env_keys": ["DEEPSEEK_API_KEY"],
     "base_url": "https://api.deepseek.com",
     "model": "deepseek-v4-pro",
+    "max_prompt_chars": 600000,
     "request_defaults": {
       "thinking": {
         "type": "enabled"
@@ -19,6 +20,7 @@
     "env_keys": ["ZAI_API_KEY", "ZAI_GLM_API_KEY"],
     "base_url": "https://api.z.ai/api/coding/paas/v4",
     "model": "glm-5.1",
+    "max_prompt_chars": 600000,
     "request_defaults": {
       "thinking": {
         "type": "enabled"

--- a/plugins/api-reviewers/scripts/api-reviewer.mjs
+++ b/plugins/api-reviewers/scripts/api-reviewer.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
 import { lstat, mkdir, open, readFile, readdir, realpath, rename, rm, unlink, writeFile } from "node:fs/promises";
-import { constants as fsConstants, existsSync } from "node:fs";
+import { constants as fsConstants } from "node:fs";
 import { dirname, isAbsolute, resolve, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import { randomUUID } from "node:crypto";
@@ -34,6 +34,7 @@ const GIT_SAFE_PATH = "/usr/bin:/bin";
 const SCOPE_FILE_OPEN_FLAGS = fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0);
 const MAX_SCOPE_FILE_BYTES = 256 * 1024;
 const MAX_SCOPE_TOTAL_BYTES = 1024 * 1024;
+const DEFAULT_MAX_PROMPT_CHARS = 600000;
 const GIT_SHOW_MAX_BUFFER_BYTES = MAX_SCOPE_FILE_BYTES + 1;
 const API_REVIEWER_EXPECTED_KEYS = Object.freeze([
   "id",
@@ -627,6 +628,10 @@ function parseMaxTokensOverride(env = process.env) {
   return parsePositiveIntegerEnv(env, "API_REVIEWERS_MAX_TOKENS", "tokens");
 }
 
+function parseMaxPromptCharsOverride(env = process.env) {
+  return parsePositiveIntegerEnv(env, "API_REVIEWERS_MAX_PROMPT_CHARS", "characters");
+}
+
 function parseProviderTimeoutMs(env = process.env) {
   const parsed = parsePositiveIntegerEnv(env, "API_REVIEWERS_TIMEOUT_MS", "milliseconds");
   return parsed.value === null ? { ok: true, value: 600000 } : parsed;
@@ -657,6 +662,10 @@ function validateDirectApiRunPreflight(cfg, provider, env = process.env) {
   if (!maxTokensOverride.ok) {
     return { ok: false, reason: "bad_args", error: maxTokensOverride.error };
   }
+  const maxPromptCharsOverride = parseMaxPromptCharsOverride(env);
+  if (!maxPromptCharsOverride.ok) {
+    return { ok: false, reason: "bad_args", error: maxPromptCharsOverride.error };
+  }
   const timeoutMs = parseProviderTimeoutMs(env);
   if (!timeoutMs.ok) {
     return { ok: false, reason: "bad_args", error: timeoutMs.error };
@@ -677,7 +686,40 @@ function validateDirectApiRunPreflight(cfg, provider, env = process.env) {
   if (!requestDefaultsProbe.ok) {
     return { ok: false, reason: "bad_args", error: requestDefaultsProbe.error };
   }
-  return { ok: true, maxTokensOverride, timeoutMs, credential };
+  return { ok: true, maxTokensOverride, maxPromptCharsOverride, timeoutMs, credential };
+}
+
+function maxPromptCharsFor(cfg, env = process.env) {
+  const override = parseMaxPromptCharsOverride(env);
+  if (!override.ok) return override;
+  if (override.value !== null) return override;
+  const configured = cfg.max_prompt_chars;
+  if (configured === undefined || configured === null || configured === "") {
+    return { ok: true, value: DEFAULT_MAX_PROMPT_CHARS };
+  }
+  const parsed = Number(configured);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    return {
+      ok: false,
+      error: `${cfg.display_name} max_prompt_chars must be a positive integer number of characters; got ${JSON.stringify(configured)}`,
+    };
+  }
+  return { ok: true, value: parsed };
+}
+
+function validateRenderedPromptBudget(prompt, cfg, env = process.env) {
+  const maxPromptChars = maxPromptCharsFor(cfg, env);
+  if (!maxPromptChars.ok) {
+    return { ok: false, reason: "bad_args", error: maxPromptChars.error };
+  }
+  if (prompt.length > maxPromptChars.value) {
+    return {
+      ok: false,
+      reason: "scope_failed",
+      error: `prompt_too_large:${prompt.length} chars exceeds ${cfg.display_name} max_prompt_chars=${maxPromptChars.value}`,
+    };
+  }
+  return { ok: true, maxPromptChars };
 }
 
 function redactor(env = process.env, configuredSecretNames = []) {
@@ -852,23 +894,48 @@ function matchGlob(rel, pattern) {
   return new RegExp(re).test(rel);
 }
 
-async function readUtf8ScopeFileWithinLimit(abs, relPath) {
+async function readUtf8ScopeFileWithinLimit(filePath, normalizedRel, beforeOpen = null) {
+  beforeOpen ??= await lstat(filePath);
   let handle;
   try {
-    handle = await open(abs, SCOPE_FILE_OPEN_FLAGS);
-    const info = await handle.stat();
-    if (!info.isFile()) return null;
-    if (info.size > MAX_SCOPE_FILE_BYTES) {
-      throw new Error(`scope_file_too_large:${relPath}: ${info.size} bytes exceeds ${MAX_SCOPE_FILE_BYTES} byte limit`);
-    }
-    return await handle.readFile({ encoding: "utf8" });
+    handle = await open(filePath, SCOPE_FILE_OPEN_FLAGS);
   } catch (e) {
-    if (e?.code === "ELOOP") throw new Error(`unsafe_scope_path:${relPath}`);
+    if (e?.code === "ELOOP") throw new Error(`unsafe_scope_path:${normalizedRel}`);
     if (e?.code === "ENOENT") return null;
     throw e;
+  }
+  try {
+    const info = await handle.stat();
+    if (!info.isFile()) return null;
+    if (!sameFileIdentity(beforeOpen, info)) {
+      throw new Error(`unsafe_scope_path:${normalizedRel}: file changed before secure open`);
+    }
+    if (info.size > MAX_SCOPE_FILE_BYTES) {
+      throw new Error(`scope_file_too_large:${normalizedRel}: ${info.size} bytes exceeds ${MAX_SCOPE_FILE_BYTES} byte limit`);
+    }
+
+    const chunks = [];
+    let total = 0;
+    for (;;) {
+      const remaining = MAX_SCOPE_FILE_BYTES + 1 - total;
+      const buffer = Buffer.allocUnsafe(Math.min(remaining, 64 * 1024));
+      const { bytesRead } = await handle.read(buffer, 0, buffer.length, null);
+      if (bytesRead === 0) break;
+      total += bytesRead;
+      if (total > MAX_SCOPE_FILE_BYTES) {
+        throw new Error(`scope_file_too_large:${normalizedRel}: ${total} bytes exceeds ${MAX_SCOPE_FILE_BYTES} byte limit`);
+      }
+      chunks.push(buffer.subarray(0, bytesRead));
+    }
+    if (total === 0) return "";
+    return Buffer.concat(chunks, total).toString("utf8");
   } finally {
     await handle?.close();
   }
+}
+
+function sameFileIdentity(left, right) {
+  return left.dev === right.dev && left.ino === right.ino;
 }
 
 function addScopeFile(files, normalizedRel, text, totalBytes) {
@@ -888,6 +955,14 @@ function scopeName(options) {
   return options.scope ?? (options.mode === "custom-review" ? "custom" : "branch-diff");
 }
 
+function safeScopeBase(base) {
+  const value = base ?? "main";
+  if (typeof value !== "string" || value.trim() === "" || value.startsWith("-")) {
+    throw new Error(`scope_base_invalid: base ref ${JSON.stringify(value)} is not safe for git branch-diff`);
+  }
+  return value;
+}
+
 function selectedScopePaths(scope, options, cwd) {
   if (scope === "custom") {
     const relPaths = splitScopePaths(options["scope-paths"]);
@@ -895,7 +970,7 @@ function selectedScopePaths(scope, options, cwd) {
     return relPaths;
   }
   if (scope === "branch-diff") {
-    const base = options["scope-base"] ?? "main";
+    const base = safeScopeBase(options["scope-base"]);
     const changed = gitRaw(["diff", "-z", "--name-only", `${base}...HEAD`, "--"], cwd);
     const requested = splitScopePaths(options["scope-paths"]);
     const changedPaths = splitGitPathList(changed);
@@ -909,7 +984,7 @@ function selectedScopePaths(scope, options, cwd) {
 }
 
 function validateScopePath(workspaceRoot, relPath) {
-  if (relPath.includes("..") || isAbsolute(relPath) || relPath.includes("\\")) {
+  if (relPath.includes("..") || isAbsolute(relPath) || relPath.includes("\\") || /[\u0000-\u001f\u007f]/u.test(relPath)) {
     throw new Error(`unsafe_scope_path:${relPath}`);
   }
   const abs = resolve(workspaceRoot, relPath);
@@ -952,13 +1027,22 @@ async function readFilesystemScopeFiles(workspaceRoot, relPaths) {
   const realWorkspaceRoot = await realpath(workspaceRoot);
   for (const relPath of relPaths) {
     const { abs, normalizedRel } = validateScopePath(workspaceRoot, relPath);
-    if (!existsSync(abs)) continue;
+    let beforeOpen;
+    try {
+      beforeOpen = await lstat(abs);
+    } catch (error) {
+      if (error?.code === "ENOENT") continue;
+      throw error;
+    }
+    if (beforeOpen.isSymbolicLink()) {
+      throw new Error(`unsafe_scope_path:${normalizedRel}`);
+    }
     const realAbs = await realpath(abs);
     const realRel = relative(realWorkspaceRoot, realAbs);
     if (realRel.startsWith("..") || realRel === "") {
       throw new Error(`unsafe_scope_path:${relPath}`);
     }
-    const text = await readUtf8ScopeFileWithinLimit(abs, normalizedRel);
+    const text = await readUtf8ScopeFileWithinLimit(realAbs, normalizedRel, beforeOpen);
     if (text === null) continue;
     addScopeFile(files, normalizedRel, text, totalBytes);
   }
@@ -1005,6 +1089,26 @@ function repositoryIdentity(cwd, workspaceRoot) {
   return match ? match[1] : remote;
 }
 
+function fileContentDelimiter(file, index) {
+  let delimiter = `API REVIEWER FILE ${index}: ${file.path}`;
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (!file.text.includes(`BEGIN ${delimiter}`) && !file.text.includes(`END ${delimiter}`)) {
+      return delimiter;
+    }
+    delimiter = `${delimiter} #`;
+  }
+  throw new Error(`scope_delimiter_collision:${file.path}`);
+}
+
+function promptFileBlock(file, index) {
+  const delimiter = fileContentDelimiter(file, index);
+  return [
+    `BEGIN ${delimiter}`,
+    file.text,
+    `END ${delimiter}`,
+  ].join("\n");
+}
+
 function promptFor(mode, userPrompt, scopeInfo, providerName = "Direct API reviewer") {
   const modeLine = mode === "adversarial-review"
     ? "You are performing an adversarial code review. Prioritize correctness bugs, security risks, regressions, and missing tests."
@@ -1015,12 +1119,7 @@ function promptFor(mode, userPrompt, scopeInfo, providerName = "Direct API revie
     "- Do not reject model IDs or endpoint hosts solely because they differ from general public documentation; require current run failure evidence or repo-local contradictory evidence.",
     "- The JobRecord will include the actual endpoint, HTTP status, raw model, credential key name, and usage metadata when the provider returns them.",
   ].join("\n");
-  const files = scopeInfo.files.map((file) => [
-    `### ${file.path}`,
-    "```",
-    file.text,
-    "```",
-  ].join("\n")).join("\n\n");
+  const files = scopeInfo.files.map((file, index) => promptFileBlock(file, index + 1)).join("\n\n");
   return buildReviewPrompt({
     provider: providerName,
     mode,
@@ -1079,6 +1178,10 @@ function mockProviderExecution(cfg, prompt, credential, env, requestBody) {
   const expectedPromptText = env.API_REVIEWERS_MOCK_ASSERT_PROMPT_INCLUDES;
   if (expectedPromptText && !prompt.includes(expectedPromptText)) {
     return providerFailureWithDiagnostics("mock_assertion_failed", `prompt missing expected text: ${expectedPromptText}`, 200, null, false, diagnostics());
+  }
+  const excludedPromptText = env.API_REVIEWERS_MOCK_ASSERT_PROMPT_EXCLUDES;
+  if (excludedPromptText && prompt.includes(excludedPromptText)) {
+    return providerFailureWithDiagnostics("mock_assertion_failed", `prompt included excluded text: ${excludedPromptText}`, 200, null, false, diagnostics());
   }
   if (env.API_REVIEWERS_MOCK_ASSERT_REQUEST_BODY) {
     const parsedExpected = parseJson(env.API_REVIEWERS_MOCK_ASSERT_REQUEST_BODY);
@@ -1297,6 +1400,30 @@ function providerFailureWithDiagnostics(reason, message, httpStatus, raw = null,
   };
 }
 
+function providerUnavailableSuggestedAction(errorMessage = "", httpStatus = null, env = process.env) {
+  const looksLikeNetworkFailure = /fetch failed|ENOTFOUND|EAI_AGAIN|ECONNREFUSED|EHOSTUNREACH|ENETUNREACH|ETIMEDOUT/i.test(errorMessage);
+  if (httpStatus == null && isCodexSandbox(env) && looksLikeNetworkFailure) {
+    return `If running inside Codex, set [sandbox_workspace_write].network_access = true in ~/.codex/config.toml, start a fresh Codex session, then retry; or run this direct API reviewer outside sandbox. If network is already enabled, retry later or switch reviewer provider.`;
+  }
+  if (httpStatus == null && looksLikeNetworkFailure) {
+    return `Check network access, retry later, or switch reviewer provider.`;
+  }
+  return `Retry later or switch reviewer provider.`;
+}
+
+function scopeFailedSuggestedAction(errorMessage = "") {
+  if (/scope_empty:\s*branch-diff selected no files/i.test(errorMessage)) {
+    return "Branch-diff selected no files before provider launch. Branch-diff reviews committed HEAD-vs-base changes only; it does not include dirty working-tree edits. Choose a different --scope-base <ref> if this branch should have committed changes, use --scope-base HEAD~1 to review the last commit, or use custom-review with explicit --scope-paths for uncommitted, already-merged, or no-diff branches.";
+  }
+  if (/scope_base_invalid:/i.test(errorMessage)) {
+    return "Use a concrete branch, tag, remote ref, or commit SHA for --scope-base; option-shaped values beginning with '-' are rejected before git branch-diff runs.";
+  }
+  if (/prompt_too_large:/i.test(errorMessage)) {
+    return "Rendered prompt exceeds the direct API provider prompt budget before launch. Use a narrower scope, split the review into explicit custom-review shards, or raise API_REVIEWERS_MAX_PROMPT_CHARS only after confirming the selected provider accepts larger prompts.";
+  }
+  return "Adjust --scope, --scope-base, or --scope-paths and retry.";
+}
+
 function suggestedAction(errorCode, provider, cfg, errorMessage = "", httpStatus = null, env = process.env) {
   if (errorCode === "bad_args") return "Correct the api-reviewer command arguments and retry.";
   if (errorCode === "config_error") return "Reinstall or repair plugins/api-reviewers/config/providers.json and retry.";
@@ -1304,17 +1431,8 @@ function suggestedAction(errorCode, provider, cfg, errorMessage = "", httpStatus
   if (errorCode === "auth_rejected") return `Check the ${cfg.display_name} API key and billing/plan for ${cfg.model}.`;
   if (errorCode === "rate_limited") return `Wait and retry, or lower concurrency for ${provider}.`;
   if (errorCode === "timeout") return `The provider did not respond within the timeout window. Retry later, increase API_REVIEWERS_TIMEOUT_MS, or switch reviewer provider.`;
-  if (errorCode === "provider_unavailable") {
-    const looksLikeNetworkFailure = /fetch failed|ENOTFOUND|EAI_AGAIN|ECONNREFUSED|EHOSTUNREACH|ENETUNREACH|ETIMEDOUT/i.test(errorMessage);
-    if (httpStatus == null && isCodexSandbox(env) && looksLikeNetworkFailure) {
-      return `If running inside Codex, set [sandbox_workspace_write].network_access = true in ~/.codex/config.toml, start a fresh Codex session, then retry; or run this direct API reviewer outside sandbox. If network is already enabled, retry later or switch reviewer provider.`;
-    }
-    if (httpStatus == null && looksLikeNetworkFailure) {
-      return `Check network access, retry later, or switch reviewer provider.`;
-    }
-    return `Retry later or switch reviewer provider.`;
-  }
-  if (errorCode === "scope_failed") return "Adjust --scope, --scope-base, or --scope-paths and retry.";
+  if (errorCode === "provider_unavailable") return providerUnavailableSuggestedAction(errorMessage, httpStatus, env);
+  if (errorCode === "scope_failed") return scopeFailedSuggestedAction(errorMessage);
   return "Inspect error_message and retry after correcting the provider or request configuration.";
 }
 
@@ -1633,6 +1751,20 @@ async function cmdRun(options) {
     }
   }
   if (!execution) {
+    let renderedPrompt = null;
+    try {
+      renderedPrompt = promptFor(mode, options.prompt ?? "", scopeInfo, cfg.display_name);
+      const promptBudget = validateRenderedPromptBudget(renderedPrompt, cfg, process.env);
+      if (!promptBudget.ok) {
+        execution = providerFailure(promptBudget.reason, redactor(process.env)(promptBudget.error), null, null, false);
+        execution.prompt = renderedPrompt;
+      }
+    } catch (e) {
+      execution = providerFailure("scope_failed", redactor(process.env)(e?.message ?? String(e)), null, null, false);
+    }
+    if (execution) {
+      // handled below by the terminal JobRecord path without a launch event
+    } else {
     if (lifecycleEvents) {
       printLifecycleJson({
         event: "external_review_launched",
@@ -1643,11 +1775,12 @@ async function cmdRun(options) {
       }, lifecycleEvents);
     }
     try {
-      const renderedPrompt = promptFor(mode, options.prompt ?? "", scopeInfo, cfg.display_name);
       execution = await callProvider(provider, cfg, renderedPrompt);
       execution.prompt = renderedPrompt;
     } catch (e) {
       execution = providerFailure("provider_unavailable", redactor(process.env)(e?.message ?? String(e)), null, null, null);
+      execution.prompt = renderedPrompt;
+    }
     }
   }
   const record = redactRecord(buildRecord({

--- a/plugins/api-reviewers/skills/api-reviewers-delegation/SKILL.md
+++ b/plugins/api-reviewers/skills/api-reviewers-delegation/SKILL.md
@@ -39,6 +39,7 @@ node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider deepseek --mo
 
 For branch-diff review or adversarial-review, add `--scope-base REF` before `--prompt` when the user provides a base ref. Use `<focus>` as the user's review prompt or focus area.
 Replace `<file1>,<file2>` with comma- or newline-separated concrete relative paths for `--scope-paths`; expand globs before running.
+Rendered prompts above the provider `max_prompt_chars` budget fail before launch with `source_content_transmission: "not_sent"`; use narrower scope shards or override `API_REVIEWERS_MAX_PROMPT_CHARS` only after confirming the provider accepts larger prompts.
 If the command fails, report `error_code`, `error_message`, `http_status` when present, and `suggested_action` from the JobRecord. Do not expose API keys.
 Render `external_review_launched` as soon as it appears. If `external_review` is present, render it before the review result.
 

--- a/plugins/api-reviewers/skills/deepseek-adversarial-review/SKILL.md
+++ b/plugins/api-reviewers/skills/deepseek-adversarial-review/SKILL.md
@@ -15,4 +15,5 @@ node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider deepseek --mo
 ```
 
 If the user provides a base ref, add `--scope-base REF` before `--prompt`. `<focus>` is the user's review prompt or focus area.
+The review timeout default is 600000 ms; `API_REVIEWERS_TIMEOUT_MS` is the non-interactive fallback. Rendered prompts above the provider `max_prompt_chars` budget fail before launch with `source_content_transmission: "not_sent"`; use narrower scope shards or override `API_REVIEWERS_MAX_PROMPT_CHARS` only after confirming the provider accepts larger prompts.
 Render the returned JobRecord, render `external_review_launched` as soon as it appears, then render `external_review` before the review result when present. If the JobRecord failed, report `error_code`, `error_message`, `http_status` when present, and `suggested_action`. Never print API-key values.

--- a/plugins/api-reviewers/skills/deepseek-custom-review/SKILL.md
+++ b/plugins/api-reviewers/skills/deepseek-custom-review/SKILL.md
@@ -15,3 +15,4 @@ node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider deepseek --mo
 ```
 
 Replace `<file1>,<file2>` with comma- or newline-separated concrete relative `--scope-paths`; expand globs before running. `<focus>` is the user's review prompt or focus area. Render `external_review_launched` as soon as it appears, then render `external_review` before the review result when present. If the JobRecord failed, report `error_code`, `error_message`, `http_status` when present, and `suggested_action`. Never print API-key values.
+The review timeout default is 600000 ms; `API_REVIEWERS_TIMEOUT_MS` is the non-interactive fallback. Rendered prompts above the provider `max_prompt_chars` budget fail before launch with `source_content_transmission: "not_sent"`; use narrower scope shards or override `API_REVIEWERS_MAX_PROMPT_CHARS` only after confirming the provider accepts larger prompts.

--- a/plugins/api-reviewers/skills/deepseek-review/SKILL.md
+++ b/plugins/api-reviewers/skills/deepseek-review/SKILL.md
@@ -15,5 +15,5 @@ node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider deepseek --mo
 ```
 
 If the user provides a base ref, add `--scope-base REF` before `--prompt`. `<focus>` is the user's review prompt or focus area.
-The review timeout default is 600000 ms; `API_REVIEWERS_TIMEOUT_MS` is the non-interactive fallback.
+The review timeout default is 600000 ms; `API_REVIEWERS_TIMEOUT_MS` is the non-interactive fallback. Rendered prompts above the provider `max_prompt_chars` budget fail before launch with `source_content_transmission: "not_sent"`; use narrower scope shards or override `API_REVIEWERS_MAX_PROMPT_CHARS` only after confirming the provider accepts larger prompts.
 Render the returned JobRecord, render `external_review_launched` as soon as it appears, then render `external_review` before the review result when present. If the JobRecord failed, report `error_code`, `error_message`, `http_status` when present, and `suggested_action`. Never print API-key values.

--- a/plugins/api-reviewers/skills/glm-adversarial-review/SKILL.md
+++ b/plugins/api-reviewers/skills/glm-adversarial-review/SKILL.md
@@ -15,4 +15,5 @@ node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider glm --mode ad
 ```
 
 If the user provides a base ref, add `--scope-base REF` before `--prompt`. `<focus>` is the user's review prompt or focus area.
+The review timeout default is 600000 ms; `API_REVIEWERS_TIMEOUT_MS` is the non-interactive fallback. Rendered prompts above the provider `max_prompt_chars` budget fail before launch with `source_content_transmission: "not_sent"`; use narrower scope shards or override `API_REVIEWERS_MAX_PROMPT_CHARS` only after confirming the provider accepts larger prompts.
 Render the returned JobRecord, render `external_review_launched` as soon as it appears, then render `external_review` before the review result when present. If the JobRecord failed, report `error_code`, `error_message`, `http_status` when present, and `suggested_action`. Never print API-key values.

--- a/plugins/api-reviewers/skills/glm-custom-review/SKILL.md
+++ b/plugins/api-reviewers/skills/glm-custom-review/SKILL.md
@@ -15,3 +15,4 @@ node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider glm --mode cu
 ```
 
 Replace `<file1>,<file2>` with comma- or newline-separated concrete relative `--scope-paths`; expand globs before running. `<focus>` is the user's review prompt or focus area. Render `external_review_launched` as soon as it appears, then render `external_review` before the review result when present. If the JobRecord failed, report `error_code`, `error_message`, `http_status` when present, and `suggested_action`. Never print API-key values.
+The review timeout default is 600000 ms; `API_REVIEWERS_TIMEOUT_MS` is the non-interactive fallback. Rendered prompts above the provider `max_prompt_chars` budget fail before launch with `source_content_transmission: "not_sent"`; use narrower scope shards or override `API_REVIEWERS_MAX_PROMPT_CHARS` only after confirming the provider accepts larger prompts.

--- a/plugins/api-reviewers/skills/glm-review/SKILL.md
+++ b/plugins/api-reviewers/skills/glm-review/SKILL.md
@@ -15,4 +15,5 @@ node plugins/api-reviewers/scripts/api-reviewer.mjs run --provider glm --mode re
 ```
 
 If the user provides a base ref, add `--scope-base REF` before `--prompt`. `<focus>` is the user's review prompt or focus area.
+The review timeout default is 600000 ms; `API_REVIEWERS_TIMEOUT_MS` is the non-interactive fallback. Rendered prompts above the provider `max_prompt_chars` budget fail before launch with `source_content_transmission: "not_sent"`; use narrower scope shards or override `API_REVIEWERS_MAX_PROMPT_CHARS` only after confirming the provider accepts larger prompts.
 Render the returned JobRecord, render `external_review_launched` as soon as it appears, then render `external_review` before the review result when present. If the JobRecord failed, report `error_code`, `error_message`, `http_status` when present, and `suggested_action`. Never print API-key values.

--- a/plugins/claude/commands/claude-adversarial-review.md
+++ b/plugins/claude/commands/claude-adversarial-review.md
@@ -18,7 +18,11 @@ Adversarial review via Claude Code. Assumes the author is wrong; looks for failu
    ```
    (Containment=worktree, scope=branch-diff, dispose=true all come from the profile — spec §21.4.)
    Review timeout defaults to 600000 ms. Use `--timeout-ms <ms>` or `CLAUDE_REVIEW_TIMEOUT_MS`; the effective value is persisted in `review_metadata.audit_manifest.request.timeout_ms`.
-   `branch-diff` is object-pure: checkout filters, replace refs, and grafts are ignored.
+   `branch-diff` is object-pure and committed-only: checkout filters, replace
+   refs, grafts, and dirty working-tree edits are ignored. If the target
+   changes are uncommitted, do not use adversarial branch-diff as the review
+   evidence; use `run --mode=review` for working-tree scope or an explicit
+   `custom-review` bundle instead.
    For a pinned review bundle, run `preflight` and then use
    `run --mode=custom-review --scope-paths <g1,g2,...>` with prompt wording
    that names relative paths inside the selected bundle scope.

--- a/plugins/claude/scripts/lib/job-record.mjs
+++ b/plugins/claude/scripts/lib/job-record.mjs
@@ -260,6 +260,7 @@ function classifyExecution(execution) {
 const SCOPE_FAILURE_PREFIXES = [
   "unsafe_symlink:",
   "scope_population_failed:",
+  "scope_base_invalid:",
   "scope_base_missing:",
   "scope_requires_git:",
   "scope_requires_head:",
@@ -315,16 +316,16 @@ function buildErrorDiagnostic(invocation, status, error_code, error_message) {
     };
   }
 
-  if (message.startsWith("scope_base_missing:")) {
+  if (message.startsWith("scope_base_invalid:") || message.startsWith("scope_base_missing:")) {
     return {
       error_summary: "Review scope was rejected before target launch.",
       error_cause:
-        "A missing base ref or unresolvable git ref prevented scope preparation. " +
+        "A missing, unsafe, or unresolvable git base ref prevented scope preparation. " +
         "Branch-diff scopes require a valid, fetchable base ref.",
       suggested_action:
-        "To fix this, choose a valid base ref (a branch name, tag, or commit SHA) and " +
+        "To fix this, choose a valid base ref (a branch name, tag, remote ref, or commit SHA) and " +
         "pass it via `--scope-base <ref>`. Alternatively, use working-tree scope which " +
-        "does not require a base ref.",
+        "does not require a base ref. Option-shaped values beginning with '-' are rejected before git branch-diff runs.",
       disclosure_note: disclosure,
     };
   }
@@ -374,9 +375,10 @@ function buildErrorDiagnostic(invocation, status, error_code, error_message) {
         "The selected scope was empty and resolved to no reviewable files. Launching the target " +
         "would produce a misleading completed review with no useful source context.",
       suggested_action:
-        "For pinned bundles or selected files, retry with `--mode=custom-review` " +
-        "and explicit `--scope-paths <glob,...>`. For branch diffs, check the " +
-        "`--scope-base <ref>` value and run preflight before launching the provider.",
+        "Branch-diff reviews committed HEAD-vs-base changes only; it does not include dirty working-tree edits. " +
+        "For branch diffs, choose a different --scope-base <ref> if this branch should have committed changes, " +
+        "or retry with --scope-base HEAD~1 to review the last commit. For uncommitted, already-merged, or no-diff branches, " +
+        "retry with `--mode=custom-review` and explicit `--scope-paths <glob,...>` so source selection stays explicit.",
       disclosure_note: disclosure,
     };
   }

--- a/plugins/claude/scripts/lib/scope.mjs
+++ b/plugins/claude/scripts/lib/scope.mjs
@@ -130,6 +130,14 @@ function scopeEmpty(message) {
   throw new Error(`scope_empty: ${message}`);
 }
 
+function safeScopeBase(base) {
+  const value = base ?? "main";
+  if (typeof value !== "string" || value.trim() === "" || value.startsWith("-")) {
+    throw new Error(`scope_base_invalid: base ref ${JSON.stringify(value)} is not safe for git branch-diff`);
+  }
+  return value;
+}
+
 function lstatForScope(abs, rel) {
   try {
     return lstatSync(abs);
@@ -718,7 +726,7 @@ function scopeBranchDiff(sourceCwd, targetPath, scopeBase, scopePaths = []) {
   assertGitWorktree(sourceCwd);
   const ctx = gitScopeContext(sourceCwd);
   assertGitHead(ctx, sourceCwd);
-  const base = scopeBase ?? "main";
+  const base = safeScopeBase(scopeBase);
   // Verify base exists. `rev-parse --verify` exits non-zero if not.
   try {
     git(ctx.gitRoot, ["rev-parse", "--verify", "--quiet", base]);

--- a/plugins/gemini/commands/gemini-adversarial-review.md
+++ b/plugins/gemini/commands/gemini-adversarial-review.md
@@ -16,7 +16,11 @@ Run:
 node "<plugin-root>/scripts/gemini-companion.mjs" run --mode=adversarial-review --foreground --lifecycle-events jsonl -- "<focus text>"
 ```
 Review timeout defaults to 600000 ms. Use `--timeout-ms <ms>` or `GEMINI_REVIEW_TIMEOUT_MS`; the effective value is persisted in `review_metadata.audit_manifest.request.timeout_ms`.
-`branch-diff` is object-pure: checkout filters, replace refs, and grafts are ignored.
+`branch-diff` is object-pure and committed-only: checkout filters, replace refs,
+grafts, and dirty working-tree edits are ignored. If the target changes are
+uncommitted, do not use adversarial branch-diff as the review evidence; use
+`run --mode=review` for working-tree scope or an explicit `custom-review` bundle
+instead.
 It reduces the selected review scope, but a successful run still sends those
 selected source files to Gemini. If a private-repo approval reviewer denies the
 run as external-provider disclosure before launch, report the workflow as

--- a/plugins/gemini/scripts/lib/job-record.mjs
+++ b/plugins/gemini/scripts/lib/job-record.mjs
@@ -256,6 +256,7 @@ function classifyExecution(execution) {
 const SCOPE_FAILURE_PREFIXES = [
   "unsafe_symlink:",
   "scope_population_failed:",
+  "scope_base_invalid:",
   "scope_base_missing:",
   "scope_requires_git:",
   "scope_requires_head:",
@@ -311,16 +312,16 @@ function buildErrorDiagnostic(invocation, status, error_code, error_message) {
     };
   }
 
-  if (message.startsWith("scope_base_missing:")) {
+  if (message.startsWith("scope_base_invalid:") || message.startsWith("scope_base_missing:")) {
     return {
       error_summary: "Review scope was rejected before target launch.",
       error_cause:
-        "A missing base ref or unresolvable git ref prevented scope preparation. " +
+        "A missing, unsafe, or unresolvable git base ref prevented scope preparation. " +
         "Branch-diff scopes require a valid, fetchable base ref.",
       suggested_action:
-        "To fix this, choose a valid base ref (a branch name, tag, or commit SHA) and " +
+        "To fix this, choose a valid base ref (a branch name, tag, remote ref, or commit SHA) and " +
         "pass it via `--scope-base <ref>`. Alternatively, use working-tree scope which " +
-        "does not require a base ref.",
+        "does not require a base ref. Option-shaped values beginning with '-' are rejected before git branch-diff runs.",
       disclosure_note: disclosure,
     };
   }
@@ -370,9 +371,10 @@ function buildErrorDiagnostic(invocation, status, error_code, error_message) {
         "The selected scope was empty and resolved to no reviewable files. Launching the target " +
         "would produce a misleading completed review with no useful source context.",
       suggested_action:
-        "For pinned bundles or selected files, retry with `--mode=custom-review` " +
-        "and explicit `--scope-paths <glob,...>`. For branch diffs, check the " +
-        "`--scope-base <ref>` value and run preflight before launching the provider.",
+        "Branch-diff reviews committed HEAD-vs-base changes only; it does not include dirty working-tree edits. " +
+        "For branch diffs, choose a different --scope-base <ref> if this branch should have committed changes, " +
+        "or retry with --scope-base HEAD~1 to review the last commit. For uncommitted, already-merged, or no-diff branches, " +
+        "retry with `--mode=custom-review` and explicit `--scope-paths <glob,...>` so source selection stays explicit.",
       disclosure_note: disclosure,
     };
   }

--- a/plugins/gemini/scripts/lib/scope.mjs
+++ b/plugins/gemini/scripts/lib/scope.mjs
@@ -130,6 +130,14 @@ function scopeEmpty(message) {
   throw new Error(`scope_empty: ${message}`);
 }
 
+function safeScopeBase(base) {
+  const value = base ?? "main";
+  if (typeof value !== "string" || value.trim() === "" || value.startsWith("-")) {
+    throw new Error(`scope_base_invalid: base ref ${JSON.stringify(value)} is not safe for git branch-diff`);
+  }
+  return value;
+}
+
 function lstatForScope(abs, rel) {
   try {
     return lstatSync(abs);
@@ -718,7 +726,7 @@ function scopeBranchDiff(sourceCwd, targetPath, scopeBase, scopePaths = []) {
   assertGitWorktree(sourceCwd);
   const ctx = gitScopeContext(sourceCwd);
   assertGitHead(ctx, sourceCwd);
-  const base = scopeBase ?? "main";
+  const base = safeScopeBase(scopeBase);
   // Verify base exists. `rev-parse --verify` exits non-zero if not.
   try {
     git(ctx.gitRoot, ["rev-parse", "--verify", "--quiet", base]);

--- a/plugins/grok/commands/grok-adversarial-review.md
+++ b/plugins/grok/commands/grok-adversarial-review.md
@@ -16,4 +16,6 @@ present. If the JobRecord failed, report `error_code`, `error_message`,
 cookies, tunnel API keys, or bearer token values.
 Do not recommend direct xAI API keys as a fallback for subscription web mode.
 
-Review timeout defaults to 600000 ms. Use `GROK_WEB_TIMEOUT_MS=<ms>` to override it; the effective value is persisted in `review_metadata.audit_manifest.request.timeout_ms`. Doctor timeouts remain separate readiness checks.
+`branch-diff` is committed-only and does not include dirty working-tree edits. If the target changes are uncommitted, do not use adversarial branch-diff as the review evidence; run `grok-custom-review` with explicit `--scope-paths` instead.
+
+Review timeout defaults to 600000 ms. Use `GROK_WEB_TIMEOUT_MS=<ms>` to override it; the effective value is persisted in `review_metadata.audit_manifest.request.timeout_ms`. Rendered prompts above `GROK_WEB_MAX_PROMPT_CHARS` (default 400000) fail before tunnel launch with `source_content_transmission: "not_sent"`; split or narrow the scope instead of relying on truncation. Doctor timeouts remain separate readiness checks.

--- a/plugins/grok/commands/grok-custom-review.md
+++ b/plugins/grok/commands/grok-custom-review.md
@@ -15,4 +15,4 @@ Replace `<file1>,<file2>` with comma- or newline-separated concrete relative pat
 cookies, tunnel API keys, or bearer token values. Do not recommend direct xAI
 API keys as a fallback for subscription web mode.
 
-Review timeout defaults to 600000 ms. Use `GROK_WEB_TIMEOUT_MS=<ms>` to override it; the effective value is persisted in `review_metadata.audit_manifest.request.timeout_ms`. Doctor timeouts remain separate readiness checks.
+Review timeout defaults to 600000 ms. Use `GROK_WEB_TIMEOUT_MS=<ms>` to override it; the effective value is persisted in `review_metadata.audit_manifest.request.timeout_ms`. Rendered prompts above `GROK_WEB_MAX_PROMPT_CHARS` (default 400000) fail before tunnel launch with `source_content_transmission: "not_sent"`; split or narrow the scope instead of relying on truncation. Doctor timeouts remain separate readiness checks.

--- a/plugins/grok/commands/grok-review.md
+++ b/plugins/grok/commands/grok-review.md
@@ -16,4 +16,4 @@ present. If the JobRecord failed, report `error_code`, `error_message`,
 cookies, tunnel API keys, or bearer token values.
 Do not recommend direct xAI API keys as a fallback for subscription web mode.
 
-Review timeout defaults to 600000 ms. Use `GROK_WEB_TIMEOUT_MS=<ms>` to override it; the effective value is persisted in `review_metadata.audit_manifest.request.timeout_ms`. Doctor timeouts remain separate readiness checks.
+Review timeout defaults to 600000 ms. Use `GROK_WEB_TIMEOUT_MS=<ms>` to override it; the effective value is persisted in `review_metadata.audit_manifest.request.timeout_ms`. Rendered prompts above `GROK_WEB_MAX_PROMPT_CHARS` (default 400000) fail before tunnel launch with `source_content_transmission: "not_sent"`; split or narrow the scope instead of relying on truncation. Doctor timeouts remain separate readiness checks.

--- a/plugins/grok/scripts/grok-web-reviewer.mjs
+++ b/plugins/grok/scripts/grok-web-reviewer.mjs
@@ -2,7 +2,7 @@
 import { spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { constants as fsConstants } from "node:fs";
-import { mkdir, open, readFile, readdir, realpath, rename, rm, rmdir, stat, unlink, writeFile } from "node:fs/promises";
+import { lstat, mkdir, open, readFile, readdir, realpath, rename, rm, rmdir, stat, unlink, writeFile } from "node:fs/promises";
 import { hostname } from "node:os";
 import { dirname, isAbsolute, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -19,6 +19,7 @@ const DEFAULT_MODEL = "grok-4.20-fast";
 const DEFAULT_TIMEOUT_MS = 600000;
 const DEFAULT_DOCTOR_TIMEOUT_MS = 2000;
 const DEFAULT_CHAT_DOCTOR_TIMEOUT_MS = 10000;
+const DEFAULT_MAX_PROMPT_CHARS = 400000;
 const MAX_SCOPE_FILE_BYTES = 256 * 1024;
 const MAX_SCOPE_TOTAL_BYTES = 1024 * 1024;
 const GIT_SHOW_MAX_BUFFER_BYTES = 16 * 1024 * 1024;
@@ -144,6 +145,7 @@ function config(env = process.env) {
   const timeoutMs = parsePositiveIntegerEnv(env, "GROK_WEB_TIMEOUT_MS", DEFAULT_TIMEOUT_MS);
   const doctorTimeoutMs = parsePositiveIntegerEnv(env, "GROK_WEB_DOCTOR_TIMEOUT_MS", DEFAULT_DOCTOR_TIMEOUT_MS);
   const chatDoctorTimeoutMs = parsePositiveIntegerEnv(env, "GROK_WEB_CHAT_DOCTOR_TIMEOUT_MS", DEFAULT_CHAT_DOCTOR_TIMEOUT_MS);
+  const maxPromptChars = parsePositiveIntegerEnv(env, "GROK_WEB_MAX_PROMPT_CHARS", DEFAULT_MAX_PROMPT_CHARS, "character count");
   return {
     provider: "grok-web",
     display_name: "Grok Web",
@@ -153,17 +155,34 @@ function config(env = process.env) {
     timeout_ms: timeoutMs,
     doctor_timeout_ms: doctorTimeoutMs,
     chat_doctor_timeout_ms: chatDoctorTimeoutMs,
+    max_prompt_chars: maxPromptChars,
     credential_ref: env.GROK_WEB_TUNNEL_API_KEY ? "GROK_WEB_TUNNEL_API_KEY" : null,
     credential_value: env.GROK_WEB_TUNNEL_API_KEY || null,
   };
 }
 
-function parsePositiveIntegerEnv(env, name, fallback) {
+function fallbackConfig(env = process.env) {
+  return {
+    provider: "grok-web",
+    display_name: "Grok Web",
+    auth_mode: "subscription_web",
+    base_url: normalizeBaseUrl(env.GROK_WEB_BASE_URL),
+    model: env.GROK_WEB_MODEL || DEFAULT_MODEL,
+    timeout_ms: DEFAULT_TIMEOUT_MS,
+    doctor_timeout_ms: DEFAULT_DOCTOR_TIMEOUT_MS,
+    chat_doctor_timeout_ms: DEFAULT_CHAT_DOCTOR_TIMEOUT_MS,
+    max_prompt_chars: DEFAULT_MAX_PROMPT_CHARS,
+    credential_ref: env.GROK_WEB_TUNNEL_API_KEY ? "GROK_WEB_TUNNEL_API_KEY" : null,
+    credential_value: env.GROK_WEB_TUNNEL_API_KEY || null,
+  };
+}
+
+function parsePositiveIntegerEnv(env, name, fallback, unit = "number of milliseconds") {
   const value = env[name];
   if (value === undefined || value === null || value === "") return fallback;
   const parsed = Number(value);
   if (!Number.isSafeInteger(parsed) || parsed <= 0) {
-    throw new Error(`bad_args: ${name} must be a positive integer number of milliseconds; got ${JSON.stringify(value)}`);
+    throw new Error(`bad_args: ${name} must be a positive integer ${unit}; got ${JSON.stringify(value)}`);
   }
   return parsed;
 }
@@ -312,6 +331,14 @@ function scopeName(options) {
   return options.scope ?? (options.mode === "custom-review" ? "custom" : "branch-diff");
 }
 
+function safeScopeBase(base) {
+  const value = base ?? "main";
+  if (typeof value !== "string" || value.trim() === "" || value.startsWith("-")) {
+    throw new Error(`scope_base_invalid: base ref ${JSON.stringify(value)} is not safe for git branch-diff`);
+  }
+  return value;
+}
+
 function selectedScopePaths(scope, options, cwd) {
   if (scope === "custom") {
     const relPaths = splitScopePaths(options["scope-paths"]);
@@ -319,7 +346,7 @@ function selectedScopePaths(scope, options, cwd) {
     return relPaths;
   }
   if (scope === "branch-diff") {
-    const base = options["scope-base"] ?? "main";
+    const base = safeScopeBase(options["scope-base"]);
     const changed = gitRaw(["diff", "-z", "--name-only", `${base}...HEAD`, "--"], cwd);
     const requested = splitScopePaths(options["scope-paths"]);
     const changedPaths = splitGitPathList(changed);
@@ -333,7 +360,7 @@ function selectedScopePaths(scope, options, cwd) {
 }
 
 function validateScopePath(workspaceRoot, relPath) {
-  if (relPath.includes("..") || isAbsolute(relPath) || relPath.includes("\\")) {
+  if (relPath.includes("..") || isAbsolute(relPath) || relPath.includes("\\") || /[\u0000-\u001f\u007f]/u.test(relPath)) {
     throw new Error(`unsafe_scope_path:${relPath}`);
   }
   const abs = resolve(workspaceRoot, relPath);
@@ -357,11 +384,22 @@ function addScopeFile(files, normalizedRel, text, totalBytes) {
   files.push({ path: normalizedRel, text });
 }
 
-async function readUtf8ScopeFileWithinLimit(filePath, normalizedRel) {
-  const handle = await open(filePath, SCOPE_FILE_OPEN_FLAGS);
+async function readUtf8ScopeFileWithinLimit(filePath, normalizedRel, beforeOpen = null) {
+  beforeOpen ??= await lstat(filePath);
+  let handle;
+  try {
+    handle = await open(filePath, SCOPE_FILE_OPEN_FLAGS);
+  } catch (e) {
+    if (e?.code === "ELOOP") throw new Error(`unsafe_scope_path:${normalizedRel}`);
+    if (e?.code === "ENOENT") return null;
+    throw e;
+  }
   try {
     const info = await handle.stat();
     if (!info.isFile()) return null;
+    if (!sameFileIdentity(beforeOpen, info)) {
+      throw new Error(`unsafe_scope_path:${normalizedRel}: file changed before secure open`);
+    }
     if (info.size > MAX_SCOPE_FILE_BYTES) {
       throw new Error(`scope_file_too_large:${normalizedRel}: ${info.size} bytes exceeds ${MAX_SCOPE_FILE_BYTES} byte limit`);
     }
@@ -385,7 +423,7 @@ async function readUtf8ScopeFileWithinLimit(filePath, normalizedRel) {
     if (total === 0) return "";
     return Buffer.concat(chunks, total).toString("utf8");
   } finally {
-    await handle.close();
+    await handle?.close();
   }
 }
 
@@ -421,18 +459,22 @@ async function readFilesystemScopeFiles(workspaceRoot, relPaths) {
   const realWorkspaceRoot = await realpath(workspaceRoot);
   for (const relPath of relPaths) {
     const { abs, normalizedRel } = validateScopePath(workspaceRoot, relPath);
-    let realAbs;
+    let beforeOpen;
     try {
-      realAbs = await realpath(abs);
+      beforeOpen = await lstat(abs);
     } catch (error) {
       if (error?.code === "ENOENT") continue;
       throw error;
     }
+    if (beforeOpen.isSymbolicLink()) {
+      throw new Error(`unsafe_scope_path:${normalizedRel}`);
+    }
+    const realAbs = await realpath(abs);
     const realRel = relative(realWorkspaceRoot, realAbs);
     if (realRel.startsWith("..") || realRel === "") {
       throw new Error(`unsafe_scope_path:${relPath}`);
     }
-    const text = await readUtf8ScopeFileWithinLimit(realAbs, normalizedRel);
+    const text = await readUtf8ScopeFileWithinLimit(realAbs, normalizedRel, beforeOpen);
     if (text === null) continue;
     addScopeFile(files, normalizedRel, text, totalBytes);
   }
@@ -818,9 +860,20 @@ function disclosure(cfg, completed, payloadSent) {
   return `Selected source content may have been sent to ${cfg.display_name} through a subscription-backed web session.`;
 }
 
-function suggestedAction(errorCode) {
+function suggestedAction(errorCode, errorMessage = "") {
   if (errorCode === "bad_args") return "Correct the grok-web command arguments and retry.";
-  if (errorCode === "scope_failed") return "Adjust --scope, --scope-base, or --scope-paths and retry.";
+  if (errorCode === "scope_failed") {
+    if (/scope_empty:\s*branch-diff selected no files/i.test(errorMessage)) {
+      return "Branch-diff selected no files before tunnel launch. Branch-diff reviews committed HEAD-vs-base changes only; it does not include dirty working-tree edits. Choose a different --scope-base <ref> if this branch should have committed changes, use --scope-base HEAD~1 to review the last commit, or use custom-review with explicit --scope-paths for uncommitted, already-merged, or no-diff branches.";
+    }
+    if (/scope_base_invalid:/i.test(errorMessage)) {
+      return "Use a concrete branch, tag, remote ref, or commit SHA for --scope-base; option-shaped values beginning with '-' are rejected before git branch-diff runs.";
+    }
+    if (/prompt_too_large:/i.test(errorMessage)) {
+      return "Rendered prompt exceeds the Grok prompt budget before tunnel launch. Use a narrower scope, split the review into explicit custom-review shards, or raise GROK_WEB_MAX_PROMPT_CHARS only after confirming the local tunnel/model accepts larger prompts.";
+    }
+    return "Adjust --scope, --scope-base, or --scope-paths and retry.";
+  }
   if (errorCode === "tunnel_unavailable") return "Start the local Grok web tunnel, verify GROK_WEB_BASE_URL, then retry.";
   if (errorCode === "tunnel_timeout") return "The local Grok web tunnel did not respond before GROK_WEB_TIMEOUT_MS; inspect the tunnel and retry.";
   if (errorCode === "session_expired") return "Refresh the Grok web login/session used by the local tunnel, then retry.";
@@ -991,7 +1044,7 @@ function buildRecord({ cfg, mode, options, scopeInfo, execution, startedAt, ende
     error_message: errorMessage,
     error_summary: completed ? null : diagnostic,
     error_cause: completed ? null : errorCauseFor(errorCode),
-    suggested_action: completed ? null : suggestedAction(errorCode),
+    suggested_action: completed ? null : suggestedAction(errorCode, errorMessage),
     external_review: buildTerminalExternalReview({ cfg, mode, options, scopeInfo, execution, transmission, reviewDisclosure }),
     disclosure_note: reviewDisclosure,
     runtime_diagnostics: null,
@@ -1363,16 +1416,18 @@ async function cmdRun(options) {
   const mode = options.mode ?? "review";
   let lifecycleEvents = null;
   const startedAt = new Date().toISOString();
-  const cfg = config();
+  let cfg = null;
   const jobId = `job_${randomUUID()}`;
   const runOptions = { ...options, jobId };
   let scopeInfo;
   let execution;
   try {
     lifecycleEvents = parseLifecycleEventsMode(options["lifecycle-events"]);
+    cfg = config();
     if (!VALID_MODES.has(mode)) throw new Error(`bad_args: unsupported --mode ${mode}`);
     scopeInfo = await collectScope({ ...runOptions, mode });
   } catch (e) {
+    cfg ??= fallbackConfig();
     const cwd = resolve(process.cwd());
     scopeInfo = {
       cwd,
@@ -1392,6 +1447,10 @@ async function cmdRun(options) {
     let prompt;
     try {
       prompt = promptFor(mode, options.prompt ?? "", scopeInfo);
+      if (prompt.length > cfg.max_prompt_chars) {
+        execution = providerFailure("scope_failed", redactor()(`prompt_too_large:${prompt.length} chars exceeds GROK_WEB_MAX_PROMPT_CHARS=${cfg.max_prompt_chars}`), null, null, false);
+        execution.prompt = prompt;
+      }
     } catch (e) {
       execution = providerFailure(e.message.startsWith("bad_args:") ? "bad_args" : "scope_failed", redactor()(e.message), null, null, false);
     }

--- a/plugins/grok/scripts/grok-web-reviewer.mjs
+++ b/plugins/grok/scripts/grok-web-reviewer.mjs
@@ -1528,7 +1528,14 @@ async function runCli() {
   }
 }
 
-export { releaseStateLock, sortJobSummaries, staleLockReason, withStateLock };
+export {
+  readUtf8ScopeFileWithinLimit,
+  releaseStateLock,
+  sameFileIdentity,
+  sortJobSummaries,
+  staleLockReason,
+  withStateLock,
+};
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
   await runCli();

--- a/plugins/kimi/commands/kimi-adversarial-review.md
+++ b/plugins/kimi/commands/kimi-adversarial-review.md
@@ -16,7 +16,11 @@ Run:
 node "<plugin-root>/scripts/kimi-companion.mjs" run --mode=adversarial-review --foreground --lifecycle-events jsonl -- "<focus text>"
 ```
 Review timeout defaults to 600000 ms. Use `--timeout-ms <ms>` or `KIMI_REVIEW_TIMEOUT_MS`; the effective value is persisted in `review_metadata.audit_manifest.request.timeout_ms`.
-`branch-diff` is object-pure: checkout filters, replace refs, and grafts are ignored.
+`branch-diff` is object-pure and committed-only: checkout filters, replace refs,
+grafts, and dirty working-tree edits are ignored. If the target changes are
+uncommitted, do not use adversarial branch-diff as the review evidence; use
+`run --mode=review` for working-tree scope or an explicit `custom-review` bundle
+instead.
 It reduces the selected review scope, but a successful run still sends those
 selected source files to Kimi. If a private-repo approval reviewer denies the
 run as external-provider disclosure before launch, report the workflow as

--- a/plugins/kimi/scripts/lib/job-record.mjs
+++ b/plugins/kimi/scripts/lib/job-record.mjs
@@ -272,6 +272,7 @@ function classifyExecution(execution) {
 const SCOPE_FAILURE_PREFIXES = [
   "unsafe_symlink:",
   "scope_population_failed:",
+  "scope_base_invalid:",
   "scope_base_missing:",
   "scope_requires_git:",
   "scope_requires_head:",
@@ -362,16 +363,16 @@ function buildErrorDiagnostic(invocation, status, error_code, error_message) {
     };
   }
 
-  if (message.startsWith("scope_base_missing:")) {
+  if (message.startsWith("scope_base_invalid:") || message.startsWith("scope_base_missing:")) {
     return {
       error_summary: "Review scope was rejected before target launch.",
       error_cause:
-        "A missing base ref or unresolvable git ref prevented scope preparation. " +
+        "A missing, unsafe, or unresolvable git base ref prevented scope preparation. " +
         "Branch-diff scopes require a valid, fetchable base ref.",
       suggested_action:
-        "To fix this, choose a valid base ref (a branch name, tag, or commit SHA) and " +
+        "To fix this, choose a valid base ref (a branch name, tag, remote ref, or commit SHA) and " +
         "pass it via `--scope-base <ref>`. Alternatively, use working-tree scope which " +
-        "does not require a base ref.",
+        "does not require a base ref. Option-shaped values beginning with '-' are rejected before git branch-diff runs.",
       disclosure_note: disclosure,
     };
   }
@@ -421,9 +422,10 @@ function buildErrorDiagnostic(invocation, status, error_code, error_message) {
         "The selected scope was empty and resolved to no reviewable files. Launching the target " +
         "would produce a misleading completed review with no useful source context.",
       suggested_action:
-        "For pinned bundles or selected files, retry with `--mode=custom-review` " +
-        "and explicit `--scope-paths <glob,...>`. For branch diffs, check the " +
-        "`--scope-base <ref>` value and run preflight before launching the provider.",
+        "Branch-diff reviews committed HEAD-vs-base changes only; it does not include dirty working-tree edits. " +
+        "For branch diffs, choose a different --scope-base <ref> if this branch should have committed changes, " +
+        "or retry with --scope-base HEAD~1 to review the last commit. For uncommitted, already-merged, or no-diff branches, " +
+        "retry with `--mode=custom-review` and explicit `--scope-paths <glob,...>` so source selection stays explicit.",
       disclosure_note: disclosure,
     };
   }

--- a/plugins/kimi/scripts/lib/scope.mjs
+++ b/plugins/kimi/scripts/lib/scope.mjs
@@ -130,6 +130,14 @@ function scopeEmpty(message) {
   throw new Error(`scope_empty: ${message}`);
 }
 
+function safeScopeBase(base) {
+  const value = base ?? "main";
+  if (typeof value !== "string" || value.trim() === "" || value.startsWith("-")) {
+    throw new Error(`scope_base_invalid: base ref ${JSON.stringify(value)} is not safe for git branch-diff`);
+  }
+  return value;
+}
+
 function lstatForScope(abs, rel) {
   try {
     return lstatSync(abs);
@@ -718,7 +726,7 @@ function scopeBranchDiff(sourceCwd, targetPath, scopeBase, scopePaths = []) {
   assertGitWorktree(sourceCwd);
   const ctx = gitScopeContext(sourceCwd);
   assertGitHead(ctx, sourceCwd);
-  const base = scopeBase ?? "main";
+  const base = safeScopeBase(scopeBase);
   // Verify base exists. `rev-parse --verify` exits non-zero if not.
   try {
     git(ctx.gitRoot, ["rev-parse", "--verify", "--quiet", base]);

--- a/tests/smoke/api-reviewers.smoke.test.mjs
+++ b/tests/smoke/api-reviewers.smoke.test.mjs
@@ -180,6 +180,17 @@ function makeBranchDiffWorkspace() {
   return cwd;
 }
 
+function makeEmptyBranchDiffWorkspace() {
+  const cwd = makeWorkspace();
+  git(cwd, ["init", "-b", "main"]);
+  git(cwd, ["config", "user.email", "test@example.com"]);
+  git(cwd, ["config", "user.name", "Test User"]);
+  git(cwd, ["add", "seed.txt"]);
+  git(cwd, ["commit", "-m", "seed"]);
+  git(cwd, ["checkout", "-b", "feature"]);
+  return cwd;
+}
+
 test("doctor reports DeepSeek API-key readiness by key name only", async () => {
   const result = await run(["doctor", "--provider", "deepseek"], {
     env: { DEEPSEEK_API_KEY: "secret-test-value" },
@@ -1166,6 +1177,8 @@ test("installed api-reviewers package layout is self-contained for branch-diff r
 test("DeepSeek direct API custom-review completes and persists JobRecord", async () => {
   const cwd = makeWorkspace();
   const dataDir = mkdtempSync(path.join(tmpdir(), "api-reviewers-data-"));
+  const sourceText = "hello from selected scope\n// ``` nested markdown fence\n";
+  writeFileSync(path.join(cwd, "seed.txt"), sourceText);
   const result = await run([
     "run",
     "--provider", "deepseek",
@@ -1180,7 +1193,8 @@ test("DeepSeek direct API custom-review completes and persists JobRecord", async
       API_REVIEWERS_PLUGIN_DATA: dataDir,
       API_REVIEWERS_TIMEOUT_MS: "123456",
       API_REVIEWERS_MOCK_RESPONSE: mockResponse("deepseek-v4-pro"),
-      API_REVIEWERS_MOCK_ASSERT_PROMPT_INCLUDES: "Live verification context",
+      API_REVIEWERS_MOCK_ASSERT_PROMPT_INCLUDES: "BEGIN API REVIEWER FILE 1: seed.txt",
+      API_REVIEWERS_MOCK_ASSERT_PROMPT_EXCLUDES: "\n```\n",
       DEEPSEEK_API_KEY: "secret-test-value",
     },
   });
@@ -1201,7 +1215,7 @@ test("DeepSeek direct API custom-review completes and persists JobRecord", async
     bytes: file.bytes,
     hashOk: /^[a-f0-9]{64}$/.test(file.content_hash.value),
   })), [
-    { path: "seed.txt", bytes: "hello from selected scope\n".length, hashOk: true },
+    { path: "seed.txt", bytes: sourceText.length, hashOk: true },
   ]);
   assert.equal(record.review_metadata.audit_manifest.request.model, "deepseek-v4-pro");
   assert.equal(record.review_metadata.audit_manifest.request.timeout_ms, 123456);
@@ -1235,6 +1249,38 @@ test("DeepSeek direct API custom-review completes and persists JobRecord", async
   assert.equal(record.result.includes("Verdict: APPROVE"), true);
   assert.deepEqual(record.usage, { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 });
   assert.doesNotMatch(result.stdout, /secret-test-value/);
+});
+
+test("direct API reviewer chooses a collision-free source delimiter", async () => {
+  const cwd = makeWorkspace();
+  const dataDir = mkdtempSync(path.join(tmpdir(), "api-reviewers-data-"));
+  writeFileSync(path.join(cwd, "seed.txt"), [
+    "BEGIN API REVIEWER FILE 1: seed.txt",
+    "source content that resembles the default delimiter",
+    "END API REVIEWER FILE 1: seed.txt",
+    "",
+  ].join("\n"));
+  const result = await run([
+    "run",
+    "--provider", "deepseek",
+    "--mode", "custom-review",
+    "--scope", "custom",
+    "--scope-paths", "seed.txt",
+    "--foreground",
+    "--prompt", "Check this file.",
+  ], {
+    cwd,
+    env: {
+      API_REVIEWERS_PLUGIN_DATA: dataDir,
+      API_REVIEWERS_MOCK_RESPONSE: mockResponse("deepseek-v4-pro"),
+      API_REVIEWERS_MOCK_ASSERT_PROMPT_INCLUDES: "BEGIN API REVIEWER FILE 1: seed.txt #",
+      DEEPSEEK_API_KEY: "secret-test-value",
+    },
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const record = parseJson(result.stdout);
+  assert.equal(record.status, "completed");
+  assert.equal(record.external_review.source_content_transmission, "sent");
 });
 
 test("direct API provider session_id accepts safe provider ID shapes", async () => {
@@ -1794,6 +1840,16 @@ test("custom-review rejects symlinked scope files before provider delivery", asy
   assert.doesNotMatch(result.stdout, /workspace secret should not be sent/);
 });
 
+test("scope file reads open canonical paths after symlink boundary check", () => {
+  const source = readFileSync(COMPANION, "utf8");
+  assert.match(source, /const SCOPE_FILE_OPEN_FLAGS = fsConstants\.O_RDONLY \| \(fsConstants\.O_NOFOLLOW \?\? 0\);/);
+  assert.match(source, /if \(beforeOpen\.isSymbolicLink\(\)\) \{/);
+  assert.match(source, /const realRel = relative\(realWorkspaceRoot, realAbs\);/);
+  assert.match(source, /if \(e\?\.code === "ENOENT"\) return null;/);
+  assert.match(source, /const text = await readUtf8ScopeFileWithinLimit\(realAbs, normalizedRel, beforeOpen\);/);
+  assert.doesNotMatch(source, /readUtf8ScopeFileWithinLimit\(abs, normalizedRel\)/);
+});
+
 test("custom-review rejects oversized scope files before provider delivery", async () => {
   const cwd = makeWorkspace();
   const dataDir = mkdtempSync(path.join(tmpdir(), "api-reviewers-data-"));
@@ -1850,6 +1906,35 @@ test("branch-diff default reviews committed changes against main with scrubbed g
   assert.deepEqual(record.scope_paths, ["feature.txt"]);
   assert.doesNotMatch(result.stdout, /secret-test-value/);
   assert.doesNotMatch(result.stdout, /DIRTY_SELECTED_SECRET/);
+});
+
+test("branch-diff rejects control characters in selected paths before provider delivery", async () => {
+  const cwd = makeBranchDiffWorkspace();
+  const dataDir = mkdtempSync(path.join(tmpdir(), "api-reviewers-data-"));
+  writeFileSync(path.join(cwd, "bad\nname.txt"), "newline path should not reach the prompt\n");
+  git(cwd, ["add", "bad\nname.txt"]);
+  git(cwd, ["commit", "-m", "newline path"]);
+  const result = await run([
+    "run",
+    "--provider", "deepseek",
+    "--mode", "review",
+    "--scope", "branch-diff",
+    "--foreground",
+    "--prompt", "Check this branch.",
+  ], {
+    cwd,
+    env: {
+      API_REVIEWERS_PLUGIN_DATA: dataDir,
+      API_REVIEWERS_MOCK_RESPONSE: mockResponse("deepseek-v4-pro"),
+      DEEPSEEK_API_KEY: "secret-test-value",
+    },
+  });
+  assert.equal(result.status, 1);
+  const record = parseJson(result.stdout);
+  assert.equal(record.error_code, "scope_failed");
+  assert.match(record.error_message, /unsafe_scope_path:bad\nname\.txt/);
+  assert.equal(record.external_review.source_content_transmission, "not_sent");
+  assert.doesNotMatch(result.stdout, /newline path should not reach the prompt/);
 });
 
 test("branch-diff scope paths narrow committed changes", async () => {
@@ -2126,6 +2211,133 @@ test("direct API reviewers reject missing prompt before launch or source transmi
   assert.equal(record.status, "failed");
   assert.equal(record.error_code, "bad_args");
   assert.match(record.error_message, /prompt is required/);
+  assertDirectApiNotSent(record, "DeepSeek");
+  assert.doesNotMatch(result.stdout, /external_review_launched/);
+  assert.doesNotMatch(result.stdout, /secret-test-value/);
+});
+
+test("direct API reviewers explain empty branch-diff recovery before launch", async () => {
+  const cwd = makeEmptyBranchDiffWorkspace();
+  const result = await run([
+    "run",
+    "--provider", "deepseek",
+    "--mode", "adversarial-review",
+    "--scope", "branch-diff",
+    "--scope-base", "main",
+    "--lifecycle-events", "jsonl",
+    "--prompt", "Review this branch.",
+  ], {
+    cwd,
+    env: {
+      API_REVIEWERS_MOCK_RESPONSE: mockResponse("deepseek-v4-pro"),
+      DEEPSEEK_API_KEY: "secret-test-value",
+    },
+  });
+  assert.equal(result.status, 1);
+  const lines = parseJsonLines(result.stdout);
+  assert.equal(lines.length, 1);
+  const [record] = lines;
+  assert.equal(record.status, "failed");
+  assert.equal(record.error_code, "scope_failed");
+  assert.match(record.error_message, /scope_empty: branch-diff selected no files/);
+  assert.match(record.suggested_action, /different --scope-base/);
+  assert.match(record.suggested_action, /--scope-base HEAD~1/);
+  assert.match(record.suggested_action, /custom-review/);
+  assertDirectApiNotSent(record, "DeepSeek");
+  assert.doesNotMatch(result.stdout, /external_review_launched/);
+  assert.doesNotMatch(result.stdout, /secret-test-value/);
+});
+
+test("direct API reviewers reject option-shaped scope-base before git diff", async () => {
+  const cwd = makeWorkspace();
+  const result = await run([
+    "run",
+    "--provider", "deepseek",
+    "--mode", "adversarial-review",
+    "--scope", "branch-diff",
+    "--scope-base", "--definitely-not-a-real-ref",
+    "--lifecycle-events", "jsonl",
+    "--prompt", "Review this branch.",
+  ], {
+    cwd,
+    env: {
+      API_REVIEWERS_MOCK_RESPONSE: mockResponse("deepseek-v4-pro"),
+      DEEPSEEK_API_KEY: "secret-test-value",
+    },
+  });
+  assert.equal(result.status, 1);
+  const lines = parseJsonLines(result.stdout);
+  assert.equal(lines.length, 1);
+  const [record] = lines;
+  assert.equal(record.status, "failed");
+  assert.equal(record.error_code, "scope_failed");
+  assert.match(record.error_message, /scope_base_invalid/);
+  assert.match(record.suggested_action, /option-shaped values/);
+  assertDirectApiNotSent(record, "DeepSeek");
+  assert.doesNotMatch(result.stdout, /external_review_launched/);
+  assert.doesNotMatch(result.stdout, /invalid option/);
+  assert.doesNotMatch(result.stdout, /secret-test-value/);
+});
+
+test("direct API reviewers reject invalid API_REVIEWERS_MAX_PROMPT_CHARS env", async () => {
+  const cwd = makeWorkspace();
+  const result = await run([
+    "run",
+    "--provider", "deepseek",
+    "--mode", "custom-review",
+    "--scope", "custom",
+    "--scope-paths", "seed.txt",
+    "--foreground",
+    "--prompt", "Check this file.",
+  ], {
+    cwd,
+    env: {
+      API_REVIEWERS_MAX_PROMPT_CHARS: "not-a-number",
+      API_REVIEWERS_MOCK_RESPONSE: mockResponse("deepseek-v4-pro"),
+      DEEPSEEK_API_KEY: "secret-test-value",
+    },
+  });
+
+  assert.equal(result.status, 1);
+  const record = parseJson(result.stdout);
+  assert.equal(record.status, "failed");
+  assert.equal(record.error_code, "bad_args");
+  assert.match(record.error_message, /API_REVIEWERS_MAX_PROMPT_CHARS must be a positive integer number of characters/);
+  assertDirectApiNotSent(record, "DeepSeek");
+});
+
+test("direct API reviewers reject rendered prompt over provider budget before launch", async () => {
+  const cwd = makeWorkspace();
+  const result = await run([
+    "run",
+    "--provider", "deepseek",
+    "--mode", "custom-review",
+    "--scope", "custom",
+    "--scope-paths", "seed.txt",
+    "--foreground",
+    "--lifecycle-events", "jsonl",
+    "--prompt", "Check this file.",
+  ], {
+    cwd,
+    env: {
+      API_REVIEWERS_MAX_PROMPT_CHARS: "100",
+      API_REVIEWERS_MOCK_RESPONSE: mockResponse("deepseek-v4-pro"),
+      DEEPSEEK_API_KEY: "secret-test-value",
+    },
+  });
+
+  assert.equal(result.status, 1);
+  const lines = parseJsonLines(result.stdout);
+  assert.equal(lines.length, 1);
+  const [record] = lines;
+  assert.equal(record.status, "failed");
+  assert.equal(record.error_code, "scope_failed");
+  assert.match(record.error_message, /prompt_too_large:/);
+  assert.match(record.suggested_action, /narrower scope|split/i);
+  assert.match(record.review_metadata.audit_manifest.rendered_prompt_hash.value, /^[a-f0-9]{64}$/);
+  assert.equal(record.review_metadata.audit_manifest.selected_source.files.length, 1);
+  assert.equal(JSON.stringify(record.review_metadata.audit_manifest).includes("Check this file"), false);
+  assert.equal(JSON.stringify(record.review_metadata.audit_manifest).includes("hello from selected scope"), false);
   assertDirectApiNotSent(record, "DeepSeek");
   assert.doesNotMatch(result.stdout, /external_review_launched/);
   assert.doesNotMatch(result.stdout, /secret-test-value/);

--- a/tests/smoke/api-reviewers.smoke.test.mjs
+++ b/tests/smoke/api-reviewers.smoke.test.mjs
@@ -1,11 +1,11 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { execFile, execFileSync } from "node:child_process";
-import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, symlinkSync, utimesSync, writeFileSync } from "node:fs";
+import { cpSync, existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, symlinkSync, utimesSync, writeFileSync } from "node:fs";
 import { createServer } from "node:http";
 import { hostname, tmpdir } from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { externalReviewLaunchedEvent } from "../../scripts/lib/companion-common.mjs";
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
@@ -115,6 +115,30 @@ function assertDirectApiNotSent(record, displayName) {
     `Selected source content was not sent to ${displayName} through direct API auth.`,
   );
   assert.equal(record.disclosure_note, record.external_review.disclosure);
+}
+
+async function importApiReviewerInternalsForTest() {
+  const tempScriptsDir = mkdtempSync(path.join(tmpdir(), "api-reviewers-module-"));
+  const source = readFileSync(COMPANION, "utf8");
+  const footer = `try {
+  await main();
+} catch (e) {
+  printJson({ ok: false, error: e.message });
+  process.exit(1);
+}
+`;
+  assert.match(source, /async function readUtf8ScopeFileWithinLimit/);
+  assert.match(source, /try \{\n  await main\(\);/);
+  const testSource = source.replace(footer, "export { readUtf8ScopeFileWithinLimit, sameFileIdentity };\n");
+  assert.notEqual(testSource, source);
+  cpSync(path.join(REPO_ROOT, "plugins/api-reviewers/scripts/lib"), path.join(tempScriptsDir, "lib"), { recursive: true });
+  const modulePath = path.join(tempScriptsDir, "api-reviewer.mjs");
+  writeFileSync(modulePath, testSource);
+  try {
+    return await import(pathToFileURL(modulePath).href);
+  } finally {
+    rmSync(tempScriptsDir, { recursive: true, force: true });
+  }
 }
 
 function makeWorkspace() {
@@ -1848,6 +1872,21 @@ test("scope file reads open canonical paths after symlink boundary check", () =>
   assert.match(source, /if \(e\?\.code === "ENOENT"\) return null;/);
   assert.match(source, /const text = await readUtf8ScopeFileWithinLimit\(realAbs, normalizedRel, beforeOpen\);/);
   assert.doesNotMatch(source, /readUtf8ScopeFileWithinLimit\(abs, normalizedRel\)/);
+});
+
+test("scope file reads reject stale file identity after secure open", async () => {
+  const cwd = makeWorkspace();
+  const first = path.join(cwd, "first.txt");
+  const second = path.join(cwd, "second.txt");
+  writeFileSync(first, "first file\n");
+  writeFileSync(second, "second file\n");
+  const beforeOpen = lstatSync(first);
+  const { readUtf8ScopeFileWithinLimit } = await importApiReviewerInternalsForTest();
+
+  await assert.rejects(
+    () => readUtf8ScopeFileWithinLimit(second, "first.txt", beforeOpen),
+    /unsafe_scope_path:first\.txt: file changed before secure open/,
+  );
 });
 
 test("custom-review rejects oversized scope files before provider delivery", async () => {

--- a/tests/smoke/grok-web.smoke.test.mjs
+++ b/tests/smoke/grok-web.smoke.test.mjs
@@ -109,6 +109,18 @@ function rmTree(dir) {
   rmSync(dir, { recursive: true, force: true });
 }
 
+function makeEmptyBranchDiffWorkspace() {
+  const cwd = realpathSync(mkdtempSync(path.join(tmpdir(), "grok-web-empty-branch-diff-")));
+  writeFileSync(path.join(cwd, "review.js"), "export const value = 1;\n");
+  execFileSync("git", ["init", "-b", "main"], { cwd, stdio: "ignore" });
+  execFileSync("git", ["config", "user.email", "test@example.com"], { cwd });
+  execFileSync("git", ["config", "user.name", "Test User"], { cwd });
+  execFileSync("git", ["add", "review.js"], { cwd });
+  execFileSync("git", ["commit", "-m", "base"], { cwd, stdio: "ignore" });
+  execFileSync("git", ["checkout", "-b", "feature"], { cwd, stdio: "ignore" });
+  return cwd;
+}
+
 async function withServer(handler, fn) {
   const server = http.createServer(handler);
   server.listen(0, "127.0.0.1");
@@ -342,8 +354,41 @@ test("custom-review rejects invalid GROK_WEB_TIMEOUT_MS env", () => {
     const parsed = parseStdout(result);
 
     assert.equal(result.status, 1);
+    assert.deepEqual(Object.keys(parsed), [...GROK_EXPECTED_KEYS]);
+    assert.equal(parsed.status, "failed");
     assert.equal(parsed.error_code, "bad_args");
     assert.match(parsed.error_message, /GROK_WEB_TIMEOUT_MS must be a positive integer number of milliseconds/);
+    assert.equal(parsed.external_review.source_content_transmission, "not_sent");
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("custom-review rejects invalid GROK_WEB_MAX_PROMPT_CHARS env", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "grok-web-invalid-prompt-budget-cwd-"));
+  try {
+    writeFileSync(path.join(cwd, "review.js"), "export const value = 42;\n");
+    const result = run([
+      "run",
+      "--mode", "custom-review",
+      "--scope", "custom",
+      "--scope-paths", "review.js",
+      "--foreground",
+      "--prompt", "Check this file.",
+    ], {
+      cwd,
+      env: {
+        GROK_WEB_MAX_PROMPT_CHARS: "not-a-number",
+      },
+    });
+    const parsed = parseStdout(result);
+
+    assert.equal(result.status, 1);
+    assert.deepEqual(Object.keys(parsed), [...GROK_EXPECTED_KEYS]);
+    assert.equal(parsed.status, "failed");
+    assert.equal(parsed.error_code, "bad_args");
+    assert.match(parsed.error_message, /GROK_WEB_MAX_PROMPT_CHARS must be a positive integer character count/);
+    assert.equal(parsed.external_review.source_content_transmission, "not_sent");
   } finally {
     rmSync(cwd, { recursive: true, force: true });
   }
@@ -899,6 +944,102 @@ test("custom-review rejects aggregate selected source that exceeds the prompt ca
   assert.match(record.error_message, /scope_total_too_large/);
   assert.equal(record.external_review.source_content_transmission, "not_sent");
   assert.match(record.external_review.disclosure, /not sent/i);
+});
+
+test("branch-diff with no changed files explains recovery before contacting the tunnel", async () => {
+  const cwd = makeEmptyBranchDiffWorkspace();
+  const result = await runAsync([
+    "run",
+    "--mode", "adversarial-review",
+    "--scope", "branch-diff",
+    "--scope-base", "main",
+    "--foreground",
+    "--lifecycle-events", "jsonl",
+    "--prompt", "Review this branch.",
+  ], {
+    cwd,
+    env: { GROK_WEB_BASE_URL: "http://127.0.0.1:9/api" },
+  });
+  const lines = parseJsonLines(result);
+  assert.equal(result.status, 1);
+  assert.equal(lines.length, 1);
+  const [record] = lines;
+  assert.equal(record.status, "failed");
+  assert.equal(record.error_code, "scope_failed");
+  assert.match(record.error_message, /scope_empty: branch-diff selected no files/);
+  assert.match(record.suggested_action, /different --scope-base/);
+  assert.match(record.suggested_action, /--scope-base HEAD~1/);
+  assert.match(record.suggested_action, /custom-review/);
+  assert.equal(record.external_review.source_content_transmission, "not_sent");
+  assert.match(record.external_review.disclosure, /not sent/i);
+  assert.doesNotMatch(result.stdout, /external_review_launched/);
+});
+
+test("branch-diff rejects option-shaped scope-base before contacting the tunnel", async () => {
+  const cwd = makeEmptyBranchDiffWorkspace();
+  try {
+    const result = await runAsync([
+      "run",
+      "--mode", "adversarial-review",
+      "--scope", "branch-diff",
+      "--scope-base", "--definitely-not-a-real-ref",
+      "--foreground",
+      "--lifecycle-events", "jsonl",
+      "--prompt", "Review this branch.",
+    ], {
+      cwd,
+      env: { GROK_WEB_BASE_URL: "http://127.0.0.1:9/api" },
+    });
+    const lines = parseJsonLines(result);
+    assert.equal(result.status, 1);
+    assert.equal(lines.length, 1);
+    const [record] = lines;
+    assert.equal(record.status, "failed");
+    assert.equal(record.error_code, "scope_failed");
+    assert.match(record.error_message, /scope_base_invalid/);
+    assert.match(record.suggested_action, /option-shaped values/);
+    assert.equal(record.external_review.source_content_transmission, "not_sent");
+    assert.match(record.external_review.disclosure, /not sent/i);
+    assert.doesNotMatch(result.stdout, /external_review_launched/);
+    assert.doesNotMatch(result.stdout, /invalid option/);
+  } finally {
+    rmTree(cwd);
+  }
+});
+
+test("rendered prompt over Grok budget fails before contacting the tunnel", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "grok-web-workspace-"));
+  writeFileSync(path.join(cwd, "review.js"), "export const value = 42;\n");
+
+  const result = run([
+    "run",
+    "--mode", "custom-review",
+    "--scope", "custom",
+    "--scope-paths", "review.js",
+    "--foreground",
+    "--lifecycle-events", "jsonl",
+    "--prompt", "Check this file.",
+  ], {
+    cwd,
+    env: {
+      GROK_WEB_BASE_URL: "http://127.0.0.1:9/api",
+      GROK_WEB_MAX_PROMPT_CHARS: "100",
+    },
+  });
+  const lines = parseJsonLines(result);
+  assert.equal(result.status, 1);
+  assert.equal(lines.length, 1);
+  const [record] = lines;
+  assert.equal(record.status, "failed");
+  assert.equal(record.error_code, "scope_failed");
+  assert.match(record.error_message, /prompt_too_large:/);
+  assert.match(record.suggested_action, /narrower scope|split/i);
+  assert.match(record.review_metadata.audit_manifest.rendered_prompt_hash.value, /^[a-f0-9]{64}$/);
+  assert.equal(record.review_metadata.audit_manifest.selected_source.files.length, 1);
+  assert.equal(JSON.stringify(record.review_metadata.audit_manifest).includes("Check this file"), false);
+  assert.equal(JSON.stringify(record.review_metadata.audit_manifest).includes("export const value"), false);
+  assert.equal(record.external_review.source_content_transmission, "not_sent");
+  assert.doesNotMatch(result.stdout, /external_review_launched/);
 });
 
 test("concurrent Grok runs preserve every completed job in the state index", async () => {
@@ -1690,10 +1831,13 @@ test("scope file reads use canonical real paths after symlink boundary check", (
   // and must read through the bounded file-handle helper instead of unbounded readFile().
   const source = readFileSync(COMPANION, "utf8");
   assert.match(source, /const SCOPE_FILE_OPEN_FLAGS = fsConstants\.O_RDONLY \| \(fsConstants\.O_NOFOLLOW \?\? 0\);/);
-  assert.match(source, /const handle = await open\(filePath, SCOPE_FILE_OPEN_FLAGS\);/);
+  assert.match(source, /handle = await open\(filePath, SCOPE_FILE_OPEN_FLAGS\);/);
   assert.match(source, /const info = await handle\.stat\(\);/);
+  assert.match(source, /if \(!sameFileIdentity\(beforeOpen, info\)\)/);
+  assert.match(source, /beforeOpen = await lstat\(abs\);/);
+  assert.match(source, /if \(beforeOpen\.isSymbolicLink\(\)\)/);
   assert.match(source, /const \{ bytesRead \} = await handle\.read\(buffer, 0, buffer\.length, null\);/);
-  assert.match(source, /const text = await readUtf8ScopeFileWithinLimit\(realAbs, normalizedRel\);/);
+  assert.match(source, /const text = await readUtf8ScopeFileWithinLimit\(realAbs, normalizedRel, beforeOpen\);/);
   assert.doesNotMatch(source, /const text = await readFile\(realAbs, "utf8"\);/);
 });
 
@@ -1919,6 +2063,33 @@ test("custom-review rejects unsafe scope paths before contacting the tunnel", ()
     "--mode", "custom-review",
     "--scope", "custom",
     "--scope-paths", "../review.js",
+    "--foreground",
+    "--prompt", "Check this file.",
+  ], {
+    cwd,
+    env: {
+      GROK_WEB_BASE_URL: "http://127.0.0.1:9/api",
+      GROK_WEB_TUNNEL_API_KEY: "secret-cookie-like-token",
+    },
+  });
+  const record = parseStdout(result);
+
+  assert.equal(result.status, 1);
+  assert.equal(record.status, "failed");
+  assert.equal(record.error_code, "scope_failed");
+  assert.match(record.error_message, /unsafe_scope_path/);
+  assert.equal(record.external_review.source_content_transmission, "not_sent");
+});
+
+test("custom-review rejects control characters in scope paths before contacting the tunnel", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "grok-web-workspace-"));
+  writeFileSync(path.join(cwd, "review.js"), "export const value = 42;\n");
+
+  const result = run([
+    "run",
+    "--mode", "custom-review",
+    "--scope", "custom",
+    "--scope-paths", "review.js\tother.js",
     "--foreground",
     "--prompt", "Check this file.",
   ], {

--- a/tests/smoke/grok-web.smoke.test.mjs
+++ b/tests/smoke/grok-web.smoke.test.mjs
@@ -1,10 +1,10 @@
 import { once } from "node:events";
 import { execFileSync, spawn, spawnSync } from "node:child_process";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, utimesSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, utimesSync, writeFileSync } from "node:fs";
 import http from "node:http";
 import { hostname, tmpdir } from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { externalReviewLaunchedEvent } from "../../scripts/lib/companion-common.mjs";
@@ -1839,6 +1839,21 @@ test("scope file reads use canonical real paths after symlink boundary check", (
   assert.match(source, /const \{ bytesRead \} = await handle\.read\(buffer, 0, buffer\.length, null\);/);
   assert.match(source, /const text = await readUtf8ScopeFileWithinLimit\(realAbs, normalizedRel, beforeOpen\);/);
   assert.doesNotMatch(source, /const text = await readFile\(realAbs, "utf8"\);/);
+});
+
+test("scope file reads reject stale file identity after secure open", async () => {
+  const cwd = realpathSync(mkdtempSync(path.join(tmpdir(), "grok-web-workspace-")));
+  const first = path.join(cwd, "first.txt");
+  const second = path.join(cwd, "second.txt");
+  writeFileSync(first, "first file\n");
+  writeFileSync(second, "second file\n");
+  const beforeOpen = lstatSync(first);
+  const { readUtf8ScopeFileWithinLimit } = await import(pathToFileURL(COMPANION).href);
+
+  await assert.rejects(
+    () => readUtf8ScopeFileWithinLimit(second, "first.txt", beforeOpen),
+    /unsafe_scope_path:first\.txt: file changed before secure open/,
+  );
 });
 
 test("tunnel invocation catch is separated from prompt construction catch", () => {

--- a/tests/unit/job-record.test.mjs
+++ b/tests/unit/job-record.test.mjs
@@ -695,8 +695,20 @@ test("buildJobRecord: scope_base_missing provides targeted diagnostic", () => {
   }, []);
   assert.equal(rec.status, "failed");
   assert.equal(rec.error_code, "scope_failed");
-  assert.match(rec.error_cause, /unresolvable git ref/);
+  assert.match(rec.error_cause, /unresolvable git base ref/);
   assert.match(rec.suggested_action, /choose a valid base ref/);
+});
+
+test("buildJobRecord: scope_base_invalid remains a pre-launch scope failure", () => {
+  const rec = buildJobRecord(makeInvocation(), {
+    exitCode: null, parsed: null, pidInfo: null, claudeSessionId: null,
+    errorMessage: "scope_base_invalid: base ref \"--bad\" is not safe for git branch-diff",
+  }, []);
+  assert.equal(rec.status, "failed");
+  assert.equal(rec.error_code, "scope_failed");
+  assert.match(rec.error_cause, /unsafe/);
+  assert.match(rec.suggested_action, /Option-shaped values/);
+  assert.equal(rec.external_review.source_content_transmission, "not_sent");
 });
 
 test("buildJobRecord: scope_requires_git provides targeted diagnostic", () => {
@@ -744,6 +756,9 @@ test("buildJobRecord: scope_empty provides targeted diagnostic", () => {
   assert.equal(rec.error_code, "scope_failed");
   assert.match(rec.error_cause, /empty/i);
   assert.match(rec.suggested_action, /custom-review|--scope-paths/);
+  assert.match(rec.suggested_action, /different --scope-base/);
+  assert.match(rec.suggested_action, /--scope-base HEAD~1/);
+  assert.doesNotMatch(rec.suggested_action, /--scope head/);
 });
 
 test("buildJobRecord: invalid_profile provides targeted diagnostic", () => {
@@ -1234,6 +1249,34 @@ test("gemini buildJobRecord: scope_base_missing carries targeted base-ref diagno
   assert.match(rec.disclosure_note, /external provider/);
 });
 
+test("gemini buildJobRecord: scope_base_invalid remains a pre-launch scope failure", () => {
+  const rec = buildGeminiJobRecord(makeInvocation({ target: "gemini", binary: "gemini" }), {
+    exitCode: null, parsed: null, pidInfo: null, geminiSessionId: null,
+    errorMessage: "scope_base_invalid: base ref \"--bad\" is not safe for git branch-diff",
+  }, []);
+  assert.equal(rec.status, "failed");
+  assert.equal(rec.error_code, "scope_failed");
+  assert.match(rec.error_cause, /unsafe/);
+  assert.match(rec.suggested_action, /Option-shaped values/);
+  assert.equal(rec.external_review.source_content_transmission, "not_sent");
+});
+
+test("kimi buildJobRecord: scope_base_invalid remains a pre-launch scope failure", () => {
+  const rec = buildKimiJobRecord(makeInvocation({
+    target: "kimi",
+    binary: "kimi",
+    review_prompt_provider: "Kimi",
+  }), {
+    exitCode: null, parsed: null, pidInfo: null, kimiSessionId: null,
+    errorMessage: "scope_base_invalid: base ref \"--bad\" is not safe for git branch-diff",
+  }, []);
+  assert.equal(rec.status, "failed");
+  assert.equal(rec.error_code, "scope_failed");
+  assert.match(rec.error_cause, /unsafe/);
+  assert.match(rec.suggested_action, /Option-shaped values/);
+  assert.equal(rec.external_review.source_content_transmission, "not_sent");
+});
+
 test("gemini buildJobRecord: scope_requires_git carries git-worktree diagnostic", () => {
   const rec = buildGeminiJobRecord(makeInvocation({ target: "gemini", binary: "gemini" }), {
     exitCode: null, parsed: null, pidInfo: null, geminiSessionId: null,
@@ -1279,7 +1322,21 @@ test("gemini buildJobRecord: scope_empty carries empty-scope diagnostic", () => 
   assert.equal(rec.error_code, "scope_failed");
   assert.match(rec.error_cause, /empty/i);
   assert.match(rec.suggested_action, /--scope-paths/);
+  assert.match(rec.suggested_action, /--scope-base HEAD~1/);
+  assert.doesNotMatch(rec.suggested_action, /--scope head/);
   assert.match(rec.disclosure_note, /external provider/);
+});
+
+test("kimi buildJobRecord: scope_empty carries HEAD~1 recovery diagnostic", () => {
+  const rec = buildKimiJobRecord(makeInvocation({ target: "kimi", binary: "kimi" }), {
+    exitCode: null, parsed: null, pidInfo: null, kimiSessionId: null,
+    errorMessage: "scope_empty: branch-diff selected no files under /tmp/review-bundle",
+  }, []);
+  assert.equal(rec.status, "failed");
+  assert.equal(rec.error_code, "scope_failed");
+  assert.match(rec.error_cause, /empty/i);
+  assert.match(rec.suggested_action, /--scope-base HEAD~1/);
+  assert.doesNotMatch(rec.suggested_action, /--scope head/);
 });
 
 test("gemini buildJobRecord: invalid_profile carries plugin-bug diagnostic, raw error preserved", () => {

--- a/tests/unit/scope.test.mjs
+++ b/tests/unit/scope.test.mjs
@@ -2154,6 +2154,23 @@ test("populateScope scope=branch-diff: throws scope_base_missing when base ref i
   }
 });
 
+test("populateScope scope=branch-diff: rejects option-shaped base refs before git diff", () => {
+  const src = seedRepo();
+  const tgt = mkTarget();
+  try {
+    writeFileSync(path.join(src, "A.txt"), "a\n");
+    git(src, "add", ".");
+    git(src, "commit", "-qm", "seed");
+
+    assert.throws(
+      () => populateScope(profile("branch-diff"), src, tgt, { scopeBase: "--definitely-not-a-real-ref" }),
+      /scope_base_invalid/,
+    );
+  } finally {
+    cleanup(src, tgt);
+  }
+});
+
 test("populateScope scope=branch-diff: throws scope_base_missing when base has no merge-base with HEAD", () => {
   const src = seedRepo();
   const tgt = mkTarget();


### PR DESCRIPTION
Addresses #83.

## Summary
- prevent empty branch-diff reviews from launching provider/tunnel jobs and give explicit recovery choices
- add rendered prompt budget preflight for Grok Web and direct API reviewers before source transmission
- keep privacy-safe audit manifests for over-budget rendered prompts without storing prompt/source text

## Root-cause handling
- Grok HTTP 400 after source send: preflight now rejects rendered prompts over GROK_WEB_MAX_PROMPT_CHARS before tunnel launch.
- Direct API oversized prompts: DeepSeek/GLM now have max_prompt_chars defaults plus API_REVIEWERS_MAX_PROMPT_CHARS override before provider launch.
- Empty/no-diff branch reviews: branch-diff scope_empty now stops before launch and points to a different --scope-base, --scope-base HEAD~1 for last-commit review, or explicit custom-review scope paths.

## Verification
- git diff --check
- npm run lint:sync
- node --test tests/unit/job-record.test.mjs tests/smoke/api-reviewers.smoke.test.mjs tests/smoke/grok-web.smoke.test.mjs
- node --test tests/smoke/api-reviewers.smoke.test.mjs tests/smoke/grok-web.smoke.test.mjs
- npm test