### PR TITLE
Restore pre-PR94 state

### DIFF
--- a/plugins/claude/scripts/claude-companion.mjs
+++ b/plugins/claude/scripts/claude-companion.mjs
@@ -1302,7 +1302,7 @@ async function cmdPing(rest) {
     process.exit(2);
   }
   // Classify. Real Claude error texts change per version; match on signals only.
-  if (execution.parsed?.ok && (execution.parsed?.result || execution.parsed?.structured)) {
+  if (execution.parsed.ok && (execution.parsed.result || execution.parsed.structured)) {
     // T7.4: drop the legacy `.sessionId` alias. Ping uses claudeSessionId
     // (Claude's echo) with sessionIdSent fallback when the mock short-circuits.
     const payload = { status: "ok", ...pingOkFields(), ...authDiagnosticFields(authSelection), model: model ?? null,
@@ -1329,7 +1329,7 @@ async function cmdPing(rest) {
     process.exit(2);
   }
   printJson({ status: "error", ...pingErrorFields(), ...authDiagnosticFields(authSelection),
-    detail: "parsed result missing", raw: execution.parsed?.raw ?? null });
+    detail: "parsed result missing", raw: execution.parsed.raw });
   process.exit(2);
 }
 

--- a/plugins/claude/scripts/lib/process.mjs
+++ b/plugins/claude/scripts/lib/process.mjs
@@ -8,8 +8,6 @@ export function runCommand(command, args = [], options = {}) {
     encoding: "utf8",
     input: options.input,
     maxBuffer: options.maxBuffer,
-    timeout: options.timeout,
-    killSignal: options.killSignal,
     stdio: options.stdio ?? "pipe",
     shell: process.platform === "win32" ? (process.env.SHELL || true) : false,
     windowsHide: true

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -1258,9 +1258,9 @@ async function cmdPing(rest) {
       }
       break;
     }
-    if (execution.parsed?.ok) {
+    if (execution.parsed.ok) {
       const payload = { status: "ok", ...pingOkFields(modelFallback), ...authDiagnosticFields(authSelection), model: selectedModel ?? null,
-        session_id: execution.geminiSessionId, usage: execution.parsed?.usage };
+        session_id: execution.geminiSessionId, usage: execution.parsed.usage };
       printJson(payload);
       process.exit(0);
     }

--- a/plugins/gemini/scripts/lib/process.mjs
+++ b/plugins/gemini/scripts/lib/process.mjs
@@ -8,8 +8,6 @@ export function runCommand(command, args = [], options = {}) {
     encoding: "utf8",
     input: options.input,
     maxBuffer: options.maxBuffer,
-    timeout: options.timeout,
-    killSignal: options.killSignal,
     stdio: options.stdio ?? "pipe",
     shell: process.platform === "win32" ? (process.env.SHELL || true) : false,
     windowsHide: true

--- a/plugins/kimi/scripts/kimi-companion.mjs
+++ b/plugins/kimi/scripts/kimi-companion.mjs
@@ -1278,9 +1278,9 @@ async function cmdPing(rest) {
       }
       break;
     }
-    if (execution.parsed?.ok) {
+    if (execution.parsed.ok) {
       const payload = { status: "ok", ...pingOkFields(modelFallback), ...ignoredApiKeyAuthFields(), model: selectedModel ?? null,
-        session_id: execution.kimiSessionId, usage: execution.parsed?.usage };
+        session_id: execution.kimiSessionId, usage: execution.parsed.usage };
       printJson(payload);
       process.exit(0);
     }

--- a/plugins/kimi/scripts/lib/process.mjs
+++ b/plugins/kimi/scripts/lib/process.mjs
@@ -8,8 +8,6 @@ export function runCommand(command, args = [], options = {}) {
     encoding: "utf8",
     input: options.input,
     maxBuffer: options.maxBuffer,
-    timeout: options.timeout,
-    killSignal: options.killSignal,
     stdio: options.stdio ?? "pipe",
     shell: process.platform === "win32" ? (process.env.SHELL || true) : false,
     windowsHide: true

--- a/scripts/ci/sync-external-review.mjs
+++ b/scripts/ci/sync-external-review.mjs
@@ -12,7 +12,6 @@ const COPIES = [
     path.join(REPO_ROOT, `plugins/${plugin}/scripts/lib/external-review.mjs`)
   ),
   path.join(REPO_ROOT, "plugins/api-reviewers/scripts/lib/external-review.mjs"),
-  path.join(REPO_ROOT, "plugins/grok/scripts/lib/external-review.mjs"),
 ];
 
 const checkOnly = process.argv.includes("--check");

--- a/tests/smoke/claude-companion.smoke.test.mjs
+++ b/tests/smoke/claude-companion.smoke.test.mjs
@@ -1712,29 +1712,6 @@ process.exit(7);
   }
 });
 
-test("ping: malformed successful stdout reports parsed result missing without crashing", () => {
-  const tmp = mkdtempSync(path.join(tmpdir(), "claude-ping-malformed-ok-"));
-  const binary = writeExecutable(tmp, "claude-malformed-ok", `#!/usr/bin/env node
-process.stdout.write("not json\\n");
-process.exit(0);
-`);
-  const { stdout, status, dataDir } = runCompanion(
-    ["ping", "--model", "claude-haiku-4-5-20251001"],
-    { cwd: tmpdir(), env: { CLAUDE_BINARY: binary } },
-  );
-  try {
-    assert.equal(status, 2);
-    const result = JSON.parse(stdout);
-    assert.equal(result.status, "error");
-    assert.equal(result.ready, false);
-    assert.equal(result.detail, "parsed result missing");
-    assert.match(JSON.stringify(result.raw), /json_parse_error|not json/);
-  } finally {
-    cleanup(dataDir);
-    rmSync(tmp, { recursive: true, force: true });
-  }
-});
-
 test("status: empty workspace returns empty jobs list", () => {
   const cwd = mkdtempSync(path.join(tmpdir(), "smoke-status-"));
   const { stdout, status, dataDir } = runCompanion(["status", "--cwd", cwd], { cwd });

--- a/tests/unit/ci-workflow.test.mjs
+++ b/tests/unit/ci-workflow.test.mjs
@@ -8,7 +8,6 @@ const pkg = JSON.parse(readFileSync(resolve("package.json"), "utf8"));
 const workflow = readFileSync(resolve(".github/workflows/pull-request-ci.yml"), "utf8");
 const e2eDocs = readFileSync(resolve("docs/e2e.md"), "utf8");
 const sonarConfig = readFileSync(resolve(".sonarcloud.properties"), "utf8");
-const syncExternalReview = readFileSync(resolve("scripts/ci/sync-external-review.mjs"), "utf8");
 
 test("package scripts expose per-target smoke commands", () => {
   assert.match(pkg.scripts["smoke:claude"] ?? "", /claude-companion\.smoke\.test\.mjs/);
@@ -38,10 +37,6 @@ test("pull-request CI runs shared-copy sync checks", () => {
   assert.match(pkg.scripts["lint:sync"] ?? "", /sync-auth-selection\.mjs --check/);
   assert.match(pkg.scripts["lint:sync"] ?? "", /sync-provider-env\.mjs --check/);
   assert.match(workflow, /npm run lint:sync/);
-});
-
-test("external-review sync script includes the Grok packaged copy", () => {
-  assert.match(syncExternalReview, /plugins\/grok\/scripts\/lib\/external-review\.mjs/);
 });
 
 test("pull-request CI runs the enforced coverage gate", () => {

--- a/tests/unit/process.test.mjs
+++ b/tests/unit/process.test.mjs
@@ -25,17 +25,6 @@ test("runCommand: captures stdout, stderr, status, and command metadata", () => 
   assert.equal(result.error, null);
 });
 
-test("runCommand: supports bounded spawnSync timeouts", () => {
-  const result = runCommand(process.execPath, ["-e", "setTimeout(() => {}, 1000)"], {
-    timeout: 25,
-    killSignal: "SIGTERM",
-  });
-
-  assert.equal(result.status, 0);
-  assert.equal(result.signal, "SIGTERM");
-  assert.equal(result.error?.code, "ETIMEDOUT");
-});
-
 test("runCommandChecked: returns successful result and throws formatted failures", () => {
   const ok = runCommandChecked(process.execPath, ["-e", "process.stdout.write('ok')"]);
   assert.equal(ok.stdout, "ok");


### PR DESCRIPTION
## Summary

This PR restores the repository content to the exact state before PR #94 was merged.

This is a cleanup PR for a process failure, not a product feature PR.

## Why This Exists

PR #94, "Classify Claude OAuth inference rejection", was merged into `main` as merge commit `27cd2d2565ffdc9fb1e58cc9a2ab6e7b7ce252c1`. That merge should not have happened because it did not have the required user approval and did not have the required latest-head external approval state.

PR #100, "Revert Claude OAuth inference rejection merge", was then opened to revert PR #94. The mechanical revert was commit `f1a1bee24c71dc055a5d90d31c3f2225e81a8617`, which reverted PR #94's squash merge commit.

However, PR #100 then accumulated two additional follow-up commits:

- `d4a5d8c6875087722bcd8026b491b3e60e946c06` - `fix: address revert review findings`
- `82f14c880d0eeadf3b619caae37db47e241c51a8` - `fix: address PR100 review blockers`

Those two commits were review-fix/collateral hardening added inside the revert PR. They were not required for the mechanical revert of PR #94, and they were not part of the intended clean rollback state.

The desired cleanup state is: make the repository content look exactly as it did before PR #94 merged. That means removing the remaining content effects of PR #94 and the two PR #100 follow-up commits.

## Baseline Restored

- Pre-PR #94 baseline: `7f775882e156843e251560e9b5e81dcf45112e90`
- Current `main` before this branch: `10208a39c1505bc4af386e8952138ac70e9c888e`
- Restore commit on this PR: `b0dc548279d798ae3d22e24a18f87d9ef1d15634`

This PR does not rewrite Git history. It opens a normal PR on top of current `main` whose resulting tree matches the pre-PR #94 baseline.

## Scope

This PR restores the 10 files that still differed from the pre-PR #94 baseline after PR #100 was merged:

- `plugins/claude/scripts/claude-companion.mjs`
- `plugins/claude/scripts/lib/process.mjs`
- `plugins/gemini/scripts/gemini-companion.mjs`
- `plugins/gemini/scripts/lib/process.mjs`
- `plugins/kimi/scripts/kimi-companion.mjs`
- `plugins/kimi/scripts/lib/process.mjs`
- `scripts/ci/sync-external-review.mjs`
- `tests/smoke/claude-companion.smoke.test.mjs`
- `tests/unit/ci-workflow.test.mjs`
- `tests/unit/process.test.mjs`

## Verification

- `git diff --name-only 7f775882e156843e251560e9b5e81dcf45112e90 HEAD` -> empty output
- `git diff --check` -> pass
- pre-commit `npm test` -> 1016 tests, 1010 pass, 0 fail, 6 skipped

## Issue Impact

Issue #93 remains open after this restore. That is intentional: this PR returns the repository to the pre-PR #94 state, so the PR #94 fix for #93 is not present after this cleanup.
