### PR TITLE
Restore Claude OAuth inference readiness fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ lets Claude Code delegate to Codex.
 
 - Codex with plugin marketplace support.
 - Git and Node.js available on `PATH`.
-- Claude Code installed and authenticated if you enable the Claude plugin.
+- Claude Code installed and OAuth-authenticated if you enable the Claude plugin.
+  `claude auth status` alone is not enough for review readiness; `/claude-setup`
+  also verifies OAuth-only non-interactive `claude -p` inference because status
+  can report logged-in while print-mode inference returns HTTP 401.
 - Gemini CLI installed and authenticated if you enable the Gemini plugin.
 - Kimi Code CLI installed and authenticated if you enable the Kimi plugin.
 - A local Grok web tunnel if you enable the Grok plugin. The default endpoint
@@ -280,7 +283,7 @@ command docs:
 
 | Command | Status | Behavior |
 |---|---|---|
-| `/claude-setup` / `/gemini-setup` / `/kimi-setup` | Packaged | Target CLI availability and OAuth readiness check. |
+| `/claude-setup` / `/gemini-setup` / `/kimi-setup` | Packaged | Target CLI availability and OAuth readiness check. Claude setup includes an OAuth-only non-interactive inference probe, not just `claude auth status`. |
 | `/deepseek-setup` / `/glm-setup` | Packaged | Direct API-key readiness check; reports key names only. |
 | `/grok-setup` | Packaged | Grok subscription-backed local tunnel readiness check; probes `/v1/models` by default and reports key names only. |
 | `/claude-review [focus]` / `/gemini-review [focus]` / `/kimi-review [focus]` | Packaged | Read-only review profile over the selected scope. |

--- a/plugins/api-reviewers/scripts/lib/external-review.mjs
+++ b/plugins/api-reviewers/scripts/lib/external-review.mjs
@@ -37,6 +37,7 @@ const CONTENT_RECEIVED_ERROR_CODES = Object.freeze(new Set([
   "gemini_error",
   "kimi_error",
   "parse_error",
+  "oauth_inference_rejected",
   "step_limit_exceeded",
   "usage_limited",
   "finalization_failed",
@@ -57,6 +58,7 @@ const NOT_SENT_DISCLOSURE_BY_STATUS = Object.freeze({
 const NOT_SENT_DISCLOSURE_BY_ERROR = Object.freeze({
   scope_failed: (provider) => `Selected source content was not sent to ${provider}; the review scope was rejected before the target process was started.`,
   spawn_failed: (provider) => `Selected source content was not sent to ${provider}; the target process was not spawned.`,
+  oauth_inference_rejected: (provider) => `Selected source content was not sent to ${provider}; OAuth inference readiness was rejected before the review target was started.`,
 });
 
 const UNKNOWN_DISCLOSURE_BY_STATUS = Object.freeze({
@@ -107,6 +109,9 @@ export function sourceContentTransmissionForExecution({ status, errorCode, pidIn
     return SOURCE_CONTENT_TRANSMISSION.UNKNOWN;
   }
   if (errorCode === "scope_failed" || errorCode === "spawn_failed") {
+    return SOURCE_CONTENT_TRANSMISSION.NOT_SENT;
+  }
+  if (errorCode === "oauth_inference_rejected" && !pidInfo) {
     return SOURCE_CONTENT_TRANSMISSION.NOT_SENT;
   }
   if (status === "cancelled") {

--- a/plugins/api-reviewers/scripts/lib/review-prompt.mjs
+++ b/plugins/api-reviewers/scripts/lib/review-prompt.mjs
@@ -236,6 +236,7 @@ export function buildReviewAuditManifest({
       scope_paths: Array.isArray(scope.paths) ? Object.freeze([...scope.paths]) : null,
       reason: scope.reason ?? null,
     }),
+    error_code: errorCode,
     review_quality: qualityFlags({ result, status, errorCode }),
   });
 }

--- a/plugins/api-reviewers/scripts/lib/review-prompt.mjs
+++ b/plugins/api-reviewers/scripts/lib/review-prompt.mjs
@@ -159,7 +159,7 @@ function qualityFlags({ result = "", status = null, errorCode = null } = {}) {
     ]),
     checklist_items_seen: checklistItemsSeen,
     looks_shallow: text.trim().length > 0 && text.trim().length < 500,
-    failed_review_slot: status !== "completed" || errorCode !== null,
+    failed_review_slot: status !== "preflight_failed" && (status !== "completed" || errorCode !== null),
   });
 }
 

--- a/plugins/claude/commands/claude-setup.md
+++ b/plugins/claude/commands/claude-setup.md
@@ -14,6 +14,9 @@ Setup readiness check for the Claude plugin.
    - Always show `summary`.
    - If `ready: true`, report that Claude Code is ready.
    - If `ready: false`, show `next_action` exactly.
+   - If `status: "oauth_inference_rejected"`, explain that OAuth status is
+     present but non-interactive `claude -p` inference failed; this is a failed
+     review slot, not a model verdict.
    - If `ignored_env_credentials` is present, explain that those env vars were intentionally ignored by plugin policy; never print values.
 3. Print a smoke-test hint: ask Codex to use the Claude delegation skill for a
    read-only review.
@@ -21,5 +24,7 @@ Setup readiness check for the Claude plugin.
 ## Guardrails
 
 - Never read or write `ANTHROPIC_API_KEY` or any `*_API_KEY` env var.
+- Never treat API-key fallback as a valid setup result for subscription/OAuth
+  review readiness unless the user explicitly asked for API-key mode.
 - Never persist credentials.
 - Never auto-install or auto-update Claude Code.

--- a/plugins/claude/scripts/claude-companion.mjs
+++ b/plugins/claude/scripts/claude-companion.mjs
@@ -914,8 +914,17 @@ async function claudeOAuthInferencePreflight(invocation, authSelection) {
       timeoutMs: Math.min(Number(invocation.timeout_ms ?? 15000), 15000),
       allowedApiKeyEnv: authSelection.allowed_env_credentials,
     });
-  } catch {
-    return null;
+  } catch (e) {
+    return {
+      preflight: true,
+      exitCode: null,
+      parsed: null,
+      pidInfo: null,
+      claudeSessionId: null,
+      stdout: "",
+      stderr: "",
+      errorMessage: e.message,
+    };
   }
   if (execution.parsed?.ok === true) return null;
   const detail = pingFailureDetail(execution);
@@ -969,6 +978,7 @@ function buildClaudeFinalRecord(invocation, execution, cancelMarker, mutations, 
     parsed: execution.parsed,
     pidInfo: execution.pidInfo,
     claudeSessionId: execution.claudeSessionId ?? null,
+    errorMessage: execution.errorMessage,
     ...(cancelMarker ? { status: "cancelled" } : {}),
     signal: execution.signal ?? null,
     timedOut: execution.timedOut === true,
@@ -1380,7 +1390,7 @@ function isClaudeAuthStatusObject(value) {
 
 function parseJsonObjectOutput(stdout, acceptsObject = () => true) {
   const text = String(stdout ?? "").trim();
-  if (!text) return {};
+  if (!text) throw new Error("no_json_object");
   try {
     const parsed = JSON.parse(text);
     if (acceptsObject(parsed)) return parsed;

--- a/plugins/claude/scripts/claude-companion.mjs
+++ b/plugins/claude/scripts/claude-companion.mjs
@@ -713,8 +713,9 @@ async function executeRun(invocation, prompt, { foreground, lifecycleEvents = nu
       executionScope.addDir,
       runtimeDiagnostics,
     );
-    commitJobRecord(workspaceRoot, jobId, finalRecord);
+    const { metaError, stateError } = commitJobRecord(workspaceRoot, jobId, finalRecord);
     writeExecutionSidecars(workspaceRoot, jobId, oauthPreflightExecution);
+    exitIfFinalizationFailed(invocation, oauthPreflightExecution, finalRecord, mutationContext, executionScope, { metaError, stateError });
     cleanupExecutionResources(executionScope, mutationContext);
     if (foreground) printLifecycleJson(finalRecord, lifecycleEvents);
     process.exit(2);
@@ -895,7 +896,7 @@ async function claudeOAuthInferencePreflight(invocation, authSelection) {
   if (execution.parsed?.ok === true) return null;
   const detail = pingFailureDetail(execution);
   if (!PING_AUTH_RE.test(detail)) return null;
-  const oauthStatus = safeClaudeOAuthStatus(invocation.binary, authSelection);
+  const oauthStatus = safeClaudeOAuthStatus(invocation.binary, authSelection, invocation.cwd);
   if (oauthStatus?.logged_in !== true || !/401|invalid authentication credentials/i.test(detail)) return null;
   return {
     ...execution,
@@ -1308,11 +1309,11 @@ function oauthInferenceRejectedFields() {
   };
 }
 
-function safeClaudeOAuthStatus(binary, authSelection) {
+function safeClaudeOAuthStatus(binary, authSelection, cwd = process.cwd()) {
   if (authSelection.selected_auth_path !== "subscription_oauth") return null;
   const env = sanitizeTargetEnv(process.env, { allowedApiKeyEnv: authSelection.allowed_env_credentials });
   const result = runCommand(binary, ["auth", "status", "--json"], {
-    cwd: process.cwd(),
+    cwd,
     env,
     maxBuffer: 1024 * 1024,
     timeout: CLAUDE_AUTH_STATUS_TIMEOUT_MS,

--- a/plugins/claude/scripts/claude-companion.mjs
+++ b/plugins/claude/scripts/claude-companion.mjs
@@ -40,7 +40,7 @@ import { resolveProfile, resolveModelForProfile } from "./lib/mode-profiles.mjs"
 import { setupContainment } from "./lib/containment.mjs";
 import { populateScope } from "./lib/scope.mjs";
 import { newJobId, verifyPidInfo } from "./lib/identity.mjs";
-import { buildJobRecord, externalReviewForInvocation } from "./lib/job-record.mjs";
+import { buildJobRecord, externalReviewForInvocation, isOAuthInferenceRejected } from "./lib/job-record.mjs";
 import { reconcileActiveJobs } from "./lib/reconcile.mjs";
 import { cleanGitEnv } from "./lib/git-env.mjs";
 import { sanitizeTargetEnv } from "./lib/provider-env.mjs";
@@ -213,9 +213,11 @@ function scopeResolutionReason(invocation) {
 function reviewAuditManifest(invocation, prompt, containmentPath, execution) {
   if (!invocation.review_prompt_contract_version || invocation.mode_profile_name === "rescue") return null;
   const meta = promptMetadata(invocation);
-  const errorCode = String(execution?.errorMessage ?? "").startsWith("oauth_inference_rejected:")
-    ? "oauth_inference_rejected"
-    : (execution?.parsed?.reason ?? null);
+  let errorCode = execution?.parsed?.reason ?? null;
+  if (String(execution?.errorMessage ?? "").startsWith("oauth_inference_rejected:")
+      || isOAuthInferenceRejected(execution, invocation)) {
+    errorCode = "oauth_inference_rejected";
+  }
   return buildReviewAuditManifest({
     prompt,
     sourceFiles: auditSourceFiles(containmentPath),
@@ -895,9 +897,9 @@ async function claudeOAuthInferencePreflight(invocation, authSelection) {
   }
   if (execution.parsed?.ok === true) return null;
   const detail = pingFailureDetail(execution);
-  if (!PING_AUTH_RE.test(detail)) return null;
+  if (!isOAuthInferenceRejected(execution, invocation)) return null;
   const oauthStatus = safeClaudeOAuthStatus(invocation.binary, authSelection, invocation.cwd);
-  if (oauthStatus?.logged_in !== true || !/401|invalid authentication credentials/i.test(detail)) return null;
+  if (oauthStatus?.logged_in !== true) return null;
   return {
     ...execution,
     pidInfo: null,
@@ -1349,13 +1351,46 @@ function parseJsonObjectOutput(stdout) {
   try {
     return JSON.parse(text);
   } catch {
-    const start = text.indexOf("{");
-    const end = text.lastIndexOf("}");
-    if (start >= 0 && end >= start) {
-      return JSON.parse(text.slice(start, end + 1));
-    }
+    const parsed = parseFirstBalancedJsonObject(text);
+    if (parsed !== null) return parsed;
     throw new Error("no_json_object");
   }
+}
+
+function parseFirstBalancedJsonObject(text) {
+  for (let start = text.indexOf("{"); start >= 0; start = text.indexOf("{", start + 1)) {
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+    for (let index = start; index < text.length; index += 1) {
+      const char = text[index];
+      if (inString) {
+        if (escaped) {
+          escaped = false;
+        } else if (char === "\\") {
+          escaped = true;
+        } else if (char === "\"") {
+          inString = false;
+        }
+        continue;
+      }
+      if (char === "\"") {
+        inString = true;
+      } else if (char === "{") {
+        depth += 1;
+      } else if (char === "}") {
+        depth -= 1;
+        if (depth === 0) {
+          try {
+            return JSON.parse(text.slice(start, index + 1));
+          } catch {
+            break;
+          }
+        }
+      }
+    }
+  }
+  return null;
 }
 
 function pingFailureDetail(execution) {
@@ -1438,17 +1473,20 @@ async function cmdPing(rest) {
       printJson({ status: "rate_limited", ...pingRateLimitedFields(), ...authDiagnosticFields(authSelection), detail });
       process.exit(2);
     }
+    const oauthStatus = isOAuthInferenceRejected(execution, authSelection)
+      ? safeClaudeOAuthStatus(binary, authSelection)
+      : null;
+    if (oauthStatus?.logged_in === true) {
+      printJson({ status: "oauth_inference_rejected", ...oauthInferenceRejectedFields(), detail,
+        ...authDiagnosticFields(authSelection),
+        oauth_status: oauthStatus });
+      process.exit(2);
+    }
     if (PING_AUTH_RE.test(detail)) {
-      const oauthStatus = safeClaudeOAuthStatus(binary, authSelection);
-      if (oauthStatus?.logged_in === true && /401|invalid authentication credentials/i.test(detail)) {
-        printJson({ status: "oauth_inference_rejected", ...oauthInferenceRejectedFields(), detail,
-          ...authDiagnosticFields(authSelection),
-          oauth_status: oauthStatus });
-        process.exit(2);
-      }
+      const authStatus = oauthStatus ?? safeClaudeOAuthStatus(binary, authSelection);
       printJson({ status: "not_authed", ...pingNotAuthedFields(), detail,
         ...authDiagnosticFields(authSelection),
-        ...(oauthStatus ? { oauth_status: oauthStatus } : {}),
+        ...(authStatus ? { oauth_status: authStatus } : {}),
         hint: authSelection.selected_auth_path === "api_key_env"
           ? "Claude was launched with explicit API-key auth. Check the provider key and CLI support."
           : "Run `claude` interactively to complete OAuth. API-key env vars are ignored by subscription-mode policy." });

--- a/plugins/claude/scripts/claude-companion.mjs
+++ b/plugins/claude/scripts/claude-companion.mjs
@@ -915,6 +915,7 @@ async function claudeOAuthInferencePreflight(invocation, authSelection) {
       allowedApiKeyEnv: authSelection.allowed_env_credentials,
     });
   } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
     return {
       preflight: true,
       exitCode: null,
@@ -923,7 +924,7 @@ async function claudeOAuthInferencePreflight(invocation, authSelection) {
       claudeSessionId: null,
       stdout: "",
       stderr: "",
-      errorMessage: e.message,
+      errorMessage: message,
     };
   }
   if (execution.parsed?.ok === true) return null;
@@ -1346,6 +1347,8 @@ function oauthInferenceRejectedFields() {
 function safeClaudeOAuthStatus(binary, authSelection, cwd = process.cwd()) {
   if (authSelection.selected_auth_path !== "subscription_oauth") return null;
   const env = sanitizeTargetEnv(process.env, { allowedApiKeyEnv: authSelection.allowed_env_credentials });
+  // Keep cwd tied to the invocation so explicit relative binaries resolve the
+  // same way as the review run; this metadata query does not receive source.
   const result = runCommand(binary, ["auth", "status", "--json"], {
     cwd,
     env,
@@ -1382,10 +1385,18 @@ function claudeAuthStatusErrorDetail(error) {
 }
 
 function isClaudeAuthStatusObject(value) {
-  return value !== null &&
-    typeof value === "object" &&
-    !Array.isArray(value) &&
-    ("loggedIn" in value || "authMethod" in value || "apiProvider" in value || "subscriptionType" in value);
+  return claudeAuthStatusObjectScore(value) > 0;
+}
+
+function claudeAuthStatusObjectScore(value) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return 0;
+  const hasLoggedIn = Object.hasOwn(value, "loggedIn");
+  const statusFieldCount = ["authMethod", "apiProvider", "subscriptionType"]
+    .filter((field) => Object.hasOwn(value, field)).length;
+  if (!hasLoggedIn && statusFieldCount === 0) return 0;
+  if (value.loggedIn === true) return 10 + statusFieldCount;
+  if (hasLoggedIn && statusFieldCount > 0) return 5 + statusFieldCount;
+  return statusFieldCount;
 }
 
 function parseJsonObjectOutput(stdout, acceptsObject = () => true) {
@@ -1393,21 +1404,38 @@ function parseJsonObjectOutput(stdout, acceptsObject = () => true) {
   if (!text) throw new Error("no_json_object");
   try {
     const parsed = JSON.parse(text);
-    if (acceptsObject(parsed)) return parsed;
+    if (acceptsObject(parsed) ||
+        (acceptsObject === isClaudeAuthStatusObject && isClaudeLoggedInObject(parsed))) return parsed;
   } catch {
     // Fall through to balanced-object scanning below.
   }
-  const parsed = parseFirstBalancedJsonObject(text, acceptsObject);
+  const parsed = parseFirstBalancedJsonObject(text, acceptsObject,
+    acceptsObject === isClaudeAuthStatusObject ? claudeAuthStatusObjectScore : null);
   if (parsed !== null) return parsed;
   throw new Error("no_json_object");
 }
 
-function parseFirstBalancedJsonObject(text, acceptsObject = () => true) {
+function isClaudeLoggedInObject(value) {
+  return value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Object.hasOwn(value, "loggedIn");
+}
+
+function parseFirstBalancedJsonObject(text, acceptsObject = () => true, scoreObject = null) {
+  let best = null;
+  let bestScore = -Infinity;
   for (let start = text.indexOf("{"); start >= 0; start = text.indexOf("{", start + 1)) {
     const parsed = parseBalancedJsonCandidate(text, start);
-    if (parsed !== null && acceptsObject(parsed)) return parsed;
+    if (parsed === null || !acceptsObject(parsed)) continue;
+    if (!scoreObject) return parsed;
+    const score = scoreObject(parsed);
+    if (score > bestScore) {
+      best = parsed;
+      bestScore = score;
+    }
   }
-  return null;
+  return best;
 }
 
 function parseBalancedJsonCandidate(text, start) {

--- a/plugins/claude/scripts/claude-companion.mjs
+++ b/plugins/claude/scripts/claude-companion.mjs
@@ -43,6 +43,8 @@ import { newJobId, verifyPidInfo } from "./lib/identity.mjs";
 import { buildJobRecord, externalReviewForInvocation } from "./lib/job-record.mjs";
 import { reconcileActiveJobs } from "./lib/reconcile.mjs";
 import { cleanGitEnv } from "./lib/git-env.mjs";
+import { sanitizeTargetEnv } from "./lib/provider-env.mjs";
+import { runCommand } from "./lib/process.mjs";
 import {
   authDiagnosticFields,
   apiKeyMissingFields as buildApiKeyMissingFields,
@@ -78,6 +80,7 @@ configureState({
 
 const MODELS_CONFIG_PATH = resolvePath(PLUGIN_ROOT, "config/models.json");
 const DEFAULT_CLAUDE_REVIEW_TIMEOUT_MS = 600000;
+const CLAUDE_AUTH_STATUS_TIMEOUT_MS = 10000;
 const CONTINUABLE_STATUSES = new Set(["completed", "failed", "cancelled", "stale"]);
 const RUN_MODES = Object.freeze(["review", "adversarial-review", "custom-review", "rescue"]);
 const PREFLIGHT_MODES = Object.freeze(["review", "adversarial-review", "custom-review"]);
@@ -243,7 +246,9 @@ function reviewAuditManifest(invocation, prompt, containmentPath, execution) {
       reason: scopeResolutionReason(invocation),
     },
     result: execution?.parsed?.result ?? "",
-    status: execution?.exitCode === 0 && execution?.parsed?.ok === true ? "completed" : "failed",
+    status: execution?.preflight === true
+      ? "preflight_failed"
+      : (execution?.exitCode === 0 && execution?.parsed?.ok === true ? "completed" : "failed"),
     errorCode: execution?.parsed?.reason ?? null,
   });
 }
@@ -677,8 +682,14 @@ async function cmdRun(rest) {
 // prompt; background worker calls it after reading the prompt sidecar.
 // EXACTLY ONE buildJobRecord call per terminal state — §21.3.2 convergence.
 async function executeRun(invocation, prompt, { foreground, lifecycleEvents = null }) {
+  const authSelection = resolveAuthSelection(invocation.auth_mode);
+  invocation = Object.freeze({
+    ...invocation,
+    selected_auth_path: authSelection.selected_auth_path,
+  });
   const { job_id: jobId, workspace_root: workspaceRoot } = invocation;
   const profile = resolveProfile(invocation.mode_profile_name);
+
   const executionScope = setupExecutionScopeOrExit(invocation, profile, { foreground, lifecycleEvents });
   const mutationContext = prepareMutationContext(invocation, profile);
   const runtimeDiagnostics = buildRuntimeDiagnostics(
@@ -687,6 +698,24 @@ async function executeRun(invocation, prompt, { foreground, lifecycleEvents = nu
     mutationContext.neutralCwd ?? executionScope.childCwd,
   );
   const resumeId = latestResumeId(invocation);
+
+  const oauthPreflightExecution = await claudeOAuthInferencePreflight(invocation, authSelection);
+  if (oauthPreflightExecution) {
+    const finalRecord = buildClaudeFinalRecord(
+      invocation,
+      oauthPreflightExecution,
+      null,
+      mutationContext.mutations,
+      prompt,
+      executionScope.addDir,
+      runtimeDiagnostics,
+    );
+    commitJobRecord(workspaceRoot, jobId, finalRecord);
+    writeExecutionSidecars(workspaceRoot, jobId, oauthPreflightExecution);
+    cleanupExecutionResources(executionScope, mutationContext);
+    if (foreground) printLifecycleJson(finalRecord, lifecycleEvents);
+    process.exit(2);
+  }
 
   exitIfCancelledBeforeSpawn(invocation, executionScope, mutationContext, {
     foreground,
@@ -841,6 +870,37 @@ async function spawnClaudeOrExit(invocation, profile, prompt, executionScope, mu
     if (options.foreground) printLifecycleJson(errorRecord, options.lifecycleEvents);
     process.exit(2);
   }
+}
+
+async function claudeOAuthInferencePreflight(invocation, authSelection) {
+  if (authSelection.selected_auth_path !== "subscription_oauth") return null;
+  const profile = resolveProfile("ping");
+  let execution;
+  try {
+    execution = await spawnClaude(profile, {
+      model: invocation.model,
+      promptText: PING_PROMPT,
+      sessionId: newJobId(),
+      cwd: invocation.cwd,
+      binary: invocation.binary,
+      timeoutMs: Math.min(Number(invocation.timeout_ms ?? 15000), 15000),
+      allowedApiKeyEnv: authSelection.allowed_env_credentials,
+    });
+  } catch {
+    return null;
+  }
+  if (execution.parsed?.ok === true) return null;
+  const detail = pingFailureDetail(execution);
+  if (!PING_AUTH_RE.test(detail)) return null;
+  const oauthStatus = safeClaudeOAuthStatus(invocation.binary, authSelection);
+  if (oauthStatus?.logged_in !== true || !/401|invalid authentication credentials/i.test(detail)) return null;
+  return {
+    ...execution,
+    pidInfo: null,
+    claudeSessionId: null,
+    preflight: true,
+    errorMessage: `oauth_inference_rejected: ${detail}`,
+  };
 }
 
 function writeRunningRecord(invocation, pidInfo, mutations, runtimeDiagnostics = null) {
@@ -1237,6 +1297,62 @@ function pingErrorFields() {
   };
 }
 
+function oauthInferenceRejectedFields() {
+  return {
+    ready: false,
+    summary: "Claude Code OAuth login is present, but OAuth non-interactive inference is rejected.",
+    next_action: "Refresh Claude OAuth in a normal terminal with `claude auth login`, then verify OAuth-only `claude -p` inference works.",
+  };
+}
+
+function safeClaudeOAuthStatus(binary, authSelection) {
+  if (authSelection.selected_auth_path !== "subscription_oauth") return null;
+  const env = sanitizeTargetEnv(process.env, { allowedApiKeyEnv: authSelection.allowed_env_credentials });
+  const result = runCommand(binary, ["auth", "status", "--json"], {
+    cwd: process.cwd(),
+    env,
+    maxBuffer: 1024 * 1024,
+    timeout: CLAUDE_AUTH_STATUS_TIMEOUT_MS,
+  });
+  if (result.error) {
+    const detail = result.error.code === "ENOENT"
+      ? "not_found"
+      : (result.error.code === "ETIMEDOUT" ? "timeout" : "error");
+    return { checked: true, available: false, detail };
+  }
+  if (result.status !== 0) {
+    return { checked: true, available: false, detail: "status_failed" };
+  }
+  try {
+    const parsed = parseJsonObjectOutput(result.stdout);
+    return {
+      checked: true,
+      available: true,
+      logged_in: parsed.loggedIn === true,
+      auth_method: typeof parsed.authMethod === "string" ? parsed.authMethod : null,
+      api_provider: typeof parsed.apiProvider === "string" ? parsed.apiProvider : null,
+      subscription_type: typeof parsed.subscriptionType === "string" ? parsed.subscriptionType : null,
+    };
+  } catch {
+    return { checked: true, available: false, detail: "status_parse_failed" };
+  }
+}
+
+function parseJsonObjectOutput(stdout) {
+  const text = String(stdout ?? "").trim();
+  if (!text) return {};
+  try {
+    return JSON.parse(text);
+  } catch {
+    const start = text.indexOf("{");
+    const end = text.lastIndexOf("}");
+    if (start >= 0 && end >= start) {
+      return JSON.parse(text.slice(start, end + 1));
+    }
+    throw new Error("no_json_object");
+  }
+}
+
 function pingFailureDetail(execution) {
   const raw = execution?.parsed?.raw;
   const rawText = typeof raw === "string"
@@ -1302,7 +1418,7 @@ async function cmdPing(rest) {
     process.exit(2);
   }
   // Classify. Real Claude error texts change per version; match on signals only.
-  if (execution.parsed.ok && (execution.parsed.result || execution.parsed.structured)) {
+  if (execution.parsed?.ok === true) {
     // T7.4: drop the legacy `.sessionId` alias. Ping uses claudeSessionId
     // (Claude's echo) with sessionIdSent fallback when the mock short-circuits.
     const payload = { status: "ok", ...pingOkFields(), ...authDiagnosticFields(authSelection), model: model ?? null,
@@ -1318,8 +1434,16 @@ async function cmdPing(rest) {
       process.exit(2);
     }
     if (PING_AUTH_RE.test(detail)) {
+      const oauthStatus = safeClaudeOAuthStatus(binary, authSelection);
+      if (oauthStatus?.logged_in === true && /401|invalid authentication credentials/i.test(detail)) {
+        printJson({ status: "oauth_inference_rejected", ...oauthInferenceRejectedFields(), detail,
+          ...authDiagnosticFields(authSelection),
+          oauth_status: oauthStatus });
+        process.exit(2);
+      }
       printJson({ status: "not_authed", ...pingNotAuthedFields(), detail,
         ...authDiagnosticFields(authSelection),
+        ...(oauthStatus ? { oauth_status: oauthStatus } : {}),
         hint: authSelection.selected_auth_path === "api_key_env"
           ? "Claude was launched with explicit API-key auth. Check the provider key and CLI support."
           : "Run `claude` interactively to complete OAuth. API-key env vars are ignored by subscription-mode policy." });

--- a/plugins/claude/scripts/claude-companion.mjs
+++ b/plugins/claude/scripts/claude-companion.mjs
@@ -87,6 +87,20 @@ const PREFLIGHT_MODES = Object.freeze(["review", "adversarial-review", "custom-r
 const GIT_PROMPT_BINARY = "/usr/bin/git";
 const GIT_PROMPT_SAFE_PATH = "/usr/bin:/bin";
 
+function isExplicitRelativeBinary(binary) {
+  return binary === "." ||
+    binary === ".." ||
+    binary.startsWith("./") ||
+    binary.startsWith("../") ||
+    binary.startsWith(".\\") ||
+    binary.startsWith("..\\");
+}
+
+function resolveCliBinary(cwd, binary) {
+  if (!isExplicitRelativeBinary(binary)) return binary;
+  return resolvePath(cwd, binary);
+}
+
 function loadModels() {
   if (!existsSync(MODELS_CONFIG_PATH)) return { review_quality: null, rescue: null };
   return JSON.parse(_readFileSync(MODELS_CONFIG_PATH, "utf8"));
@@ -888,7 +902,7 @@ async function claudeOAuthInferencePreflight(invocation, authSelection) {
       promptText: PING_PROMPT,
       sessionId: newJobId(),
       cwd: tmpdir(),
-      binary: resolvePath(invocation.cwd, invocation.binary),
+      binary: resolveCliBinary(invocation.cwd, invocation.binary),
       timeoutMs: Math.min(Number(invocation.timeout_ms ?? 15000), 15000),
       allowedApiKeyEnv: authSelection.allowed_env_credentials,
     });
@@ -1492,7 +1506,8 @@ async function cmdPing(rest) {
   });
   const profile = resolveProfile("ping");
   const model = options.model ?? resolveModelForProfile(profile, loadModels());
-  const binary = resolvePath(process.cwd(), options.binary ?? process.env.CLAUDE_BINARY ?? "claude");
+  const rawBinary = options.binary ?? process.env.CLAUDE_BINARY ?? "claude";
+  const binary = resolveCliBinary(process.cwd(), rawBinary);
   const timeoutMs = Number(options["timeout-ms"] ?? 15000);
   const authSelection = resolveAuthSelection(options["auth-mode"]);
   if (authSelection.selected_auth_path === "api_key_env_missing") {

--- a/plugins/claude/scripts/claude-companion.mjs
+++ b/plugins/claude/scripts/claude-companion.mjs
@@ -93,12 +93,20 @@ function isExplicitRelativeBinary(binary) {
     binary.startsWith("./") ||
     binary.startsWith("../") ||
     binary.startsWith(".\\") ||
-    binary.startsWith("..\\");
+    binary.startsWith("..\\") ||
+    (!isAbsolute(binary) && (binary.includes("/") || binary.includes("\\")));
 }
 
 function resolveCliBinary(cwd, binary) {
   if (!isExplicitRelativeBinary(binary)) return binary;
   return resolvePath(cwd, binary);
+}
+
+function authSelectionClassifierContext(authSelection) {
+  return {
+    auth_mode: authSelection.auth_mode,
+    selected_auth_path: authSelection.selected_auth_path,
+  };
 }
 
 function loadModels() {
@@ -1342,7 +1350,7 @@ function safeClaudeOAuthStatus(binary, authSelection, cwd = process.cwd()) {
     return { checked: true, available: false, detail: "status_failed" };
   }
   try {
-    const parsed = parseJsonObjectOutput(result.stdout);
+    const parsed = parseJsonObjectOutput(result.stdout, isClaudeAuthStatusObject);
     // Explicit allowlist: do not add user, email, org, or account fields here.
     return {
       checked: true,
@@ -1363,22 +1371,31 @@ function claudeAuthStatusErrorDetail(error) {
   return "error";
 }
 
-function parseJsonObjectOutput(stdout) {
+function isClaudeAuthStatusObject(value) {
+  return value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    ("loggedIn" in value || "authMethod" in value || "apiProvider" in value || "subscriptionType" in value);
+}
+
+function parseJsonObjectOutput(stdout, acceptsObject = () => true) {
   const text = String(stdout ?? "").trim();
   if (!text) return {};
   try {
-    return JSON.parse(text);
+    const parsed = JSON.parse(text);
+    if (acceptsObject(parsed)) return parsed;
   } catch {
-    const parsed = parseFirstBalancedJsonObject(text);
-    if (parsed !== null) return parsed;
-    throw new Error("no_json_object");
+    // Fall through to balanced-object scanning below.
   }
+  const parsed = parseFirstBalancedJsonObject(text, acceptsObject);
+  if (parsed !== null) return parsed;
+  throw new Error("no_json_object");
 }
 
-function parseFirstBalancedJsonObject(text) {
+function parseFirstBalancedJsonObject(text, acceptsObject = () => true) {
   for (let start = text.indexOf("{"); start >= 0; start = text.indexOf("{", start + 1)) {
     const parsed = parseBalancedJsonCandidate(text, start);
-    if (parsed !== null) return parsed;
+    if (parsed !== null && acceptsObject(parsed)) return parsed;
   }
   return null;
 }
@@ -1484,7 +1501,7 @@ function printPingExecutionFailure(execution, authSelection, binary) {
     printJson({ status: "rate_limited", ...pingRateLimitedFields(), ...authDiagnosticFields(authSelection), detail });
     process.exit(2);
   }
-  const oauthStatus = isOAuthInferenceRejected(execution, authSelection)
+  const oauthStatus = isOAuthInferenceRejected(execution, authSelectionClassifierContext(authSelection))
     ? safeClaudeOAuthStatus(binary, authSelection)
     : null;
   if (oauthStatus?.logged_in === true) {
@@ -1534,12 +1551,14 @@ async function cmdPing(rest) {
   // Classify. Real Claude error texts change per version; match on signals only.
   if (execution.parsed?.ok === true) {
     printPingSuccess(execution, authSelection, model);
+    return;
   }
   if (execution.exitCode !== 0) {
     printPingExecutionFailure(execution, authSelection, binary);
+    return;
   }
   printJson({ status: "error", ...pingErrorFields(), ...authDiagnosticFields(authSelection),
-    detail: "parsed result missing", raw: execution.parsed.raw });
+    detail: "parsed result missing", raw: execution.parsed?.raw });
   process.exit(2);
 }
 

--- a/plugins/claude/scripts/claude-companion.mjs
+++ b/plugins/claude/scripts/claude-companion.mjs
@@ -210,6 +210,12 @@ function scopeResolutionReason(invocation) {
   return invocation.scope ?? null;
 }
 
+function reviewAuditStatus(execution) {
+  if (execution?.preflight === true) return "preflight_failed";
+  if (execution?.exitCode === 0 && execution?.parsed?.ok === true) return "completed";
+  return "failed";
+}
+
 function reviewAuditManifest(invocation, prompt, containmentPath, execution) {
   if (!invocation.review_prompt_contract_version || invocation.mode_profile_name === "rescue") return null;
   const meta = promptMetadata(invocation);
@@ -247,9 +253,7 @@ function reviewAuditManifest(invocation, prompt, containmentPath, execution) {
       reason: scopeResolutionReason(invocation),
     },
     result: execution?.parsed?.result ?? "",
-    status: execution?.preflight === true
-      ? "preflight_failed"
-      : (execution?.exitCode === 0 && execution?.parsed?.ok === true ? "completed" : "failed"),
+    status: reviewAuditStatus(execution),
     errorCode,
   });
 }
@@ -1317,9 +1321,7 @@ function safeClaudeOAuthStatus(binary, authSelection, cwd = process.cwd()) {
     timeout: CLAUDE_AUTH_STATUS_TIMEOUT_MS,
   });
   if (result.error) {
-    const detail = result.error.code === "ENOENT"
-      ? "not_found"
-      : (result.error.code === "ETIMEDOUT" ? "timeout" : "error");
+    const detail = claudeAuthStatusErrorDetail(result.error);
     return { checked: true, available: false, detail };
   }
   if (result.status !== 0) {
@@ -1341,6 +1343,12 @@ function safeClaudeOAuthStatus(binary, authSelection, cwd = process.cwd()) {
   }
 }
 
+function claudeAuthStatusErrorDetail(error) {
+  if (error.code === "ENOENT") return "not_found";
+  if (error.code === "ETIMEDOUT") return "timeout";
+  return "error";
+}
+
 function parseJsonObjectOutput(stdout) {
   const text = String(stdout ?? "").trim();
   if (!text) return {};
@@ -1355,38 +1363,49 @@ function parseJsonObjectOutput(stdout) {
 
 function parseFirstBalancedJsonObject(text) {
   for (let start = text.indexOf("{"); start >= 0; start = text.indexOf("{", start + 1)) {
-    let depth = 0;
-    let inString = false;
-    let escaped = false;
-    for (let index = start; index < text.length; index += 1) {
-      const char = text[index];
-      if (inString) {
-        if (escaped) {
-          escaped = false;
-        } else if (char === "\\") {
-          escaped = true;
-        } else if (char === "\"") {
-          inString = false;
-        }
-        continue;
-      }
-      if (char === "\"") {
-        inString = true;
-      } else if (char === "{") {
-        depth += 1;
-      } else if (char === "}") {
-        depth -= 1;
-        if (depth === 0) {
-          try {
-            return JSON.parse(text.slice(start, index + 1));
-          } catch {
-            break;
-          }
-        }
-      }
-    }
+    const parsed = parseBalancedJsonCandidate(text, start);
+    if (parsed !== null) return parsed;
   }
   return null;
+}
+
+function parseBalancedJsonCandidate(text, start) {
+  const state = { depth: 0, inString: false, escaped: false };
+  for (let index = start; index < text.length; index += 1) {
+    updateJsonScanState(state, text[index]);
+    if (state.depth === 0) return parseJsonSlice(text, start, index + 1);
+  }
+  return null;
+}
+
+function updateJsonScanState(state, char) {
+  if (state.inString) {
+    updateJsonStringState(state, char);
+    return;
+  }
+  if (char === "\"") state.inString = true;
+  if (char === "{") state.depth += 1;
+  if (char === "}") state.depth -= 1;
+}
+
+function updateJsonStringState(state, char) {
+  if (state.escaped) {
+    state.escaped = false;
+    return;
+  }
+  if (char === "\\") {
+    state.escaped = true;
+    return;
+  }
+  if (char === "\"") state.inString = false;
+}
+
+function parseJsonSlice(text, start, end) {
+  try {
+    return JSON.parse(text.slice(start, end));
+  } catch {
+    return null;
+  }
 }
 
 function pingFailureDetail(execution) {
@@ -1411,6 +1430,58 @@ function pingFailureDetail(execution) {
     .some((line) => line.trimStart().startsWith("at "));
   const concise = hasStackFrame && firstLine ? firstLine : detail;
   return concise.slice(0, 500);
+}
+
+function printPingSpawnError(error, authSelection) {
+  if (error.code === "ENOENT") {
+    printJson({ status: "not_found", ...pingNotFoundFields(),
+      ...authDiagnosticFields(authSelection),
+      detail: `claude binary not found on PATH (or CLAUDE_BINARY override)`,
+      install_url: "https://claude.com/claude-code" });
+    process.exit(2);
+  }
+  printJson({ status: "error", ...pingErrorFields(), ...authDiagnosticFields(authSelection), detail: error.message });
+  process.exit(2);
+}
+
+function printPingSuccess(execution, authSelection, model) {
+  // T7.4: drop the legacy `.sessionId` alias. Ping uses claudeSessionId
+  // (Claude's echo) with sessionIdSent fallback when the mock short-circuits.
+  const payload = { status: "ok", ...pingOkFields(), ...authDiagnosticFields(authSelection), model: model ?? null,
+    session_id: execution.claudeSessionId ?? execution.sessionIdSent,
+    cost_usd: execution.parsed.costUsd, usage: execution.parsed.usage };
+  printJson(payload);
+  process.exit(0);
+}
+
+function printPingNotAuthed(detail, authSelection, authStatus) {
+  printJson({ status: "not_authed", ...pingNotAuthedFields(), detail,
+    ...authDiagnosticFields(authSelection),
+    ...(authStatus ? { oauth_status: authStatus } : {}),
+    hint: authSelection.selected_auth_path === "api_key_env"
+      ? "Claude was launched with explicit API-key auth. Check the provider key and CLI support."
+      : "Run `claude` interactively to complete OAuth. API-key env vars are ignored by subscription-mode policy." });
+  process.exit(2);
+}
+
+function printPingExecutionFailure(execution, authSelection, binary) {
+  const detail = pingFailureDetail(execution);
+  if (/rate limit|429|overloaded/i.test(detail)) {
+    printJson({ status: "rate_limited", ...pingRateLimitedFields(), ...authDiagnosticFields(authSelection), detail });
+    process.exit(2);
+  }
+  const oauthStatus = isOAuthInferenceRejected(execution, authSelection)
+    ? safeClaudeOAuthStatus(binary, authSelection)
+    : null;
+  if (oauthStatus?.logged_in === true) {
+    printJson({ status: "oauth_inference_rejected", ...oauthInferenceRejectedFields(), detail,
+      ...authDiagnosticFields(authSelection),
+      oauth_status: oauthStatus });
+    process.exit(2);
+  }
+  if (PING_AUTH_RE.test(detail)) printPingNotAuthed(detail, authSelection, oauthStatus ?? safeClaudeOAuthStatus(binary, authSelection));
+  printJson({ status: "error", ...pingErrorFields(), ...authDiagnosticFields(authSelection), exit_code: execution.exitCode, detail });
+  process.exit(2);
 }
 
 // ——— subcommand: ping (OAuth health probe per spec §7.5) ———
@@ -1443,53 +1514,14 @@ async function cmdPing(rest) {
       allowedApiKeyEnv: authSelection.allowed_env_credentials,
     });
   } catch (e) {
-    if (e.code === "ENOENT") {
-      printJson({ status: "not_found", ...pingNotFoundFields(),
-        ...authDiagnosticFields(authSelection),
-        detail: `claude binary not found on PATH (or CLAUDE_BINARY override)`,
-        install_url: "https://claude.com/claude-code" });
-      process.exit(2);
-    }
-    printJson({ status: "error", ...pingErrorFields(), ...authDiagnosticFields(authSelection), detail: e.message });
-    process.exit(2);
+    printPingSpawnError(e, authSelection);
   }
   // Classify. Real Claude error texts change per version; match on signals only.
   if (execution.parsed?.ok === true) {
-    // T7.4: drop the legacy `.sessionId` alias. Ping uses claudeSessionId
-    // (Claude's echo) with sessionIdSent fallback when the mock short-circuits.
-    const payload = { status: "ok", ...pingOkFields(), ...authDiagnosticFields(authSelection), model: model ?? null,
-      session_id: execution.claudeSessionId ?? execution.sessionIdSent,
-      cost_usd: execution.parsed.costUsd, usage: execution.parsed.usage };
-    printJson(payload);
-    process.exit(0);
+    printPingSuccess(execution, authSelection, model);
   }
   if (execution.exitCode !== 0) {
-    const detail = pingFailureDetail(execution);
-    if (/rate limit|429|overloaded/i.test(detail)) {
-      printJson({ status: "rate_limited", ...pingRateLimitedFields(), ...authDiagnosticFields(authSelection), detail });
-      process.exit(2);
-    }
-    const oauthStatus = isOAuthInferenceRejected(execution, authSelection)
-      ? safeClaudeOAuthStatus(binary, authSelection)
-      : null;
-    if (oauthStatus?.logged_in === true) {
-      printJson({ status: "oauth_inference_rejected", ...oauthInferenceRejectedFields(), detail,
-        ...authDiagnosticFields(authSelection),
-        oauth_status: oauthStatus });
-      process.exit(2);
-    }
-    if (PING_AUTH_RE.test(detail)) {
-      const authStatus = oauthStatus ?? safeClaudeOAuthStatus(binary, authSelection);
-      printJson({ status: "not_authed", ...pingNotAuthedFields(), detail,
-        ...authDiagnosticFields(authSelection),
-        ...(authStatus ? { oauth_status: authStatus } : {}),
-        hint: authSelection.selected_auth_path === "api_key_env"
-          ? "Claude was launched with explicit API-key auth. Check the provider key and CLI support."
-          : "Run `claude` interactively to complete OAuth. API-key env vars are ignored by subscription-mode policy." });
-      process.exit(2);
-    }
-    printJson({ status: "error", ...pingErrorFields(), ...authDiagnosticFields(authSelection), exit_code: execution.exitCode, detail });
-    process.exit(2);
+    printPingExecutionFailure(execution, authSelection, binary);
   }
   printJson({ status: "error", ...pingErrorFields(), ...authDiagnosticFields(authSelection),
     detail: "parsed result missing", raw: execution.parsed.raw });

--- a/plugins/claude/scripts/claude-companion.mjs
+++ b/plugins/claude/scripts/claude-companion.mjs
@@ -40,7 +40,7 @@ import { resolveProfile, resolveModelForProfile } from "./lib/mode-profiles.mjs"
 import { setupContainment } from "./lib/containment.mjs";
 import { populateScope } from "./lib/scope.mjs";
 import { newJobId, verifyPidInfo } from "./lib/identity.mjs";
-import { buildJobRecord, externalReviewForInvocation, isOAuthInferenceRejected } from "./lib/job-record.mjs";
+import { buildJobRecord, classifyExecution, externalReviewForInvocation, isOAuthInferenceRejected } from "./lib/job-record.mjs";
 import { reconcileActiveJobs } from "./lib/reconcile.mjs";
 import { cleanGitEnv } from "./lib/git-env.mjs";
 import { sanitizeTargetEnv } from "./lib/provider-env.mjs";
@@ -213,11 +213,7 @@ function scopeResolutionReason(invocation) {
 function reviewAuditManifest(invocation, prompt, containmentPath, execution) {
   if (!invocation.review_prompt_contract_version || invocation.mode_profile_name === "rescue") return null;
   const meta = promptMetadata(invocation);
-  let errorCode = execution?.parsed?.reason ?? null;
-  if (String(execution?.errorMessage ?? "").startsWith("oauth_inference_rejected:")
-      || isOAuthInferenceRejected(execution, invocation)) {
-    errorCode = "oauth_inference_rejected";
-  }
+  const { error_code: errorCode } = classifyExecution(execution, invocation);
   return buildReviewAuditManifest({
     prompt,
     sourceFiles: auditSourceFiles(containmentPath),
@@ -887,8 +883,8 @@ async function claudeOAuthInferencePreflight(invocation, authSelection) {
       model: invocation.model,
       promptText: PING_PROMPT,
       sessionId: newJobId(),
-      cwd: invocation.cwd,
-      binary: invocation.binary,
+      cwd: tmpdir(),
+      binary: resolvePath(invocation.cwd, invocation.binary),
       timeoutMs: Math.min(Number(invocation.timeout_ms ?? 15000), 15000),
       allowedApiKeyEnv: authSelection.allowed_env_credentials,
     });
@@ -1425,7 +1421,7 @@ async function cmdPing(rest) {
   });
   const profile = resolveProfile("ping");
   const model = options.model ?? resolveModelForProfile(profile, loadModels());
-  const binary = options.binary ?? process.env.CLAUDE_BINARY ?? "claude";
+  const binary = resolvePath(process.cwd(), options.binary ?? process.env.CLAUDE_BINARY ?? "claude");
   const timeoutMs = Number(options["timeout-ms"] ?? 15000);
   const authSelection = resolveAuthSelection(options["auth-mode"]);
   if (authSelection.selected_auth_path === "api_key_env_missing") {
@@ -1441,7 +1437,7 @@ async function cmdPing(rest) {
       model,
       promptText: PING_PROMPT,
       sessionId,
-      cwd: process.cwd(),
+      cwd: tmpdir(),
       binary,
       timeoutMs,
       allowedApiKeyEnv: authSelection.allowed_env_credentials,

--- a/plugins/claude/scripts/claude-companion.mjs
+++ b/plugins/claude/scripts/claude-companion.mjs
@@ -213,6 +213,9 @@ function scopeResolutionReason(invocation) {
 function reviewAuditManifest(invocation, prompt, containmentPath, execution) {
   if (!invocation.review_prompt_contract_version || invocation.mode_profile_name === "rescue") return null;
   const meta = promptMetadata(invocation);
+  const errorCode = String(execution?.errorMessage ?? "").startsWith("oauth_inference_rejected:")
+    ? "oauth_inference_rejected"
+    : (execution?.parsed?.reason ?? null);
   return buildReviewAuditManifest({
     prompt,
     sourceFiles: auditSourceFiles(containmentPath),
@@ -249,7 +252,7 @@ function reviewAuditManifest(invocation, prompt, containmentPath, execution) {
     status: execution?.preflight === true
       ? "preflight_failed"
       : (execution?.exitCode === 0 && execution?.parsed?.ok === true ? "completed" : "failed"),
-    errorCode: execution?.parsed?.reason ?? null,
+    errorCode,
   });
 }
 
@@ -1325,6 +1328,7 @@ function safeClaudeOAuthStatus(binary, authSelection) {
   }
   try {
     const parsed = parseJsonObjectOutput(result.stdout);
+    // Explicit allowlist: do not add user, email, org, or account fields here.
     return {
       checked: true,
       available: true,

--- a/plugins/claude/scripts/lib/external-review.mjs
+++ b/plugins/claude/scripts/lib/external-review.mjs
@@ -37,6 +37,7 @@ const CONTENT_RECEIVED_ERROR_CODES = Object.freeze(new Set([
   "gemini_error",
   "kimi_error",
   "parse_error",
+  "oauth_inference_rejected",
   "step_limit_exceeded",
   "usage_limited",
   "finalization_failed",
@@ -57,6 +58,7 @@ const NOT_SENT_DISCLOSURE_BY_STATUS = Object.freeze({
 const NOT_SENT_DISCLOSURE_BY_ERROR = Object.freeze({
   scope_failed: (provider) => `Selected source content was not sent to ${provider}; the review scope was rejected before the target process was started.`,
   spawn_failed: (provider) => `Selected source content was not sent to ${provider}; the target process was not spawned.`,
+  oauth_inference_rejected: (provider) => `Selected source content was not sent to ${provider}; OAuth inference readiness was rejected before the review target was started.`,
 });
 
 const UNKNOWN_DISCLOSURE_BY_STATUS = Object.freeze({
@@ -107,6 +109,9 @@ export function sourceContentTransmissionForExecution({ status, errorCode, pidIn
     return SOURCE_CONTENT_TRANSMISSION.UNKNOWN;
   }
   if (errorCode === "scope_failed" || errorCode === "spawn_failed") {
+    return SOURCE_CONTENT_TRANSMISSION.NOT_SENT;
+  }
+  if (errorCode === "oauth_inference_rejected" && !pidInfo) {
     return SOURCE_CONTENT_TRANSMISSION.NOT_SENT;
   }
   if (status === "cancelled") {

--- a/plugins/claude/scripts/lib/job-record.mjs
+++ b/plugins/claude/scripts/lib/job-record.mjs
@@ -163,10 +163,10 @@ const CANCEL_SIGNALS = new Set(["SIGTERM", "SIGKILL", "SIGINT", "SIGHUP"]);
 const FINALIZATION_FAILED_PREFIX = "finalization_failed:";
 const OAUTH_INFERENCE_REJECTED_PREFIX = "oauth_inference_rejected:";
 
-export function isOAuthInferenceRejected(execution, invocation = null) {
-  if (!invocation) return false;
-  if (invocation?.selected_auth_path && invocation.selected_auth_path !== "subscription_oauth") return false;
-  if (!invocation?.selected_auth_path && invocation?.auth_mode === "api_key") return false;
+export function isOAuthInferenceRejected(execution, authContext = null) {
+  if (!authContext) return false;
+  if (authContext?.selected_auth_path && authContext.selected_auth_path !== "subscription_oauth") return false;
+  if (!authContext?.selected_auth_path && authContext?.auth_mode === "api_key") return false;
   const raw = execution?.parsed?.raw;
   const status = raw && typeof raw === "object" ? raw.api_error_status : null;
   const result = String(execution?.parsed?.result ?? "");

--- a/plugins/claude/scripts/lib/job-record.mjs
+++ b/plugins/claude/scripts/lib/job-record.mjs
@@ -173,7 +173,7 @@ export function isOAuthInferenceRejected(execution, invocation = null) {
   return status === 401 && /invalid authentication credentials|failed to authenticate/i.test(result);
 }
 
-export function classifyExecution(execution, invocation = null) {
+function classifyLifecycleState(execution) {
   if (!execution) {
     return {
       status: "queued",
@@ -210,32 +210,68 @@ export function classifyExecution(execution, invocation = null) {
       error_message: execution.errorMessage ?? "stale_active_job",
     };
   }
-  if (execution.errorMessage) {
-    if (String(execution.errorMessage).startsWith(OAUTH_INFERENCE_REJECTED_PREFIX)) {
-      return {
-        status: "failed",
-        error_code: "oauth_inference_rejected",
-        error_message: String(execution.errorMessage).slice(OAUTH_INFERENCE_REJECTED_PREFIX.length).trim(),
-      };
-    }
-    if (isScopeFailure(execution.errorMessage)) {
-      return {
-        status: "failed",
-        error_code: "scope_failed",
-        error_message: execution.errorMessage,
-      };
-    }
-    // Distinguish finalization_failed (post-target persistence failure) from
-    // spawn_failed (target never ran). The companion's executeRun fallback
-    // synthesizes the former with a fixed prefix; everything else is a true
-    // pre-spawn failure. PR #21 review HIGH 1.
-    const isFinalization = String(execution.errorMessage).startsWith(FINALIZATION_FAILED_PREFIX);
+  return null;
+}
+
+function classifyErrorMessage(message) {
+  if (!message) return null;
+  const text = String(message);
+  if (text.startsWith(OAUTH_INFERENCE_REJECTED_PREFIX)) {
     return {
       status: "failed",
-      error_code: isFinalization ? "finalization_failed" : "spawn_failed",
-      error_message: execution.errorMessage,
+      error_code: "oauth_inference_rejected",
+      error_message: text.slice(OAUTH_INFERENCE_REJECTED_PREFIX.length).trim(),
     };
   }
+  if (isScopeFailure(message)) {
+    return {
+      status: "failed",
+      error_code: "scope_failed",
+      error_message: message,
+    };
+  }
+  // Distinguish finalization_failed (post-target persistence failure) from
+  // spawn_failed (target never ran). The companion's executeRun fallback
+  // synthesizes the former with a fixed prefix; everything else is a true
+  // pre-spawn failure. PR #21 review HIGH 1.
+  const isFinalization = text.startsWith(FINALIZATION_FAILED_PREFIX);
+  return {
+    status: "failed",
+    error_code: isFinalization ? "finalization_failed" : "spawn_failed",
+    error_message: message,
+  };
+}
+
+function classifyParsedFailure(execution, invocation, parsed) {
+  const reason = parsed.reason ?? null;
+  if (reason === "json_parse_error" || reason === "empty_stdout") {
+    return {
+      status: "failed",
+      error_code: "parse_error",
+      error_message: parsed.error ?? reason,
+    };
+  }
+  if (isOAuthInferenceRejected(execution, invocation)) {
+    return {
+      status: "failed",
+      error_code: "oauth_inference_rejected",
+      error_message: parsed.result ?? parsed.error ?? null,
+    };
+  }
+  return {
+    status: "failed",
+    error_code: "claude_error",
+    error_message: parsed.error ?? null,
+  };
+}
+
+export function classifyExecution(execution, invocation = null) {
+  const lifecycleState = classifyLifecycleState(execution);
+  if (lifecycleState) return lifecycleState;
+
+  const errorMessageState = classifyErrorMessage(execution.errorMessage);
+  if (errorMessageState) return errorMessageState;
+
   // #16 follow-up 1 / 2: a wall-clock timeout fires SIGTERM too, so check
   // timedOut FIRST. Only signal-driven exits without timedOut are cancels.
   if (execution.timedOut === true) {
@@ -257,26 +293,7 @@ export function classifyExecution(execution, invocation = null) {
     return { status: "completed", error_code: null, error_message: null };
   }
   if (parsed && parsed.ok === false) {
-    const reason = parsed.reason ?? null;
-    if (reason === "json_parse_error" || reason === "empty_stdout") {
-      return {
-        status: "failed",
-        error_code: "parse_error",
-        error_message: parsed.error ?? reason,
-      };
-    }
-    if (isOAuthInferenceRejected(execution, invocation)) {
-      return {
-        status: "failed",
-        error_code: "oauth_inference_rejected",
-        error_message: parsed.result ?? parsed.error ?? null,
-      };
-    }
-    return {
-      status: "failed",
-      error_code: "claude_error",
-      error_message: parsed.error ?? null,
-    };
+    return classifyParsedFailure(execution, invocation, parsed);
   }
   // Non-zero exit with no parsed JSON diagnostic — treat as claude_error.
   return {

--- a/plugins/claude/scripts/lib/job-record.mjs
+++ b/plugins/claude/scripts/lib/job-record.mjs
@@ -163,7 +163,7 @@ const CANCEL_SIGNALS = new Set(["SIGTERM", "SIGKILL", "SIGINT", "SIGHUP"]);
 const FINALIZATION_FAILED_PREFIX = "finalization_failed:";
 const OAUTH_INFERENCE_REJECTED_PREFIX = "oauth_inference_rejected:";
 
-function isOAuthInferenceRejected(execution, invocation = null) {
+export function isOAuthInferenceRejected(execution, invocation = null) {
   if (invocation?.selected_auth_path && invocation.selected_auth_path !== "subscription_oauth") return false;
   if (!invocation?.selected_auth_path && invocation?.auth_mode === "api_key") return false;
   const raw = execution?.parsed?.raw;

--- a/plugins/claude/scripts/lib/job-record.mjs
+++ b/plugins/claude/scripts/lib/job-record.mjs
@@ -113,7 +113,7 @@ function buildReviewMetadata(invocation, execution = null, parsed = null) {
 }
 
 export function externalReviewForInvocation(invocation, execution = null) {
-  const { status, error_code } = classifyExecution(execution);
+  const { status, error_code } = classifyExecution(execution, invocation);
   const sourceContentTransmission = sourceContentTransmissionForExecution({
     status,
     errorCode: error_code,
@@ -149,6 +149,10 @@ export function externalReviewForInvocation(invocation, execution = null) {
  *                         with missing-binary errors. PR #21 review HIGH 1.
  *   parse_error     — parsed.ok === false with reason starting "json_parse"/"empty_stdout".
  *   timeout         — execution.timedOut === true (companion's wall-clock kill).
+ *   oauth_inference_rejected — subscription/OAuth review inference returned
+ *                     HTTP 401 even though CLI auth status may still report
+ *                     logged-in. This must not be hidden as generic
+ *                     claude_error.
  *   claude_error    — exitCode !== 0 with parseable JSON (target's is_error=true).
  *                     Also covers exitCode === 0 but parsed.ok === false with
  *                     is_error semantics.
@@ -157,8 +161,18 @@ export function externalReviewForInvocation(invocation, execution = null) {
  */
 const CANCEL_SIGNALS = new Set(["SIGTERM", "SIGKILL", "SIGINT", "SIGHUP"]);
 const FINALIZATION_FAILED_PREFIX = "finalization_failed:";
+const OAUTH_INFERENCE_REJECTED_PREFIX = "oauth_inference_rejected:";
 
-function classifyExecution(execution) {
+function isOAuthInferenceRejected(execution, invocation = null) {
+  if (invocation?.selected_auth_path && invocation.selected_auth_path !== "subscription_oauth") return false;
+  if (!invocation?.selected_auth_path && invocation?.auth_mode === "api_key") return false;
+  const raw = execution?.parsed?.raw;
+  const status = raw && typeof raw === "object" ? raw.api_error_status : null;
+  const result = String(execution?.parsed?.result ?? "");
+  return status === 401 && /invalid authentication credentials|failed to authenticate/i.test(result);
+}
+
+function classifyExecution(execution, invocation = null) {
   if (!execution) {
     return {
       status: "queued",
@@ -196,6 +210,13 @@ function classifyExecution(execution) {
     };
   }
   if (execution.errorMessage) {
+    if (String(execution.errorMessage).startsWith(OAUTH_INFERENCE_REJECTED_PREFIX)) {
+      return {
+        status: "failed",
+        error_code: "oauth_inference_rejected",
+        error_message: String(execution.errorMessage).slice(OAUTH_INFERENCE_REJECTED_PREFIX.length).trim(),
+      };
+    }
     if (isScopeFailure(execution.errorMessage)) {
       return {
         status: "failed",
@@ -243,6 +264,13 @@ function classifyExecution(execution) {
         error_message: parsed.error ?? reason,
       };
     }
+    if (isOAuthInferenceRejected(execution, invocation)) {
+      return {
+        status: "failed",
+        error_code: "oauth_inference_rejected",
+        error_message: parsed.result ?? parsed.error ?? null,
+      };
+    }
     return {
       status: "failed",
       error_code: "claude_error",
@@ -280,7 +308,21 @@ function buildErrorDiagnostic(invocation, status, error_code, error_message) {
     suggested_action: null,
     disclosure_note: null,
   };
-  if (status !== "failed" || error_code !== "scope_failed" || !error_message) {
+  if (status !== "failed") {
+    return empty;
+  }
+  if (error_code === "oauth_inference_rejected") {
+    return {
+      error_summary: "Claude OAuth non-interactive inference was rejected.",
+      error_cause:
+        "Claude Code reported HTTP 401 while the companion was using subscription/OAuth mode. " +
+        "`claude auth status` can still report logged in; when detected by preflight, the review source is not sent.",
+      suggested_action:
+        "Run `/claude-setup`, refresh Claude OAuth in a normal terminal if needed, and verify OAuth-only `claude -p` inference works before retrying the review.",
+      disclosure_note: null,
+    };
+  }
+  if (error_code !== "scope_failed" || !error_message) {
     return empty;
   }
 
@@ -518,7 +560,7 @@ export function buildJobRecord(invocation, execution, mutations) {
   if (!Array.isArray(mutations)) {
     throw new Error("buildJobRecord: mutations must be an array (empty ok)");
   }
-  const { status, error_code, error_message } = classifyExecution(execution);
+  const { status, error_code, error_message } = classifyExecution(execution, invocation);
   const diagnostic = buildErrorDiagnostic(invocation, status, error_code, error_message);
 
   const parsed = execution?.parsed ?? null;

--- a/plugins/claude/scripts/lib/job-record.mjs
+++ b/plugins/claude/scripts/lib/job-record.mjs
@@ -164,6 +164,7 @@ const FINALIZATION_FAILED_PREFIX = "finalization_failed:";
 const OAUTH_INFERENCE_REJECTED_PREFIX = "oauth_inference_rejected:";
 
 export function isOAuthInferenceRejected(execution, invocation = null) {
+  if (!invocation) return false;
   if (invocation?.selected_auth_path && invocation.selected_auth_path !== "subscription_oauth") return false;
   if (!invocation?.selected_auth_path && invocation?.auth_mode === "api_key") return false;
   const raw = execution?.parsed?.raw;
@@ -172,7 +173,7 @@ export function isOAuthInferenceRejected(execution, invocation = null) {
   return status === 401 && /invalid authentication credentials|failed to authenticate/i.test(result);
 }
 
-function classifyExecution(execution, invocation = null) {
+export function classifyExecution(execution, invocation = null) {
   if (!execution) {
     return {
       status: "queued",
@@ -316,7 +317,7 @@ function buildErrorDiagnostic(invocation, status, error_code, error_message) {
       error_summary: "Claude OAuth non-interactive inference was rejected.",
       error_cause:
         "Claude Code reported HTTP 401 while the companion was using subscription/OAuth mode. " +
-        "`claude auth status` can still report logged in; when detected by preflight, the review source is not sent.",
+        "`claude auth status` can still report logged in; non-interactive inference was rejected.",
       suggested_action:
         "Run `/claude-setup`, refresh Claude OAuth in a normal terminal if needed, and verify OAuth-only `claude -p` inference works before retrying the review.",
       disclosure_note: null,

--- a/plugins/claude/scripts/lib/job-record.mjs
+++ b/plugins/claude/scripts/lib/job-record.mjs
@@ -165,8 +165,7 @@ const OAUTH_INFERENCE_REJECTED_PREFIX = "oauth_inference_rejected:";
 
 export function isOAuthInferenceRejected(execution, authContext = null) {
   if (!authContext) return false;
-  if (authContext?.selected_auth_path && authContext.selected_auth_path !== "subscription_oauth") return false;
-  if (!authContext?.selected_auth_path && authContext?.auth_mode === "api_key") return false;
+  if (authContext.selected_auth_path !== "subscription_oauth") return false;
   const raw = execution?.parsed?.raw;
   const status = raw && typeof raw === "object" ? raw.api_error_status : null;
   const result = String(execution?.parsed?.result ?? "");

--- a/plugins/claude/scripts/lib/process.mjs
+++ b/plugins/claude/scripts/lib/process.mjs
@@ -18,7 +18,7 @@ export function runCommand(command, args = [], options = {}) {
   return {
     command,
     args,
-    status: result.status ?? 0,
+    status: result.status,
     signal: result.signal ?? null,
     stdout: result.stdout ?? "",
     stderr: result.stderr ?? "",

--- a/plugins/claude/scripts/lib/process.mjs
+++ b/plugins/claude/scripts/lib/process.mjs
@@ -8,6 +8,8 @@ export function runCommand(command, args = [], options = {}) {
     encoding: "utf8",
     input: options.input,
     maxBuffer: options.maxBuffer,
+    timeout: options.timeout,
+    killSignal: options.killSignal,
     stdio: options.stdio ?? "pipe",
     shell: process.platform === "win32" ? (process.env.SHELL || true) : false,
     windowsHide: true

--- a/plugins/claude/scripts/lib/review-prompt.mjs
+++ b/plugins/claude/scripts/lib/review-prompt.mjs
@@ -236,6 +236,7 @@ export function buildReviewAuditManifest({
       scope_paths: Array.isArray(scope.paths) ? Object.freeze([...scope.paths]) : null,
       reason: scope.reason ?? null,
     }),
+    error_code: errorCode,
     review_quality: qualityFlags({ result, status, errorCode }),
   });
 }

--- a/plugins/claude/scripts/lib/review-prompt.mjs
+++ b/plugins/claude/scripts/lib/review-prompt.mjs
@@ -159,7 +159,7 @@ function qualityFlags({ result = "", status = null, errorCode = null } = {}) {
     ]),
     checklist_items_seen: checklistItemsSeen,
     looks_shallow: text.trim().length > 0 && text.trim().length < 500,
-    failed_review_slot: status !== "completed" || errorCode !== null,
+    failed_review_slot: status !== "preflight_failed" && (status !== "completed" || errorCode !== null),
   });
 }
 

--- a/plugins/claude/skills/claude-result-handling/SKILL.md
+++ b/plugins/claude/skills/claude-result-handling/SKILL.md
@@ -59,7 +59,7 @@ comes back to you.
   "started_at":          "<iso-8601>",
   "ended_at":            null | "<iso-8601>",
   "exit_code":           null | 0 | 1 | 2,
-  "error_code":          null | "scope_failed" | "spawn_failed" | "claude_error" | "gemini_error" | "kimi_error" | "parse_error" | "step_limit_exceeded" | "usage_limited" | "finalization_failed" | "timeout" | "stale_active_job",
+  "error_code":          null | "scope_failed" | "spawn_failed" | "claude_error" | "gemini_error" | "kimi_error" | "parse_error" | "oauth_inference_rejected" | "step_limit_exceeded" | "usage_limited" | "finalization_failed" | "timeout" | "stale_active_job",
   "error_message":       null | "<human>",
   "error_summary":       null | "<short operator-facing summary>",
   "error_cause":         null | "<why this happened>",
@@ -213,6 +213,11 @@ from short-lived index contention.
   target CLI or external provider.
 - `claude_error` — Claude ran but returned `is_error: true`. `result` may
   still contain partial text worth showing.
+- `oauth_inference_rejected` — Claude Code returned an HTTP 401 authentication
+  rejection from non-interactive inference while the companion was using
+  subscription/OAuth mode. Treat this as a failed review slot, not a model
+  verdict or approval. Tell the user to run `/claude-setup`; `claude auth
+  status` may be a false positive for review readiness.
 - `gemini_error` / `kimi_error` — the corresponding external CLI ran but
   returned a target-level failure. `result` may contain partial text worth
   showing if present; otherwise use the structured diagnostic fields.

--- a/plugins/claude/skills/claude-setup/SKILL.md
+++ b/plugins/claude/skills/claude-setup/SKILL.md
@@ -14,4 +14,4 @@ Use the Claude companion setup workflow. Current Codex builds expose it as `clau
 node "<plugin-root>/scripts/claude-companion.mjs" doctor
 ```
 
-Show `summary`, `ready`, and `next_action` exactly. Never print secret values or suggest Claude API keys for subscription/OAuth setup.
+Show `summary`, `ready`, and `next_action` exactly. If `status` is `oauth_inference_rejected`, report that Claude OAuth status is present but non-interactive `claude -p` inference failed, so Claude review slots are not ready. Never print secret values or suggest Claude API keys for subscription/OAuth setup.

--- a/plugins/gemini/scripts/lib/external-review.mjs
+++ b/plugins/gemini/scripts/lib/external-review.mjs
@@ -37,6 +37,7 @@ const CONTENT_RECEIVED_ERROR_CODES = Object.freeze(new Set([
   "gemini_error",
   "kimi_error",
   "parse_error",
+  "oauth_inference_rejected",
   "step_limit_exceeded",
   "usage_limited",
   "finalization_failed",
@@ -57,6 +58,7 @@ const NOT_SENT_DISCLOSURE_BY_STATUS = Object.freeze({
 const NOT_SENT_DISCLOSURE_BY_ERROR = Object.freeze({
   scope_failed: (provider) => `Selected source content was not sent to ${provider}; the review scope was rejected before the target process was started.`,
   spawn_failed: (provider) => `Selected source content was not sent to ${provider}; the target process was not spawned.`,
+  oauth_inference_rejected: (provider) => `Selected source content was not sent to ${provider}; OAuth inference readiness was rejected before the review target was started.`,
 });
 
 const UNKNOWN_DISCLOSURE_BY_STATUS = Object.freeze({
@@ -107,6 +109,9 @@ export function sourceContentTransmissionForExecution({ status, errorCode, pidIn
     return SOURCE_CONTENT_TRANSMISSION.UNKNOWN;
   }
   if (errorCode === "scope_failed" || errorCode === "spawn_failed") {
+    return SOURCE_CONTENT_TRANSMISSION.NOT_SENT;
+  }
+  if (errorCode === "oauth_inference_rejected" && !pidInfo) {
     return SOURCE_CONTENT_TRANSMISSION.NOT_SENT;
   }
   if (status === "cancelled") {

--- a/plugins/gemini/scripts/lib/process.mjs
+++ b/plugins/gemini/scripts/lib/process.mjs
@@ -18,7 +18,7 @@ export function runCommand(command, args = [], options = {}) {
   return {
     command,
     args,
-    status: result.status ?? 0,
+    status: result.status,
     signal: result.signal ?? null,
     stdout: result.stdout ?? "",
     stderr: result.stderr ?? "",

--- a/plugins/gemini/scripts/lib/process.mjs
+++ b/plugins/gemini/scripts/lib/process.mjs
@@ -8,6 +8,8 @@ export function runCommand(command, args = [], options = {}) {
     encoding: "utf8",
     input: options.input,
     maxBuffer: options.maxBuffer,
+    timeout: options.timeout,
+    killSignal: options.killSignal,
     stdio: options.stdio ?? "pipe",
     shell: process.platform === "win32" ? (process.env.SHELL || true) : false,
     windowsHide: true

--- a/plugins/gemini/scripts/lib/review-prompt.mjs
+++ b/plugins/gemini/scripts/lib/review-prompt.mjs
@@ -236,6 +236,7 @@ export function buildReviewAuditManifest({
       scope_paths: Array.isArray(scope.paths) ? Object.freeze([...scope.paths]) : null,
       reason: scope.reason ?? null,
     }),
+    error_code: errorCode,
     review_quality: qualityFlags({ result, status, errorCode }),
   });
 }

--- a/plugins/gemini/scripts/lib/review-prompt.mjs
+++ b/plugins/gemini/scripts/lib/review-prompt.mjs
@@ -159,7 +159,7 @@ function qualityFlags({ result = "", status = null, errorCode = null } = {}) {
     ]),
     checklist_items_seen: checklistItemsSeen,
     looks_shallow: text.trim().length > 0 && text.trim().length < 500,
-    failed_review_slot: status !== "completed" || errorCode !== null,
+    failed_review_slot: status !== "preflight_failed" && (status !== "completed" || errorCode !== null),
   });
 }
 

--- a/plugins/grok/scripts/lib/external-review.mjs
+++ b/plugins/grok/scripts/lib/external-review.mjs
@@ -37,6 +37,7 @@ const CONTENT_RECEIVED_ERROR_CODES = Object.freeze(new Set([
   "gemini_error",
   "kimi_error",
   "parse_error",
+  "oauth_inference_rejected",
   "step_limit_exceeded",
   "usage_limited",
   "finalization_failed",
@@ -57,6 +58,7 @@ const NOT_SENT_DISCLOSURE_BY_STATUS = Object.freeze({
 const NOT_SENT_DISCLOSURE_BY_ERROR = Object.freeze({
   scope_failed: (provider) => `Selected source content was not sent to ${provider}; the review scope was rejected before the target process was started.`,
   spawn_failed: (provider) => `Selected source content was not sent to ${provider}; the target process was not spawned.`,
+  oauth_inference_rejected: (provider) => `Selected source content was not sent to ${provider}; OAuth inference readiness was rejected before the review target was started.`,
 });
 
 const UNKNOWN_DISCLOSURE_BY_STATUS = Object.freeze({
@@ -107,6 +109,9 @@ export function sourceContentTransmissionForExecution({ status, errorCode, pidIn
     return SOURCE_CONTENT_TRANSMISSION.UNKNOWN;
   }
   if (errorCode === "scope_failed" || errorCode === "spawn_failed") {
+    return SOURCE_CONTENT_TRANSMISSION.NOT_SENT;
+  }
+  if (errorCode === "oauth_inference_rejected" && !pidInfo) {
     return SOURCE_CONTENT_TRANSMISSION.NOT_SENT;
   }
   if (status === "cancelled") {

--- a/plugins/grok/scripts/lib/review-prompt.mjs
+++ b/plugins/grok/scripts/lib/review-prompt.mjs
@@ -236,6 +236,7 @@ export function buildReviewAuditManifest({
       scope_paths: Array.isArray(scope.paths) ? Object.freeze([...scope.paths]) : null,
       reason: scope.reason ?? null,
     }),
+    error_code: errorCode,
     review_quality: qualityFlags({ result, status, errorCode }),
   });
 }

--- a/plugins/grok/scripts/lib/review-prompt.mjs
+++ b/plugins/grok/scripts/lib/review-prompt.mjs
@@ -159,7 +159,7 @@ function qualityFlags({ result = "", status = null, errorCode = null } = {}) {
     ]),
     checklist_items_seen: checklistItemsSeen,
     looks_shallow: text.trim().length > 0 && text.trim().length < 500,
-    failed_review_slot: status !== "completed" || errorCode !== null,
+    failed_review_slot: status !== "preflight_failed" && (status !== "completed" || errorCode !== null),
   });
 }
 

--- a/plugins/kimi/scripts/lib/external-review.mjs
+++ b/plugins/kimi/scripts/lib/external-review.mjs
@@ -37,6 +37,7 @@ const CONTENT_RECEIVED_ERROR_CODES = Object.freeze(new Set([
   "gemini_error",
   "kimi_error",
   "parse_error",
+  "oauth_inference_rejected",
   "step_limit_exceeded",
   "usage_limited",
   "finalization_failed",
@@ -57,6 +58,7 @@ const NOT_SENT_DISCLOSURE_BY_STATUS = Object.freeze({
 const NOT_SENT_DISCLOSURE_BY_ERROR = Object.freeze({
   scope_failed: (provider) => `Selected source content was not sent to ${provider}; the review scope was rejected before the target process was started.`,
   spawn_failed: (provider) => `Selected source content was not sent to ${provider}; the target process was not spawned.`,
+  oauth_inference_rejected: (provider) => `Selected source content was not sent to ${provider}; OAuth inference readiness was rejected before the review target was started.`,
 });
 
 const UNKNOWN_DISCLOSURE_BY_STATUS = Object.freeze({
@@ -107,6 +109,9 @@ export function sourceContentTransmissionForExecution({ status, errorCode, pidIn
     return SOURCE_CONTENT_TRANSMISSION.UNKNOWN;
   }
   if (errorCode === "scope_failed" || errorCode === "spawn_failed") {
+    return SOURCE_CONTENT_TRANSMISSION.NOT_SENT;
+  }
+  if (errorCode === "oauth_inference_rejected" && !pidInfo) {
     return SOURCE_CONTENT_TRANSMISSION.NOT_SENT;
   }
   if (status === "cancelled") {

--- a/plugins/kimi/scripts/lib/process.mjs
+++ b/plugins/kimi/scripts/lib/process.mjs
@@ -18,7 +18,7 @@ export function runCommand(command, args = [], options = {}) {
   return {
     command,
     args,
-    status: result.status ?? 0,
+    status: result.status,
     signal: result.signal ?? null,
     stdout: result.stdout ?? "",
     stderr: result.stderr ?? "",

--- a/plugins/kimi/scripts/lib/process.mjs
+++ b/plugins/kimi/scripts/lib/process.mjs
@@ -8,6 +8,8 @@ export function runCommand(command, args = [], options = {}) {
     encoding: "utf8",
     input: options.input,
     maxBuffer: options.maxBuffer,
+    timeout: options.timeout,
+    killSignal: options.killSignal,
     stdio: options.stdio ?? "pipe",
     shell: process.platform === "win32" ? (process.env.SHELL || true) : false,
     windowsHide: true

--- a/plugins/kimi/scripts/lib/review-prompt.mjs
+++ b/plugins/kimi/scripts/lib/review-prompt.mjs
@@ -236,6 +236,7 @@ export function buildReviewAuditManifest({
       scope_paths: Array.isArray(scope.paths) ? Object.freeze([...scope.paths]) : null,
       reason: scope.reason ?? null,
     }),
+    error_code: errorCode,
     review_quality: qualityFlags({ result, status, errorCode }),
   });
 }

--- a/plugins/kimi/scripts/lib/review-prompt.mjs
+++ b/plugins/kimi/scripts/lib/review-prompt.mjs
@@ -159,7 +159,7 @@ function qualityFlags({ result = "", status = null, errorCode = null } = {}) {
     ]),
     checklist_items_seen: checklistItemsSeen,
     looks_shallow: text.trim().length > 0 && text.trim().length < 500,
-    failed_review_slot: status !== "completed" || errorCode !== null,
+    failed_review_slot: status !== "preflight_failed" && (status !== "completed" || errorCode !== null),
   });
 }
 

--- a/scripts/ci/sync-external-review.mjs
+++ b/scripts/ci/sync-external-review.mjs
@@ -12,6 +12,7 @@ const COPIES = [
     path.join(REPO_ROOT, `plugins/${plugin}/scripts/lib/external-review.mjs`)
   ),
   path.join(REPO_ROOT, "plugins/api-reviewers/scripts/lib/external-review.mjs"),
+  path.join(REPO_ROOT, "plugins/grok/scripts/lib/external-review.mjs"),
 ];
 
 const checkOnly = process.argv.includes("--check");

--- a/scripts/lib/external-review.mjs
+++ b/scripts/lib/external-review.mjs
@@ -37,6 +37,7 @@ const CONTENT_RECEIVED_ERROR_CODES = Object.freeze(new Set([
   "gemini_error",
   "kimi_error",
   "parse_error",
+  "oauth_inference_rejected",
   "step_limit_exceeded",
   "usage_limited",
   "finalization_failed",
@@ -57,6 +58,7 @@ const NOT_SENT_DISCLOSURE_BY_STATUS = Object.freeze({
 const NOT_SENT_DISCLOSURE_BY_ERROR = Object.freeze({
   scope_failed: (provider) => `Selected source content was not sent to ${provider}; the review scope was rejected before the target process was started.`,
   spawn_failed: (provider) => `Selected source content was not sent to ${provider}; the target process was not spawned.`,
+  oauth_inference_rejected: (provider) => `Selected source content was not sent to ${provider}; OAuth inference readiness was rejected before the review target was started.`,
 });
 
 const UNKNOWN_DISCLOSURE_BY_STATUS = Object.freeze({
@@ -107,6 +109,9 @@ export function sourceContentTransmissionForExecution({ status, errorCode, pidIn
     return SOURCE_CONTENT_TRANSMISSION.UNKNOWN;
   }
   if (errorCode === "scope_failed" || errorCode === "spawn_failed") {
+    return SOURCE_CONTENT_TRANSMISSION.NOT_SENT;
+  }
+  if (errorCode === "oauth_inference_rejected" && !pidInfo) {
     return SOURCE_CONTENT_TRANSMISSION.NOT_SENT;
   }
   if (status === "cancelled") {

--- a/scripts/lib/review-prompt.mjs
+++ b/scripts/lib/review-prompt.mjs
@@ -236,6 +236,7 @@ export function buildReviewAuditManifest({
       scope_paths: Array.isArray(scope.paths) ? Object.freeze([...scope.paths]) : null,
       reason: scope.reason ?? null,
     }),
+    error_code: errorCode,
     review_quality: qualityFlags({ result, status, errorCode }),
   });
 }

--- a/scripts/lib/review-prompt.mjs
+++ b/scripts/lib/review-prompt.mjs
@@ -159,7 +159,7 @@ function qualityFlags({ result = "", status = null, errorCode = null } = {}) {
     ]),
     checklist_items_seen: checklistItemsSeen,
     looks_shallow: text.trim().length > 0 && text.trim().length < 500,
-    failed_review_slot: status !== "completed" || errorCode !== null,
+    failed_review_slot: status !== "preflight_failed" && (status !== "completed" || errorCode !== null),
   });
 }
 

--- a/tests/smoke/claude-companion.smoke.test.mjs
+++ b/tests/smoke/claude-companion.smoke.test.mjs
@@ -1736,6 +1736,49 @@ process.exit(1);
   }
 });
 
+test("doctor: OAuth status JSON tolerates trailing notices with braces", () => {
+  const tmp = mkdtempSync(path.join(tmpdir(), "claude-doctor-oauth-status-trailing-brace-"));
+  const binary = writeExecutable(tmp, "claude-oauth-status-trailing-brace", `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "auth" && args[1] === "status") {
+  process.stdout.write("claude notice: auth cache refreshed\\n");
+  process.stdout.write(JSON.stringify({
+    loggedIn: true,
+    authMethod: "claude.ai",
+    apiProvider: "firstParty",
+    email: "user@example.com",
+    subscriptionType: "max"
+  }) + "\\n");
+  process.stdout.write("claude notice: trailing diagnostic }\\n");
+  process.exit(0);
+}
+process.stdout.write(JSON.stringify({
+  type: "result",
+  is_error: true,
+  api_error_status: 401,
+  result: "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+  session_id: "33333333-3333-4333-8333-333333333333",
+  usage: { input_tokens: 0, output_tokens: 0 }
+}) + "\\n");
+process.exit(1);
+`);
+  const { stdout, status, dataDir } = runCompanion(
+    ["doctor", "--binary", binary, "--model", "claude-haiku-4-5-20251001"],
+    { cwd: tmpdir(), env: { ANTHROPIC_API_KEY: "", CLAUDE_API_KEY: "" } },
+  );
+  try {
+    assert.equal(status, 2);
+    const result = JSON.parse(stdout);
+    assert.equal(result.status, "oauth_inference_rejected");
+    assert.equal(result.oauth_status?.logged_in, true);
+    assert.equal(result.oauth_status?.subscription_type, "max");
+    assert.doesNotMatch(stdout, /user@example.com/);
+  } finally {
+    cleanup(dataDir);
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test("run: OAuth inference 401 is rejected before launch, not recorded as a failed review slot", () => {
   const cwd = mkdtempSync(path.join(tmpdir(), "claude-run-oauth-print-401-cwd-"));
   seedMinimalRepo(cwd);
@@ -1784,6 +1827,68 @@ process.exit(1);
     assert.equal(record.pid_info, null);
     assert.equal(record.review_metadata.audit_manifest.error_code, "oauth_inference_rejected");
     assert.equal(record.review_metadata.audit_manifest.review_quality.failed_review_slot, false);
+    assert.doesNotMatch(stdout, /user@example.com/);
+  } finally {
+    cleanup(dataDir);
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("run: post-spawn OAuth inference 401 is mirrored into audit manifest", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "claude-run-oauth-postspawn-cwd-"));
+  seedMinimalRepo(cwd);
+  writeFileSync(path.join(cwd, "file.txt"), "changed\\n", "utf8");
+  const tmp = mkdtempSync(path.join(tmpdir(), "claude-run-oauth-postspawn-bin-"));
+  const counterPath = path.join(tmp, "counter.txt");
+  writeFileSync(counterPath, "0", "utf8");
+  const binary = writeExecutable(tmp, "claude-oauth-postspawn-401", `#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+if (process.argv.slice(2).join(" ") === "auth status --json") {
+  process.stdout.write(JSON.stringify({
+    loggedIn: true,
+    authMethod: "claude.ai",
+    apiProvider: "firstParty",
+    subscriptionType: "max",
+    email: "user@example.com"
+  }) + "\\n");
+  process.exit(0);
+}
+const counterPath = ${JSON.stringify(counterPath)};
+const count = Number(readFileSync(counterPath, "utf8"));
+writeFileSync(counterPath, String(count + 1));
+if (count === 0) {
+  process.stdout.write(JSON.stringify({
+    type: "result",
+    is_error: false,
+    result: "pong",
+    session_id: "11111111-1111-4111-8111-111111111111",
+    usage: { input_tokens: 1, output_tokens: 1 }
+  }) + "\\n");
+  process.exit(0);
+}
+process.stdout.write(JSON.stringify({
+  type: "result",
+  is_error: true,
+  api_error_status: 401,
+  result: "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+  session_id: "22222222-2222-4222-8222-222222222222",
+  usage: { input_tokens: 0, output_tokens: 0 }
+}) + "\\n");
+process.exit(1);
+`);
+  const { stdout, status, dataDir } = runCompanion(
+    ["run", "--mode=review", "--foreground", "--binary", binary,
+     "--model", "claude-haiku-4-5-20251001", "--cwd", cwd, "--", "review this change"],
+    { cwd, env: { ANTHROPIC_API_KEY: "", CLAUDE_API_KEY: "" } },
+  );
+  try {
+    assert.equal(status, 2);
+    const record = JSON.parse(stdout);
+    assert.equal(record.error_code, "oauth_inference_rejected");
+    assert.equal(record.external_review.source_content_transmission, "sent");
+    assert.equal(record.review_metadata.audit_manifest.error_code, "oauth_inference_rejected");
+    assert.equal(record.review_metadata.audit_manifest.review_quality.failed_review_slot, true);
     assert.doesNotMatch(stdout, /user@example.com/);
   } finally {
     cleanup(dataDir);

--- a/tests/smoke/claude-companion.smoke.test.mjs
+++ b/tests/smoke/claude-companion.smoke.test.mjs
@@ -1792,6 +1792,102 @@ process.exit(1);
   }
 });
 
+test("run: OAuth preflight auth-status resolves relative binary from invocation cwd", () => {
+  const launcherCwd = mkdtempSync(path.join(tmpdir(), "claude-run-oauth-relative-launcher-"));
+  const cwd = mkdtempSync(path.join(tmpdir(), "claude-run-oauth-relative-cwd-"));
+  seedMinimalRepo(cwd);
+  writeExecutable(cwd, "claude", `#!/usr/bin/env node
+if (process.argv.slice(2).join(" ") === "auth status --json") {
+  process.stdout.write(JSON.stringify({
+    loggedIn: true,
+    authMethod: "claude.ai",
+    apiProvider: "firstParty",
+    subscriptionType: "max"
+  }) + "\\n");
+  process.exit(0);
+}
+process.stdout.write(JSON.stringify({
+  type: "result",
+  is_error: true,
+  api_error_status: 401,
+  result: "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+  session_id: "33333333-3333-4333-8333-333333333333",
+  usage: { input_tokens: 0, output_tokens: 0 }
+}) + "\\n");
+process.exit(1);
+`);
+  const { stdout, status, dataDir } = runCompanion(
+    ["run", "--mode=review", "--foreground", "--lifecycle-events", "jsonl", "--binary", "./claude",
+     "--model", "claude-haiku-4-5-20251001", "--cwd", cwd, "--", "review this change"],
+    { cwd: launcherCwd, env: { ANTHROPIC_API_KEY: "", CLAUDE_API_KEY: "" } },
+  );
+  try {
+    assert.equal(status, 2);
+    const lines = stdout.trim().split("\n").map((line) => JSON.parse(line));
+    assert.equal(lines.length, 1, "relative binary OAuth rejection must be caught before review launch");
+    const [record] = lines;
+    assert.equal(record.error_code, "oauth_inference_rejected");
+    assert.equal(record.external_review.source_content_transmission, "not_sent");
+    assert.equal(record.pid_info, null);
+  } finally {
+    cleanup(dataDir);
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(launcherCwd, { recursive: true, force: true });
+  }
+});
+
+test("run: OAuth preflight finalization failure is surfaced instead of silently ignored", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "claude-run-oauth-meta-conflict-cwd-"));
+  seedMinimalRepo(cwd);
+  const tmp = mkdtempSync(path.join(tmpdir(), "claude-run-oauth-meta-conflict-bin-"));
+  const stateModule = path.join(REPO_ROOT, "plugins/claude/scripts/lib/state.mjs");
+  const binary = writeExecutable(tmp, "claude-oauth-meta-conflict", `#!/usr/bin/env node
+import { mkdirSync, readdirSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
+const { resolveJobsDir } = await import(${JSON.stringify(stateModule)});
+if (process.argv.slice(2).join(" ") === "auth status --json") {
+  process.stdout.write(JSON.stringify({
+    loggedIn: true,
+    authMethod: "claude.ai",
+    apiProvider: "firstParty",
+    subscriptionType: "max"
+  }) + "\\n");
+  process.exit(0);
+}
+const jobsDir = resolveJobsDir(process.cwd());
+for (const name of readdirSync(jobsDir)) {
+  if (!name.endsWith(".json")) continue;
+  const metaPath = resolve(jobsDir, name);
+  rmSync(metaPath, { force: true, recursive: true });
+  mkdirSync(metaPath, { recursive: true });
+}
+process.stdout.write(JSON.stringify({
+  type: "result",
+  is_error: true,
+  api_error_status: 401,
+  result: "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+  session_id: "33333333-3333-4333-8333-333333333333",
+  usage: { input_tokens: 0, output_tokens: 0 }
+}) + "\\n");
+process.exit(1);
+`);
+  const { stdout, stderr, status, dataDir } = runCompanion(
+    ["run", "--mode=review", "--foreground", "--binary", binary,
+     "--model", "claude-haiku-4-5-20251001", "--cwd", cwd, "--", "review this change"],
+    { cwd, env: { ANTHROPIC_API_KEY: "", CLAUDE_API_KEY: "" } },
+  );
+  try {
+    assert.notEqual(status, 0, "meta write failure must exit non-zero");
+    assert.doesNotMatch(stderr, /unhandled/i);
+    const err = JSON.parse(stdout);
+    assert.equal(err.error, "finalization_failed");
+  } finally {
+    cleanup(dataDir);
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test("run: auto auth without API keys classifies OAuth inference 401 distinctly", () => {
   const cwd = mkdtempSync(path.join(tmpdir(), "claude-run-auto-oauth-print-401-cwd-"));
   seedMinimalRepo(cwd);

--- a/tests/smoke/claude-companion.smoke.test.mjs
+++ b/tests/smoke/claude-companion.smoke.test.mjs
@@ -1782,6 +1782,7 @@ process.exit(1);
     assert.equal(record.external_review.source_content_transmission, "not_sent");
     assert.match(record.external_review.disclosure, /not sent/);
     assert.equal(record.pid_info, null);
+    assert.equal(record.review_metadata.audit_manifest.error_code, "oauth_inference_rejected");
     assert.equal(record.review_metadata.audit_manifest.review_quality.failed_review_slot, false);
     assert.doesNotMatch(stdout, /user@example.com/);
   } finally {

--- a/tests/smoke/claude-companion.smoke.test.mjs
+++ b/tests/smoke/claude-companion.smoke.test.mjs
@@ -152,6 +152,62 @@ test("run --mode=review --foreground: emits JobRecord with status=completed", ()
   }
 });
 
+test("run --mode=review --foreground: audit manifest uses canonical claude_error", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "smoke-cwd-claude-error-audit-"));
+  seedMinimalRepo(cwd);
+  const tmp = mkdtempSync(path.join(tmpdir(), "claude-error-audit-bin-"));
+  const counterPath = path.join(tmp, "counter.txt");
+  writeFileSync(counterPath, "0", "utf8");
+  const binary = writeExecutable(tmp, "claude-error-audit", `#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+if (process.argv.slice(2).join(" ") === "auth status --json") {
+  process.stdout.write(JSON.stringify({
+    loggedIn: true,
+    authMethod: "claude.ai",
+    apiProvider: "firstParty",
+    subscriptionType: "max"
+  }) + "\\n");
+  process.exit(0);
+}
+const counterPath = ${JSON.stringify(counterPath)};
+const count = Number(readFileSync(counterPath, "utf8"));
+writeFileSync(counterPath, String(count + 1));
+if (count === 0) {
+  process.stdout.write(JSON.stringify({
+    type: "result",
+    is_error: false,
+    result: "pong",
+    session_id: "11111111-1111-4111-8111-111111111111",
+    usage: { input_tokens: 1, output_tokens: 1 }
+  }) + "\\n");
+  process.exit(0);
+}
+process.stdout.write(JSON.stringify({
+  type: "result",
+  is_error: true,
+  result: "tool denied",
+  session_id: "22222222-2222-4222-8222-222222222222",
+  usage: { input_tokens: 0, output_tokens: 0 }
+}) + "\\n");
+process.exit(1);
+`);
+  const { stdout, status, dataDir } = runCompanion(
+    ["run", "--mode=review", "--foreground", "--binary", binary,
+     "--model", "claude-haiku-4-5-20251001", "--cwd", cwd, "--", "review this change"],
+    { cwd, env: { ANTHROPIC_API_KEY: "", CLAUDE_API_KEY: "" } },
+  );
+  try {
+    assert.equal(status, 2);
+    const record = JSON.parse(stdout);
+    assert.equal(record.error_code, "claude_error");
+    assert.equal(record.review_metadata.audit_manifest.error_code, "claude_error");
+  } finally {
+    cleanup(dataDir);
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test("run --mode=review --foreground lifecycle jsonl emits launch event before terminal JobRecord", () => {
   const cwd = mkdtempSync(path.join(tmpdir(), "smoke-lifecycle-cwd-"));
   seedMinimalRepo(cwd);
@@ -1688,8 +1744,11 @@ process.exit(1);
 });
 
 test("doctor: OAuth status success but non-interactive inference 401 is classified distinctly", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "claude-doctor-oauth-print-401-cwd-"));
   const tmp = mkdtempSync(path.join(tmpdir(), "claude-doctor-oauth-print-401-"));
+  const probeCwdPath = path.join(tmp, "probe-cwd.txt");
   const binary = writeExecutable(tmp, "claude-oauth-print-401", `#!/usr/bin/env node
+import { writeFileSync } from "node:fs";
 const args = process.argv.slice(2);
 if (args[0] === "auth" && args[1] === "status") {
   process.stdout.write("claude notice: auth cache refreshed\\n");
@@ -1701,6 +1760,11 @@ if (args[0] === "auth" && args[1] === "status") {
     subscriptionType: "max"
   }, null, 2) + "\\n");
   process.exit(0);
+}
+writeFileSync(${JSON.stringify(probeCwdPath)}, process.cwd(), "utf8");
+if (process.cwd() === ${JSON.stringify(cwd)}) {
+  process.stderr.write("inference probe ran in caller cwd\\n");
+  process.exit(43);
 }
 process.stdout.write(JSON.stringify({
   type: "result",
@@ -1714,7 +1778,7 @@ process.exit(1);
 `);
   const { stdout, status, dataDir } = runCompanion(
     ["doctor", "--binary", binary, "--model", "claude-haiku-4-5-20251001"],
-    { cwd: tmpdir(), env: { ANTHROPIC_API_KEY: "", CLAUDE_API_KEY: "" } },
+    { cwd, env: { ANTHROPIC_API_KEY: "", CLAUDE_API_KEY: "" } },
   );
   try {
     assert.equal(status, 2);
@@ -1730,8 +1794,10 @@ process.exit(1);
     assert.match(result.summary, /OAuth.*non-interactive/i);
     assert.match(result.next_action, /claude auth login|OAuth/i);
     assert.doesNotMatch(stdout, /user@example.com/);
+    assert.notEqual(readFileSync(probeCwdPath, "utf8"), cwd);
   } finally {
     cleanup(dataDir);
+    rmSync(cwd, { recursive: true, force: true });
     rmSync(tmp, { recursive: true, force: true });
   }
 });
@@ -1901,7 +1967,9 @@ test("run: OAuth preflight auth-status resolves relative binary from invocation 
   const launcherCwd = mkdtempSync(path.join(tmpdir(), "claude-run-oauth-relative-launcher-"));
   const cwd = mkdtempSync(path.join(tmpdir(), "claude-run-oauth-relative-cwd-"));
   seedMinimalRepo(cwd);
+  const probeCwdPath = path.join(cwd, "probe-cwd.txt");
   writeExecutable(cwd, "claude", `#!/usr/bin/env node
+import { writeFileSync } from "node:fs";
 if (process.argv.slice(2).join(" ") === "auth status --json") {
   process.stdout.write(JSON.stringify({
     loggedIn: true,
@@ -1910,6 +1978,11 @@ if (process.argv.slice(2).join(" ") === "auth status --json") {
     subscriptionType: "max"
   }) + "\\n");
   process.exit(0);
+}
+writeFileSync(${JSON.stringify(probeCwdPath)}, process.cwd(), "utf8");
+if (process.cwd() === ${JSON.stringify(cwd)}) {
+  process.stderr.write("inference preflight ran in invocation cwd\\n");
+  process.exit(43);
 }
 process.stdout.write(JSON.stringify({
   type: "result",
@@ -1934,6 +2007,7 @@ process.exit(1);
     assert.equal(record.error_code, "oauth_inference_rejected");
     assert.equal(record.external_review.source_content_transmission, "not_sent");
     assert.equal(record.pid_info, null);
+    assert.notEqual(readFileSync(probeCwdPath, "utf8"), cwd);
   } finally {
     cleanup(dataDir);
     rmSync(cwd, { recursive: true, force: true });
@@ -1959,7 +2033,7 @@ if (process.argv.slice(2).join(" ") === "auth status --json") {
   }) + "\\n");
   process.exit(0);
 }
-const jobsDir = resolveJobsDir(process.cwd());
+const jobsDir = resolveJobsDir(${JSON.stringify(cwd)});
 for (const name of readdirSync(jobsDir)) {
   if (!name.endsWith(".json")) continue;
   const metaPath = resolve(jobsDir, name);

--- a/tests/smoke/claude-companion.smoke.test.mjs
+++ b/tests/smoke/claude-companion.smoke.test.mjs
@@ -91,14 +91,14 @@ function seedMinimalRepo(cwd) {
 test("run: api_key auth failure includes structured diagnostics before spawn", () => {
   const cwd = mkdtempSync(path.join(tmpdir(), "smoke-run-api-key-missing-"));
   const missingBinary = path.join(cwd, "missing-claude-binary");
-  const { stdout, status, dataDir } = runCompanion(
+  const { stdout, stderr, status, dataDir } = runCompanion(
     ["run", "--mode=rescue", "--foreground", "--auth-mode", "api_key",
      "--model", "claude-haiku-4-5-20251001", "--binary", missingBinary,
      "--cwd", cwd, "--", "auth missing"],
     { cwd, env: { ANTHROPIC_API_KEY: "", CLAUDE_API_KEY: "" } },
   );
   try {
-    assert.equal(status, 1);
+    assert.equal(status, 1, `status=${status} stdout=${stdout}`);
     assertClaudeApiKeyMissingError(JSON.parse(stdout));
   } finally {
     cleanup(dataDir);
@@ -1491,6 +1491,32 @@ test("ping: returns status=ok with the mock claude binary", () => {
   }
 });
 
+test("ping: treats empty successful result as ok", () => {
+  const tmp = mkdtempSync(path.join(tmpdir(), "claude-ping-empty-ok-"));
+  const binary = writeExecutable(tmp, "claude-empty-ok", `#!/usr/bin/env node
+process.stdout.write(JSON.stringify({
+  type: "result",
+  is_error: false,
+  result: "",
+  session_id: "33333333-3333-4333-8333-333333333333"
+}) + "\\n");
+`);
+  const { stdout, status, dataDir } = runCompanion(
+    ["ping", "--binary", binary, "--model", "claude-haiku-4-5-20251001"],
+    { cwd: tmpdir() },
+  );
+  try {
+    assert.equal(status, 0);
+    const result = JSON.parse(stdout);
+    assert.equal(result.status, "ok");
+    assert.equal(result.ready, true);
+    assert.equal(result.session_id, "33333333-3333-4333-8333-333333333333");
+  } finally {
+    cleanup(dataDir);
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test("ping: explicit api_key auth allows Claude provider key by name only", () => {
   const tmp = mkdtempSync(path.join(tmpdir(), "claude-ping-api-key-mode-"));
   const binary = writeExecutable(tmp, "claude-api-key-mode", `#!/usr/bin/env node
@@ -1657,6 +1683,156 @@ process.exit(1);
     assert.equal(result.detail, "Not logged in · Please run /login");
   } finally {
     cleanup(dataDir);
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("doctor: OAuth status success but non-interactive inference 401 is classified distinctly", () => {
+  const tmp = mkdtempSync(path.join(tmpdir(), "claude-doctor-oauth-print-401-"));
+  const binary = writeExecutable(tmp, "claude-oauth-print-401", `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "auth" && args[1] === "status") {
+  process.stdout.write("claude notice: auth cache refreshed\\n");
+  process.stdout.write(JSON.stringify({
+    loggedIn: true,
+    authMethod: "claude.ai",
+    apiProvider: "firstParty",
+    email: "user@example.com",
+    subscriptionType: "max"
+  }, null, 2) + "\\n");
+  process.exit(0);
+}
+process.stdout.write(JSON.stringify({
+  type: "result",
+  is_error: true,
+  api_error_status: 401,
+  result: "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+  session_id: "33333333-3333-4333-8333-333333333333",
+  usage: { input_tokens: 0, output_tokens: 0 }
+}) + "\\n");
+process.exit(1);
+`);
+  const { stdout, status, dataDir } = runCompanion(
+    ["doctor", "--binary", binary, "--model", "claude-haiku-4-5-20251001"],
+    { cwd: tmpdir(), env: { ANTHROPIC_API_KEY: "", CLAUDE_API_KEY: "" } },
+  );
+  try {
+    assert.equal(status, 2);
+    const result = JSON.parse(stdout);
+    assert.equal(result.status, "oauth_inference_rejected");
+    assert.equal(result.ready, false);
+    assert.equal(result.auth_mode, "subscription");
+    assert.equal(result.selected_auth_path, "subscription_oauth");
+    assert.equal(result.oauth_status?.logged_in, true);
+    assert.equal(result.oauth_status?.auth_method, "claude.ai");
+    assert.equal(result.oauth_status?.subscription_type, "max");
+    assert.equal(result.detail, "Failed to authenticate. API Error: 401 Invalid authentication credentials");
+    assert.match(result.summary, /OAuth.*non-interactive/i);
+    assert.match(result.next_action, /claude auth login|OAuth/i);
+    assert.doesNotMatch(stdout, /user@example.com/);
+  } finally {
+    cleanup(dataDir);
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("run: OAuth inference 401 is rejected before launch, not recorded as a failed review slot", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "claude-run-oauth-print-401-cwd-"));
+  seedMinimalRepo(cwd);
+  const tmp = mkdtempSync(path.join(tmpdir(), "claude-run-oauth-print-401-bin-"));
+  const binary = writeExecutable(tmp, "claude-oauth-print-401", `#!/usr/bin/env node
+if (process.argv.slice(2).join(" ") === "auth status --json") {
+  process.stdout.write(JSON.stringify({
+    loggedIn: true,
+    authMethod: "claude.ai",
+    apiProvider: "firstParty",
+    subscriptionType: "max",
+    email: "user@example.com"
+  }) + "\\n");
+  process.exit(0);
+}
+process.stdout.write(JSON.stringify({
+  type: "result",
+  is_error: true,
+  api_error_status: 401,
+  result: "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+  session_id: "33333333-3333-4333-8333-333333333333",
+  usage: { input_tokens: 0, output_tokens: 0 }
+}) + "\\n");
+process.exit(1);
+`);
+  const { stdout, status, dataDir } = runCompanion(
+    ["run", "--mode=review", "--foreground", "--lifecycle-events", "jsonl", "--binary", binary,
+     "--model", "claude-haiku-4-5-20251001", "--cwd", cwd, "--", "review this change"],
+    { cwd, env: { ANTHROPIC_API_KEY: "", CLAUDE_API_KEY: "" } },
+  );
+  try {
+    assert.equal(status, 2);
+    const lines = stdout.trim().split("\n").map((line) => JSON.parse(line));
+    assert.equal(lines.length, 1, "OAuth preflight rejection must not emit external_review_launched");
+    const [record] = lines;
+    assert.equal(record.status, "failed");
+    assert.equal(record.error_code, "oauth_inference_rejected");
+    assert.match(record.error_summary, /OAuth non-interactive inference was rejected/);
+    assert.match(record.suggested_action, /claude-setup|claude -p/);
+    assert.doesNotMatch(record.suggested_action, /API[- ]?key|ANTHROPIC_API_KEY|CLAUDE_API_KEY/i);
+    assert.match(record.result, /Invalid authentication credentials/);
+    assert.equal(record.usage.input_tokens, 0);
+    assert.equal(record.usage.output_tokens, 0);
+    assert.equal(record.external_review.source_content_transmission, "not_sent");
+    assert.match(record.external_review.disclosure, /not sent/);
+    assert.equal(record.pid_info, null);
+    assert.equal(record.review_metadata.audit_manifest.review_quality.failed_review_slot, false);
+    assert.doesNotMatch(stdout, /user@example.com/);
+  } finally {
+    cleanup(dataDir);
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("run: auto auth without API keys classifies OAuth inference 401 distinctly", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "claude-run-auto-oauth-print-401-cwd-"));
+  seedMinimalRepo(cwd);
+  const tmp = mkdtempSync(path.join(tmpdir(), "claude-run-auto-oauth-print-401-bin-"));
+  const binary = writeExecutable(tmp, "claude-auto-oauth-print-401", `#!/usr/bin/env node
+if (process.argv.slice(2).join(" ") === "auth status --json") {
+  process.stdout.write(JSON.stringify({
+    loggedIn: true,
+    authMethod: "claude.ai",
+    apiProvider: "firstParty",
+    subscriptionType: "max",
+    email: "user@example.com"
+  }) + "\\n");
+  process.exit(0);
+}
+process.stdout.write(JSON.stringify({
+  type: "result",
+  is_error: true,
+  api_error_status: 401,
+  result: "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+  session_id: "33333333-3333-4333-8333-333333333333",
+  usage: { input_tokens: 0, output_tokens: 0 }
+}) + "\\n");
+process.exit(1);
+`);
+  const { stdout, status, dataDir } = runCompanion(
+    ["run", "--mode=review", "--foreground", "--auth-mode", "auto", "--binary", binary,
+     "--model", "claude-haiku-4-5-20251001", "--cwd", cwd, "--", "review this change"],
+    { cwd, env: { ANTHROPIC_API_KEY: "", CLAUDE_API_KEY: "" } },
+  );
+  try {
+    assert.equal(status, 2);
+    const record = JSON.parse(stdout);
+    assert.equal(record.status, "failed");
+    assert.equal(record.error_code, "oauth_inference_rejected");
+    assert.equal(record.external_review.source_content_transmission, "not_sent");
+    assert.equal(record.pid_info, null);
+    assert.equal(record.review_metadata.audit_manifest.review_quality.failed_review_slot, false);
+    assert.doesNotMatch(stdout, /user@example.com/);
+  } finally {
+    cleanup(dataDir);
+    rmSync(cwd, { recursive: true, force: true });
     rmSync(tmp, { recursive: true, force: true });
   }
 });

--- a/tests/smoke/claude-companion.smoke.test.mjs
+++ b/tests/smoke/claude-companion.smoke.test.mjs
@@ -35,6 +35,22 @@ function runCompanion(args, { cwd, env = {}, dataDir = mkdtempSync(path.join(tmp
   return { ...res, dataDir };
 }
 
+function runCompanionWithPathBinary(args, { cwd, binDir, env = {}, dataDir = mkdtempSync(path.join(tmpdir(), "companion-smoke-")) } = {}) {
+  const childEnv = {
+    ...process.env,
+    CLAUDE_PLUGIN_DATA: dataDir,
+    PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+    ...env,
+  };
+  delete childEnv.CLAUDE_BINARY;
+  const res = spawnSync("node", [COMPANION, ...args], {
+    cwd,
+    env: childEnv,
+    encoding: "utf8",
+  });
+  return { ...res, dataDir };
+}
+
 function cleanup(dataDir) {
   rmSync(dataDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 });
 }
@@ -1524,6 +1540,35 @@ test("doctor: returns the same readiness contract as ping", () => {
   }
 });
 
+test("ping: default bare claude binary is resolved from PATH", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "claude-ping-path-cwd-"));
+  const binDir = mkdtempSync(path.join(tmpdir(), "claude-ping-path-bin-"));
+  writeExecutable(binDir, "claude", `#!/usr/bin/env node
+process.stdout.write(JSON.stringify({
+  type: "result",
+  is_error: false,
+  result: "pong",
+  session_id: "11111111-1111-4111-8111-111111111111",
+  usage: { input_tokens: 1, output_tokens: 1 }
+}) + "\\n");
+process.exit(0);
+`);
+  const { stdout, stderr, status, dataDir } = runCompanionWithPathBinary(
+    ["ping", "--model", "claude-haiku-4-5-20251001"],
+    { cwd: cwd, binDir, env: { ANTHROPIC_API_KEY: "", CLAUDE_API_KEY: "" } },
+  );
+  try {
+    assert.equal(status, 0, stderr || stdout);
+    const result = JSON.parse(stdout);
+    assert.equal(result.status, "ok");
+    assert.equal(result.ready, true);
+  } finally {
+    cleanup(dataDir);
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(binDir, { recursive: true, force: true });
+  }
+});
+
 test("ping: returns status=ok with the mock claude binary", () => {
   const { stdout, status, dataDir } = runCompanion(
     ["ping", "--model", "claude-haiku-4-5-20251001"],
@@ -1898,6 +1943,53 @@ process.exit(1);
     cleanup(dataDir);
     rmSync(cwd, { recursive: true, force: true });
     rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("run: OAuth preflight resolves default bare claude binary from PATH", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "claude-run-oauth-path-cwd-"));
+  seedMinimalRepo(cwd);
+  const binDir = mkdtempSync(path.join(tmpdir(), "claude-run-oauth-path-bin-"));
+  writeExecutable(binDir, "claude", `#!/usr/bin/env node
+if (process.argv.slice(2).join(" ") === "auth status --json") {
+  process.stdout.write(JSON.stringify({
+    loggedIn: true,
+    authMethod: "claude.ai",
+    apiProvider: "firstParty",
+    subscriptionType: "max",
+    email: "user@example.com"
+  }) + "\\n");
+  process.exit(0);
+}
+process.stdout.write(JSON.stringify({
+  type: "result",
+  is_error: true,
+  api_error_status: 401,
+  result: "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+  session_id: "33333333-3333-4333-8333-333333333333",
+  usage: { input_tokens: 0, output_tokens: 0 }
+}) + "\\n");
+process.exit(1);
+`);
+  const { stdout, status, dataDir } = runCompanionWithPathBinary(
+    ["run", "--mode=review", "--foreground", "--lifecycle-events", "jsonl",
+     "--model", "claude-haiku-4-5-20251001", "--cwd", cwd, "--", "review this change"],
+    { cwd, binDir, env: { ANTHROPIC_API_KEY: "", CLAUDE_API_KEY: "" } },
+  );
+  try {
+    assert.equal(status, 2);
+    const lines = stdout.trim().split("\n").map((line) => JSON.parse(line));
+    assert.equal(lines.length, 1, "PATH binary OAuth rejection must be caught before review launch");
+    const [record] = lines;
+    assert.equal(record.error_code, "oauth_inference_rejected");
+    assert.equal(record.external_review.source_content_transmission, "not_sent");
+    assert.equal(record.pid_info, null);
+    assert.equal(record.review_metadata.audit_manifest.review_quality.failed_review_slot, false);
+    assert.doesNotMatch(stdout, /user@example.com/);
+  } finally {
+    cleanup(dataDir);
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(binDir, { recursive: true, force: true });
   }
 });
 

--- a/tests/smoke/claude-companion.smoke.test.mjs
+++ b/tests/smoke/claude-companion.smoke.test.mjs
@@ -1961,6 +1961,39 @@ process.exit(1);
   }
 });
 
+test("doctor: OAuth status empty stdout reports status parse failure", () => {
+  const tmp = mkdtempSync(path.join(tmpdir(), "claude-doctor-oauth-status-empty-"));
+  const binary = writeExecutable(tmp, "claude-oauth-status-empty", `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "auth" && args[1] === "status") {
+  process.exit(0);
+}
+process.stdout.write(JSON.stringify({
+  type: "result",
+  is_error: true,
+  api_error_status: 401,
+  result: "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+  session_id: "33333333-3333-4333-8333-333333333333",
+  usage: { input_tokens: 0, output_tokens: 0 }
+}) + "\\n");
+process.exit(1);
+`);
+  const { stdout, status, dataDir } = runCompanion(
+    ["doctor", "--binary", binary, "--model", "claude-haiku-4-5-20251001"],
+    { cwd: tmpdir(), env: { ANTHROPIC_API_KEY: "", CLAUDE_API_KEY: "" } },
+  );
+  try {
+    assert.equal(status, 2);
+    const result = JSON.parse(stdout);
+    assert.equal(result.status, "not_authed");
+    assert.equal(result.oauth_status?.available, false);
+    assert.equal(result.oauth_status?.detail, "status_parse_failed");
+  } finally {
+    cleanup(dataDir);
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test("run: OAuth inference 401 is rejected before launch, not recorded as a failed review slot", () => {
   const cwd = mkdtempSync(path.join(tmpdir(), "claude-run-oauth-print-401-cwd-"));
   seedMinimalRepo(cwd);
@@ -2105,6 +2138,32 @@ process.exit(1);
     assert.equal(record.pid_info, null);
     assert.equal(record.review_metadata.audit_manifest.review_quality.failed_review_slot, false);
     assert.doesNotMatch(stdout, /user@example.com/);
+  } finally {
+    cleanup(dataDir);
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("run: OAuth preflight spawn failure fails before review launch", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "claude-run-oauth-preflight-spawn-fail-"));
+  seedMinimalRepo(cwd);
+  const missingBinary = path.join(cwd, "missing-claude");
+  const { stdout, status, dataDir } = runCompanion(
+    ["run", "--mode=review", "--foreground", "--lifecycle-events", "jsonl", "--binary", missingBinary,
+     "--model", "claude-haiku-4-5-20251001", "--cwd", cwd, "--", "review this change"],
+    { cwd, env: { ANTHROPIC_API_KEY: "", CLAUDE_API_KEY: "" } },
+  );
+  try {
+    assert.equal(status, 2);
+    const lines = stdout.trim().split("\n").map((line) => JSON.parse(line));
+    assert.equal(lines.length, 1, "preflight spawn failure must not emit external_review_launched");
+    const [record] = lines;
+    assert.equal(record.status, "failed");
+    assert.equal(record.error_code, "spawn_failed");
+    assert.equal(record.pid_info, null);
+    assert.equal(record.external_review.source_content_transmission, "not_sent");
+    assert.equal(record.review_metadata.audit_manifest.error_code, "spawn_failed");
+    assert.equal(record.review_metadata.audit_manifest.review_quality.failed_review_slot, false);
   } finally {
     cleanup(dataDir);
     rmSync(cwd, { recursive: true, force: true });

--- a/tests/smoke/claude-companion.smoke.test.mjs
+++ b/tests/smoke/claude-companion.smoke.test.mjs
@@ -95,6 +95,22 @@ function readOnlyJobRecord(dataDir) {
   return records[0];
 }
 
+async function waitForOnlyJobRecord(dataDir, predicate, label, timeoutMs = CLAUDE_SMOKE_POLL_TIMEOUT_MS) {
+  const deadline = Date.now() + timeoutMs;
+  let lastRecord = null;
+  while (Date.now() < deadline) {
+    try {
+      const { record } = readOnlyJobRecord(dataDir);
+      lastRecord = record;
+      if (predicate(record)) return record;
+    } catch {
+      // The worker may not have written the first record yet.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  assert.fail(`${label}; last record=${JSON.stringify(lastRecord)}`);
+}
+
 // T7.2: review mode's profile has scope=working-tree, which populates via
 // `git ls-files` + copy. Non-git cwds can no longer run review (spec §21.4).
 // Uses fixtureSeedRepo (#16 follow-up 9) so a stale GIT_DIR /
@@ -1621,6 +1637,37 @@ test("ping: returns status=ok with the mock claude binary", () => {
   }
 });
 
+test("ping: parent-relative binary is resolved from caller cwd before tmpdir spawn", () => {
+  const parent = mkdtempSync(path.join(tmpdir(), "claude-ping-parent-relative-parent-"));
+  const cwd = path.join(parent, "work");
+  const binDir = path.join(parent, "bin");
+  mkdirSync(cwd);
+  mkdirSync(binDir);
+  writeExecutable(binDir, "claude", `#!/usr/bin/env node
+process.stdout.write(JSON.stringify({
+  type: "result",
+  is_error: false,
+  result: "pong",
+  session_id: "11111111-1111-4111-8111-111111111111",
+  usage: { input_tokens: 1, output_tokens: 1 }
+}) + "\\n");
+process.exit(0);
+`);
+  const { stdout, stderr, status, dataDir } = runCompanion(
+    ["ping", "--binary", "../bin/claude", "--model", "claude-haiku-4-5-20251001"],
+    { cwd, env: { ANTHROPIC_API_KEY: "", CLAUDE_API_KEY: "" } },
+  );
+  try {
+    assert.equal(status, 0, stderr || stdout);
+    const result = JSON.parse(stdout);
+    assert.equal(result.status, "ok");
+    assert.equal(result.ready, true);
+  } finally {
+    cleanup(dataDir);
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
 test("ping: treats empty successful result as ok", () => {
   const tmp = mkdtempSync(path.join(tmpdir(), "claude-ping-empty-ok-"));
   const binary = writeExecutable(tmp, "claude-empty-ok", `#!/usr/bin/env node
@@ -1961,6 +2008,48 @@ process.exit(1);
   }
 });
 
+test("doctor: OAuth status JSON prefers real status over weak loggedIn prefix", () => {
+  const tmp = mkdtempSync(path.join(tmpdir(), "claude-doctor-oauth-status-loggedin-prefix-"));
+  const binary = writeExecutable(tmp, "claude-oauth-status-loggedin-prefix", `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "auth" && args[1] === "status") {
+  process.stdout.write(JSON.stringify({ loggedIn: false, reason: "refreshing" }) + "\\n");
+  process.stdout.write(JSON.stringify({
+    loggedIn: true,
+    authMethod: "claude.ai",
+    apiProvider: "firstParty",
+    email: "user@example.com",
+    subscriptionType: "max"
+  }) + "\\n");
+  process.exit(0);
+}
+process.stdout.write(JSON.stringify({
+  type: "result",
+  is_error: true,
+  api_error_status: 401,
+  result: "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+  session_id: "33333333-3333-4333-8333-333333333333",
+  usage: { input_tokens: 0, output_tokens: 0 }
+}) + "\\n");
+process.exit(1);
+`);
+  const { stdout, status, dataDir } = runCompanion(
+    ["doctor", "--binary", binary, "--model", "claude-haiku-4-5-20251001"],
+    { cwd: tmpdir(), env: { ANTHROPIC_API_KEY: "", CLAUDE_API_KEY: "" } },
+  );
+  try {
+    assert.equal(status, 2);
+    const result = JSON.parse(stdout);
+    assert.equal(result.status, "oauth_inference_rejected");
+    assert.equal(result.oauth_status?.logged_in, true);
+    assert.equal(result.oauth_status?.subscription_type, "max");
+    assert.doesNotMatch(stdout, /user@example.com/);
+  } finally {
+    cleanup(dataDir);
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test("doctor: OAuth status empty stdout reports status parse failure", () => {
   const tmp = mkdtempSync(path.join(tmpdir(), "claude-doctor-oauth-status-empty-"));
   const binary = writeExecutable(tmp, "claude-oauth-status-empty", `#!/usr/bin/env node
@@ -1988,6 +2077,110 @@ process.exit(1);
     assert.equal(result.status, "not_authed");
     assert.equal(result.oauth_status?.available, false);
     assert.equal(result.oauth_status?.detail, "status_parse_failed");
+  } finally {
+    cleanup(dataDir);
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("doctor: OAuth status nonzero exit reports status failure", () => {
+  const tmp = mkdtempSync(path.join(tmpdir(), "claude-doctor-oauth-status-nonzero-"));
+  const binary = writeExecutable(tmp, "claude-oauth-status-nonzero", `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "auth" && args[1] === "status") {
+  process.stderr.write("auth status failed\\n");
+  process.exit(3);
+}
+process.stdout.write(JSON.stringify({
+  type: "result",
+  is_error: true,
+  api_error_status: 401,
+  result: "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+  session_id: "33333333-3333-4333-8333-333333333333",
+  usage: { input_tokens: 0, output_tokens: 0 }
+}) + "\\n");
+process.exit(1);
+`);
+  const { stdout, status, dataDir } = runCompanion(
+    ["doctor", "--binary", binary, "--model", "claude-haiku-4-5-20251001"],
+    { cwd: tmpdir(), env: { ANTHROPIC_API_KEY: "", CLAUDE_API_KEY: "" } },
+  );
+  try {
+    assert.equal(status, 2);
+    const result = JSON.parse(stdout);
+    assert.equal(result.status, "not_authed");
+    assert.equal(result.oauth_status?.available, false);
+    assert.equal(result.oauth_status?.detail, "status_failed");
+  } finally {
+    cleanup(dataDir);
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("doctor: OAuth status killed by signal reports status failure", () => {
+  const tmp = mkdtempSync(path.join(tmpdir(), "claude-doctor-oauth-status-signal-"));
+  const binary = writeExecutable(tmp, "claude-oauth-status-signal", `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "auth" && args[1] === "status") {
+  process.kill(process.pid, "SIGTERM");
+}
+process.stdout.write(JSON.stringify({
+  type: "result",
+  is_error: true,
+  api_error_status: 401,
+  result: "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+  session_id: "33333333-3333-4333-8333-333333333333",
+  usage: { input_tokens: 0, output_tokens: 0 }
+}) + "\\n");
+process.exit(1);
+`);
+  const { stdout, status, dataDir } = runCompanion(
+    ["doctor", "--binary", binary, "--model", "claude-haiku-4-5-20251001"],
+    { cwd: tmpdir(), env: { ANTHROPIC_API_KEY: "", CLAUDE_API_KEY: "" } },
+  );
+  try {
+    assert.equal(status, 2);
+    const result = JSON.parse(stdout);
+    assert.equal(result.status, "not_authed");
+    assert.equal(result.oauth_status?.available, false);
+    assert.equal(result.oauth_status?.detail, "status_failed");
+  } finally {
+    cleanup(dataDir);
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("doctor: OAuth status missing binary after ping reports not found", () => {
+  const tmp = mkdtempSync(path.join(tmpdir(), "claude-doctor-oauth-status-enoent-"));
+  const binary = writeExecutable(tmp, "claude-oauth-status-enoent", `#!/usr/bin/env node
+const { unlinkSync } = require("node:fs");
+const self = process.argv[1];
+const args = process.argv.slice(2);
+if (args[0] === "auth" && args[1] === "status") {
+  process.stdout.write("unexpected auth status execution\\n");
+  process.exit(0);
+}
+unlinkSync(self);
+process.stdout.write(JSON.stringify({
+  type: "result",
+  is_error: true,
+  api_error_status: 401,
+  result: "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+  session_id: "33333333-3333-4333-8333-333333333333",
+  usage: { input_tokens: 0, output_tokens: 0 }
+}) + "\\n");
+process.exit(1);
+`);
+  const { stdout, status, dataDir } = runCompanion(
+    ["doctor", "--binary", binary, "--model", "claude-haiku-4-5-20251001"],
+    { cwd: tmpdir(), env: { ANTHROPIC_API_KEY: "", CLAUDE_API_KEY: "" } },
+  );
+  try {
+    assert.equal(status, 2);
+    const result = JSON.parse(stdout);
+    assert.equal(result.status, "not_authed");
+    assert.equal(result.oauth_status?.available, false);
+    assert.equal(result.oauth_status?.detail, "not_found");
   } finally {
     cleanup(dataDir);
     rmSync(tmp, { recursive: true, force: true });
@@ -2167,6 +2360,126 @@ test("run: OAuth preflight spawn failure fails before review launch", () => {
   } finally {
     cleanup(dataDir);
     rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("run --background: OAuth preflight rejection finalizes without failed review slot", async () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "claude-bg-oauth-preflight-reject-"));
+  seedMinimalRepo(cwd);
+  const tmp = mkdtempSync(path.join(tmpdir(), "claude-bg-oauth-preflight-reject-bin-"));
+  const countPath = path.join(tmp, "count.txt");
+  const binary = writeExecutable(tmp, "claude-bg-oauth-preflight-reject", `#!/usr/bin/env node
+const { existsSync, readFileSync, writeFileSync } = require("node:fs");
+const countPath = ${JSON.stringify(countPath)};
+const args = process.argv.slice(2);
+if (args[0] === "auth" && args[1] === "status") {
+  process.stdout.write(JSON.stringify({
+    loggedIn: true,
+    authMethod: "claude.ai",
+    apiProvider: "firstParty",
+    subscriptionType: "max",
+    email: "user@example.com"
+  }) + "\\n");
+  process.exit(0);
+}
+const count = existsSync(countPath) ? Number(readFileSync(countPath, "utf8")) : 0;
+writeFileSync(countPath, String(count + 1), "utf8");
+process.stdout.write(JSON.stringify({
+  type: "result",
+  is_error: true,
+  api_error_status: 401,
+  result: "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+  session_id: "33333333-3333-4333-8333-333333333333",
+  usage: { input_tokens: 0, output_tokens: 0 }
+}) + "\\n");
+process.exit(1);
+`);
+  const { stdout, status, stderr, dataDir } = runCompanion(
+    ["run", "--mode=review", "--background", "--binary", binary,
+     "--model", "claude-haiku-4-5-20251001", "--cwd", cwd, "--", "review this change"],
+    { cwd, env: { ANTHROPIC_API_KEY: "", CLAUDE_API_KEY: "" } },
+  );
+  try {
+    assert.equal(status, 0, stderr || stdout);
+    const launched = JSON.parse(stdout);
+    const record = await waitForOnlyJobRecord(
+      dataDir,
+      (candidate) => candidate.id === launched.job_id && candidate.status === "failed",
+      "background OAuth preflight rejection did not finalize",
+    );
+    assert.equal(record.error_code, "oauth_inference_rejected");
+    assert.equal(record.pid_info, null);
+    assert.equal(record.external_review.source_content_transmission, "not_sent");
+    assert.equal(record.review_metadata.audit_manifest.error_code, "oauth_inference_rejected");
+    assert.equal(record.review_metadata.audit_manifest.review_quality.failed_review_slot, false);
+    assert.equal(readFileSync(countPath, "utf8"), "1", "target review must not launch after preflight rejection");
+  } finally {
+    cleanup(dataDir);
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("run --background: cancel during OAuth preflight exits before target launch", async () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "claude-bg-oauth-preflight-cancel-"));
+  seedMinimalRepo(cwd);
+  const tmp = mkdtempSync(path.join(tmpdir(), "claude-bg-oauth-preflight-cancel-bin-"));
+  const countPath = path.join(tmp, "count.txt");
+  const targetLaunchedPath = path.join(tmp, "target-launched.txt");
+  const binary = writeExecutable(tmp, "claude-bg-oauth-preflight-cancel", `#!/usr/bin/env node
+const { existsSync, readFileSync, writeFileSync } = require("node:fs");
+const countPath = ${JSON.stringify(countPath)};
+const targetLaunchedPath = ${JSON.stringify(targetLaunchedPath)};
+const args = process.argv.slice(2);
+if (args[0] === "auth" && args[1] === "status") {
+  process.stdout.write(JSON.stringify({ loggedIn: true, authMethod: "claude.ai", apiProvider: "firstParty" }) + "\\n");
+  process.exit(0);
+}
+const count = existsSync(countPath) ? Number(readFileSync(countPath, "utf8")) : 0;
+writeFileSync(countPath, String(count + 1), "utf8");
+if (count > 0) writeFileSync(targetLaunchedPath, "target launched", "utf8");
+Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 1200);
+process.stdout.write(JSON.stringify({
+  type: "result",
+  is_error: false,
+  result: "pong",
+  session_id: "11111111-1111-4111-8111-111111111111",
+  usage: { input_tokens: 1, output_tokens: 1 }
+}) + "\\n");
+process.exit(0);
+`);
+  const { stdout, status, stderr, dataDir } = runCompanion(
+    ["run", "--mode=review", "--background", "--binary", binary,
+     "--model", "claude-haiku-4-5-20251001", "--cwd", cwd, "--", "review this change"],
+    { cwd, env: { ANTHROPIC_API_KEY: "", CLAUDE_API_KEY: "" } },
+  );
+  try {
+    assert.equal(status, 0, stderr || stdout);
+    const launched = JSON.parse(stdout);
+    const cancelRes = spawnSync("node", [
+      COMPANION,
+      "cancel", "--job", launched.job_id, "--cwd", cwd,
+    ], {
+      cwd,
+      encoding: "utf8",
+      env: { ...process.env, CLAUDE_PLUGIN_DATA: dataDir },
+    });
+    assert.equal(cancelRes.status, 0, cancelRes.stderr || cancelRes.stdout);
+    const cancel = JSON.parse(cancelRes.stdout);
+    assert.equal(cancel.status, "cancel_pending");
+    const record = await waitForOnlyJobRecord(
+      dataDir,
+      (candidate) => candidate.id === launched.job_id && candidate.status === "cancelled",
+      "background job cancelled during OAuth preflight did not finalize as cancelled",
+    );
+    assert.equal(record.error_code, null);
+    assert.equal(record.pid_info, null);
+    assert.equal(record.external_review.source_content_transmission, "not_sent");
+    assert.equal(existsSync(targetLaunchedPath), false);
+  } finally {
+    cleanup(dataDir);
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(tmp, { recursive: true, force: true });
   }
 });
 

--- a/tests/smoke/claude-companion.smoke.test.mjs
+++ b/tests/smoke/claude-companion.smoke.test.mjs
@@ -1569,6 +1569,35 @@ process.exit(0);
   }
 });
 
+test("ping: path-like relative binary is resolved from caller cwd before tmpdir spawn", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "claude-ping-relative-path-cwd-"));
+  const binDir = path.join(cwd, "bin");
+  mkdirSync(binDir);
+  writeExecutable(binDir, "claude", `#!/usr/bin/env node
+process.stdout.write(JSON.stringify({
+  type: "result",
+  is_error: false,
+  result: "pong",
+  session_id: "11111111-1111-4111-8111-111111111111",
+  usage: { input_tokens: 1, output_tokens: 1 }
+}) + "\\n");
+process.exit(0);
+`);
+  const { stdout, stderr, status, dataDir } = runCompanion(
+    ["ping", "--binary", "bin/claude", "--model", "claude-haiku-4-5-20251001"],
+    { cwd, env: { ANTHROPIC_API_KEY: "", CLAUDE_API_KEY: "" } },
+  );
+  try {
+    assert.equal(status, 0, stderr || stdout);
+    const result = JSON.parse(stdout);
+    assert.equal(result.status, "ok");
+    assert.equal(result.ready, true);
+  } finally {
+    cleanup(dataDir);
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test("ping: returns status=ok with the mock claude binary", () => {
   const { stdout, status, dataDir } = runCompanion(
     ["ping", "--model", "claude-haiku-4-5-20251001"],
@@ -1890,6 +1919,48 @@ process.exit(1);
   }
 });
 
+test("doctor: OAuth status JSON skips structured prefix notices", () => {
+  const tmp = mkdtempSync(path.join(tmpdir(), "claude-doctor-oauth-status-prefix-json-"));
+  const binary = writeExecutable(tmp, "claude-oauth-status-prefix-json", `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "auth" && args[1] === "status") {
+  process.stdout.write(JSON.stringify({ event: "refreshing" }) + "\\n");
+  process.stdout.write(JSON.stringify({
+    loggedIn: true,
+    authMethod: "claude.ai",
+    apiProvider: "firstParty",
+    email: "user@example.com",
+    subscriptionType: "max"
+  }) + "\\n");
+  process.exit(0);
+}
+process.stdout.write(JSON.stringify({
+  type: "result",
+  is_error: true,
+  api_error_status: 401,
+  result: "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+  session_id: "33333333-3333-4333-8333-333333333333",
+  usage: { input_tokens: 0, output_tokens: 0 }
+}) + "\\n");
+process.exit(1);
+`);
+  const { stdout, status, dataDir } = runCompanion(
+    ["doctor", "--binary", binary, "--model", "claude-haiku-4-5-20251001"],
+    { cwd: tmpdir(), env: { ANTHROPIC_API_KEY: "", CLAUDE_API_KEY: "" } },
+  );
+  try {
+    assert.equal(status, 2);
+    const result = JSON.parse(stdout);
+    assert.equal(result.status, "oauth_inference_rejected");
+    assert.equal(result.oauth_status?.logged_in, true);
+    assert.equal(result.oauth_status?.subscription_type, "max");
+    assert.doesNotMatch(stdout, /user@example.com/);
+  } finally {
+    cleanup(dataDir);
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test("run: OAuth inference 401 is rejected before launch, not recorded as a failed review slot", () => {
   const cwd = mkdtempSync(path.join(tmpdir(), "claude-run-oauth-print-401-cwd-"));
   seedMinimalRepo(cwd);
@@ -1990,6 +2061,53 @@ process.exit(1);
     cleanup(dataDir);
     rmSync(cwd, { recursive: true, force: true });
     rmSync(binDir, { recursive: true, force: true });
+  }
+});
+
+test("run: OAuth preflight resolves path-like relative binary from invocation cwd", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "claude-run-oauth-pathlike-cwd-"));
+  seedMinimalRepo(cwd);
+  const binDir = path.join(cwd, "bin");
+  mkdirSync(binDir);
+  writeExecutable(binDir, "claude", `#!/usr/bin/env node
+if (process.argv.slice(2).join(" ") === "auth status --json") {
+  process.stdout.write(JSON.stringify({
+    loggedIn: true,
+    authMethod: "claude.ai",
+    apiProvider: "firstParty",
+    subscriptionType: "max",
+    email: "user@example.com"
+  }) + "\\n");
+  process.exit(0);
+}
+process.stdout.write(JSON.stringify({
+  type: "result",
+  is_error: true,
+  api_error_status: 401,
+  result: "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+  session_id: "33333333-3333-4333-8333-333333333333",
+  usage: { input_tokens: 0, output_tokens: 0 }
+}) + "\\n");
+process.exit(1);
+`);
+  const { stdout, status, dataDir } = runCompanion(
+    ["run", "--mode=review", "--foreground", "--lifecycle-events", "jsonl", "--binary", "bin/claude",
+     "--model", "claude-haiku-4-5-20251001", "--cwd", cwd, "--", "review this change"],
+    { cwd, env: { ANTHROPIC_API_KEY: "", CLAUDE_API_KEY: "" } },
+  );
+  try {
+    assert.equal(status, 2);
+    const lines = stdout.trim().split("\n").map((line) => JSON.parse(line));
+    assert.equal(lines.length, 1, "path-like binary OAuth rejection must be caught before review launch");
+    const [record] = lines;
+    assert.equal(record.error_code, "oauth_inference_rejected");
+    assert.equal(record.external_review.source_content_transmission, "not_sent");
+    assert.equal(record.pid_info, null);
+    assert.equal(record.review_metadata.audit_manifest.review_quality.failed_review_slot, false);
+    assert.doesNotMatch(stdout, /user@example.com/);
+  } finally {
+    cleanup(dataDir);
+    rmSync(cwd, { recursive: true, force: true });
   }
 });
 

--- a/tests/smoke/claude-mock.mjs
+++ b/tests/smoke/claude-mock.mjs
@@ -14,6 +14,7 @@ import { readFileSync, existsSync, realpathSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createHash } from "node:crypto";
+import { PING_PROMPT } from "../../plugins/claude/scripts/lib/companion-common.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const FIXTURE_DIR = resolve(HERE, "fixtures/claude");
@@ -208,7 +209,7 @@ if (process.env.CLAUDE_MOCK_LIST_ADDDIR && addDir) {
 // (worktree containment). Keeps the hook additive: leaving the env unset
 // is identical to pre-T7.6 behavior.
 const mutateRel = process.env.CLAUDE_MOCK_MUTATE_FILE;
-const isPingPrompt = prompt === "reply with exactly: pong. Do not use any tools, do not read files, and do not explore the workspace.";
+const isPingPrompt = prompt === PING_PROMPT;
 if (mutateRel && !isPingPrompt) {
   const { writeFileSync: wf, mkdirSync: mk } = await import("node:fs");
   const { isAbsolute, dirname: dn } = await import("node:path");

--- a/tests/smoke/claude-mock.mjs
+++ b/tests/smoke/claude-mock.mjs
@@ -208,7 +208,8 @@ if (process.env.CLAUDE_MOCK_LIST_ADDDIR && addDir) {
 // (worktree containment). Keeps the hook additive: leaving the env unset
 // is identical to pre-T7.6 behavior.
 const mutateRel = process.env.CLAUDE_MOCK_MUTATE_FILE;
-if (mutateRel) {
+const isPingPrompt = prompt === "reply with exactly: pong. Do not use any tools, do not read files, and do not explore the workspace.";
+if (mutateRel && !isPingPrompt) {
   const { writeFileSync: wf, mkdirSync: mk } = await import("node:fs");
   const { isAbsolute, dirname: dn } = await import("node:path");
   let target;

--- a/tests/unit/companion-common.test.mjs
+++ b/tests/unit/companion-common.test.mjs
@@ -441,6 +441,10 @@ test("external-review shared helper covers disclosure and transmission branches"
       "Selected source content was not sent to Provider; the target process was not spawned.",
     );
     assert.equal(
+      mod.externalReviewDisclosure("Provider", "failed", T.NOT_SENT, "oauth_inference_rejected"),
+      "Selected source content was not sent to Provider; OAuth inference readiness was rejected before the review target was started.",
+    );
+    assert.equal(
       mod.externalReviewDisclosure("Provider", "failed", T.NOT_SENT, "unknown_pre_spawn"),
       "Selected source content was not sent to Provider; the target process was not started.",
     );
@@ -483,6 +487,16 @@ test("external-review shared helper covers disclosure and transmission branches"
       errorCode: "spawn_failed",
       pidInfo: null,
     }), T.NOT_SENT);
+    assert.equal(mod.sourceContentTransmissionForExecution({
+      status: "failed",
+      errorCode: "oauth_inference_rejected",
+      pidInfo: null,
+    }), T.NOT_SENT);
+    assert.equal(mod.sourceContentTransmissionForExecution({
+      status: "failed",
+      errorCode: "oauth_inference_rejected",
+      pidInfo: { pid: 1 },
+    }), T.SENT);
     assert.equal(mod.sourceContentTransmissionForExecution({
       status: "cancelled",
       errorCode: null,

--- a/tests/unit/job-record.test.mjs
+++ b/tests/unit/job-record.test.mjs
@@ -664,6 +664,18 @@ test("isOAuthInferenceRejected fails closed without auth context", () => {
   assert.equal(isOAuthInferenceRejected(execution), false);
 });
 
+test("isOAuthInferenceRejected fails closed when auth path is absent", () => {
+  const execution = {
+    parsed: {
+      ok: false,
+      result: "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+      raw: { api_error_status: 401 },
+    },
+  };
+
+  assert.equal(isOAuthInferenceRejected(execution, {}), false);
+});
+
 test("buildJobRecord: API-key 401 is not classified as OAuth inference rejection", () => {
   const rec = buildJobRecord(makeInvocation({
     auth_mode: "api_key",

--- a/tests/unit/job-record.test.mjs
+++ b/tests/unit/job-record.test.mjs
@@ -701,6 +701,31 @@ test("buildJobRecord: API-key 401 is not classified as OAuth inference rejection
   assert.equal(rec.external_review.source_content_transmission, "sent");
 });
 
+test("buildJobRecord: missing API-key path 401 is not classified as OAuth inference rejection", () => {
+  const rec = buildJobRecord(makeInvocation({
+    auth_mode: "api_key",
+    selected_auth_path: "api_key_env_missing",
+  }), {
+    exitCode: 1,
+    parsed: {
+      ok: false,
+      reason: "is_error",
+      result: "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+      raw: { api_error_status: 401 },
+      structured: null,
+      denials: [],
+      costUsd: null,
+      usage: null,
+    },
+    pidInfo: makePidInfo(),
+    claudeSessionId: null,
+    stdout: "", stderr: "",
+  }, []);
+  assert.equal(rec.status, "failed");
+  assert.equal(rec.error_code, "claude_error");
+  assert.equal(rec.external_review.source_content_transmission, "sent");
+});
+
 test("gemini buildJobRecord: failure path uses gemini_error, not claude_error", () => {
   const rec = buildGeminiJobRecord(makeInvocation({
     target: "gemini",

--- a/tests/unit/job-record.test.mjs
+++ b/tests/unit/job-record.test.mjs
@@ -14,6 +14,7 @@ import { dirname, resolve as resolvePath } from "node:path";
 import {
   buildJobRecord,
   EXPECTED_KEYS,
+  isOAuthInferenceRejected,
   SCHEMA_VERSION,
 } from "../../plugins/claude/scripts/lib/job-record.mjs";
 import {
@@ -644,11 +645,23 @@ test("buildJobRecord: OAuth inference 401 is distinct from generic claude_error"
   assert.equal(rec.error_code, "oauth_inference_rejected");
   assert.match(rec.error_summary, /OAuth non-interactive inference was rejected/i);
   assert.match(rec.error_cause, /HTTP 401/i);
-  assert.match(rec.error_cause, /review source is not sent/i);
+  assert.doesNotMatch(rec.error_cause, /not sent/i);
   assert.match(rec.suggested_action, /\/claude-setup/);
   assert.match(rec.suggested_action, /OAuth-only `claude -p` inference/i);
   assert.equal(rec.external_review.source_content_transmission, "sent");
   assert.equal(rec.external_review.disclosure, sentButNoCleanResult("Claude Code"));
+});
+
+test("isOAuthInferenceRejected fails closed without auth context", () => {
+  const execution = {
+    parsed: {
+      ok: false,
+      result: "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+      raw: { api_error_status: 401 },
+    },
+  };
+
+  assert.equal(isOAuthInferenceRejected(execution), false);
 });
 
 test("buildJobRecord: API-key 401 is not classified as OAuth inference rejection", () => {

--- a/tests/unit/job-record.test.mjs
+++ b/tests/unit/job-record.test.mjs
@@ -620,6 +620,62 @@ test("buildJobRecord: failure path — claude exited non-zero", () => {
   assert.equal(rec.external_review.disclosure, sentButNoCleanResult("Claude Code"));
 });
 
+test("buildJobRecord: OAuth inference 401 is distinct from generic claude_error", () => {
+  const rec = buildJobRecord(makeInvocation({
+    auth_mode: "auto",
+    selected_auth_path: "subscription_oauth",
+  }), {
+    exitCode: 1,
+    parsed: {
+      ok: false,
+      reason: "is_error",
+      result: "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+      raw: { api_error_status: 401 },
+      structured: null,
+      denials: [],
+      costUsd: null,
+      usage: null,
+    },
+    pidInfo: makePidInfo(),
+    claudeSessionId: null,
+    stdout: "", stderr: "",
+  }, []);
+  assert.equal(rec.status, "failed");
+  assert.equal(rec.error_code, "oauth_inference_rejected");
+  assert.match(rec.error_summary, /OAuth non-interactive inference was rejected/i);
+  assert.match(rec.error_cause, /HTTP 401/i);
+  assert.match(rec.error_cause, /review source is not sent/i);
+  assert.match(rec.suggested_action, /\/claude-setup/);
+  assert.match(rec.suggested_action, /OAuth-only `claude -p` inference/i);
+  assert.equal(rec.external_review.source_content_transmission, "sent");
+  assert.equal(rec.external_review.disclosure, sentButNoCleanResult("Claude Code"));
+});
+
+test("buildJobRecord: API-key 401 is not classified as OAuth inference rejection", () => {
+  const rec = buildJobRecord(makeInvocation({
+    auth_mode: "api_key",
+    selected_auth_path: "api_key_env",
+  }), {
+    exitCode: 1,
+    parsed: {
+      ok: false,
+      reason: "is_error",
+      result: "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+      raw: { api_error_status: 401 },
+      structured: null,
+      denials: [],
+      costUsd: null,
+      usage: null,
+    },
+    pidInfo: makePidInfo(),
+    claudeSessionId: null,
+    stdout: "", stderr: "",
+  }, []);
+  assert.equal(rec.status, "failed");
+  assert.equal(rec.error_code, "claude_error");
+  assert.equal(rec.external_review.source_content_transmission, "sent");
+});
+
 test("gemini buildJobRecord: failure path uses gemini_error, not claude_error", () => {
   const rec = buildGeminiJobRecord(makeInvocation({
     target: "gemini",

--- a/tests/unit/process.test.mjs
+++ b/tests/unit/process.test.mjs
@@ -31,7 +31,7 @@ test("runCommand: supports bounded spawnSync timeouts", () => {
     "setTimeout(() => {}, 1000)",
   ], { timeout: 50 });
 
-  assert.equal(result.status, 0);
+  assert.equal(result.status, null);
   assert.equal(result.error?.code, "ETIMEDOUT");
 });
 

--- a/tests/unit/process.test.mjs
+++ b/tests/unit/process.test.mjs
@@ -25,6 +25,16 @@ test("runCommand: captures stdout, stderr, status, and command metadata", () => 
   assert.equal(result.error, null);
 });
 
+test("runCommand: supports bounded spawnSync timeouts", () => {
+  const result = runCommand(process.execPath, [
+    "-e",
+    "setTimeout(() => {}, 1000)",
+  ], { timeout: 50 });
+
+  assert.equal(result.status, 0);
+  assert.equal(result.error?.code, "ETIMEDOUT");
+});
+
 test("runCommandChecked: returns successful result and throws formatted failures", () => {
   const ok = runCommandChecked(process.execPath, ["-e", "process.stdout.write('ok')"]);
   assert.equal(ok.stdout, "ok");


### PR DESCRIPTION
## Summary

Restores the Claude OAuth-only readiness fix from PR #94 after the clean-slate reset in PR #102.

This PR reapplies the original PR #94 work onto current `main` and includes current PR #104 review refinements:

- classify Claude subscription/OAuth print-mode HTTP 401 as `oauth_inference_rejected` instead of generic `claude_error`
- make `claude-companion doctor` cross-check `claude auth status --json` when OAuth inference fails, while sanitizing email/org values from output
- use the shared OAuth 401 classifier across preflight, ping, post-spawn JobRecord, and audit-manifest paths
- parse `claude auth status --json` output by balanced JSON object extraction and auth-status semantic filtering so trailing notices and structured prefix notices cannot hide OAuth readiness failures
- isolate OAuth inference ping probes from repository cwd while preserving default PATH lookup, explicit relative paths like `./claude`, and path-like relative binaries like `bin/claude`
- preserve signal/timeout `runCommand()` status as `null` instead of normalizing it to `0`, across Claude/Gemini/Kimi mirrored process helpers
- refactor Sonar-flagged nested/complex review-status, auth-status, JSON-scanning, ping, and JobRecord classification logic without changing behavior
- keep external-review source transmission accurate for preflight and post-spawn failed review slots and restore Grok sync coverage in `sync-external-review.mjs`

Closes #93.

## Context

PR #94 originally implemented this fix and was merged without the requested approval boundary. PR #100 then reverted PR #94 and added two collateral follow-up commits. PR #102 restored the repository tree to the exact pre-PR #94 baseline, removing both PR #94 and PR #100 collateral work from `main`.

This PR is the clean replacement for the #93 fix after that reset. It started from the original PR #94 final tree and now includes only PR #104 review refinements for the same Claude OAuth readiness surface.

## Exact Lineage

- Current base `main`: `a96ed61dec534c29529c2ae2c38c7b6f6fb7b826`
- Current head: `229a43cb0355105d6fb39544cdc2325442a39ea4`
- Original PR #94 base: `7f775882e156843e251560e9b5e81dcf45112e90`
- Original PR #94 head: `e452ea2dfe45dd4bb7b01e8ae0eb03fab79de7b4`
- Recreated commits on this branch:
  - `66a22e0` from original `ebace9fdadf5060612a32d93ff6371d80e7e0486`
  - `8949718` from original `e452ea2dfe45dd4bb7b01e8ae0eb03fab79de7b4`
  - `a308ad2` hardens Claude OAuth preflight failures found during internal review
  - `d4b5c5e` aligns OAuth readiness classification and auth-status JSON parsing found during full path review
  - `773564b` addresses relayed external review blockers from Kimi, GLM, Gemini, and DeepSeek
  - `3fe4ba2` resolves validated Sonar, Gemini Code Assist, and Greptile review findings with systematic refactors and the process timeout-status contract fix
  - `0146753` preserves PATH lookup for default bare `claude` while keeping tmpdir probe isolation and relative-binary support
  - `229a43c` hardens path-like binary resolution, structured auth-status JSON selection, and `cmdPing` control flow after internal adversarial review

## Verification

Run on current head `229a43cb0355105d6fb39544cdc2325442a39ea4`:

- `node --test --test-name-pattern "path-like relative binary|structured prefix notices|default bare claude binary|relative binary" tests/smoke/claude-companion.smoke.test.mjs` -> 6 pass, 0 fail
- `node --test tests/unit/job-record.test.mjs tests/unit/process.test.mjs` -> 74 pass, 0 fail
- `node --test --test-name-pattern "OAuth|audit manifest|doctor|ping" tests/smoke/claude-companion.smoke.test.mjs` -> 27 pass, 0 fail
- `git diff --check` -> pass
- `npm run lint:sync` -> pass
- `npm test` before commit -> 1034 tests, 1028 pass, 0 fail, 6 skipped
- pre-commit `npm test` -> 1034 tests, 1028 pass, 0 fail, 6 skipped

Earlier verification on head `0146753a69e4610ba91319a03d84513487c6254a`:

- `node --test --test-name-pattern "default bare claude binary|relative binary" tests/smoke/claude-companion.smoke.test.mjs` -> 3 pass, 0 fail
- `node --test --test-name-pattern "OAuth|audit manifest|doctor|ping" tests/smoke/claude-companion.smoke.test.mjs` -> 24 pass, 0 fail
- `git diff --check` -> pass
- `npm run lint:sync` -> pass
- `npm test` before commit -> 1031 tests, 1025 pass, 0 fail, 6 skipped
- pre-commit `npm test` -> 1031 tests, 1025 pass, 0 fail, 6 skipped
- GitHub CI on `0146753` -> pass for SonarCloud Code Analysis, lint, test, smoke (claude), smoke (gemini), smoke (kimi), smoke (grok), smoke (api-reviewers)

Earlier verification on head `3fe4ba2bad9e7480b8e188bc52708aae52b5ddd6`:

- `node --test tests/unit/job-record.test.mjs tests/unit/process.test.mjs` -> 74 pass, 0 fail
- `node --test --test-name-pattern "OAuth|audit manifest|doctor|ping" tests/smoke/claude-companion.smoke.test.mjs` -> 22 pass, 0 fail
- `npm run lint:sync` -> pass
- `git diff --check` -> pass
- process helper mirror parity:
  - `cmp -s plugins/claude/scripts/lib/process.mjs plugins/gemini/scripts/lib/process.mjs` -> 0
  - `cmp -s plugins/claude/scripts/lib/process.mjs plugins/kimi/scripts/lib/process.mjs` -> 0
- `npm test` before commit -> 1029 tests, 1023 pass, 0 fail, 6 skipped
- pre-commit `npm test` -> 1029 tests, 1023 pass, 0 fail, 6 skipped
- GitHub CI on `3fe4ba2` -> pass for SonarCloud Code Analysis, lint, test, smoke (claude), smoke (gemini), smoke (kimi), smoke (grok), smoke (api-reviewers)
- Sonar API after `3fe4ba2` analysis: `total: 0`, `issues: []` for `pullRequest=104&issueStatuses=OPEN,CONFIRMED&sinceLeakPeriod=true`

Earlier verification on head `773564b27a16a65f629e62f1fc2cf62f8650be58`:

- `node --test --test-name-pattern "isOAuthInferenceRejected fails closed without auth context|buildJobRecord: OAuth inference 401 is distinct from generic claude_error" tests/unit/job-record.test.mjs` -> 2 pass, 0 fail
- `node --test --test-name-pattern "audit manifest uses canonical claude_error" tests/smoke/claude-companion.smoke.test.mjs` -> 1 pass, 0 fail
- `node --test --test-name-pattern "doctor: OAuth status success but non-interactive inference 401 is classified distinctly|run: OAuth preflight auth-status resolves relative binary from invocation cwd" tests/smoke/claude-companion.smoke.test.mjs` -> 2 pass, 0 fail
- `node --test tests/unit/job-record.test.mjs` -> 65 pass, 0 fail
- `node --test --test-name-pattern "OAuth|audit manifest|doctor|ping" tests/smoke/claude-companion.smoke.test.mjs` -> 22 pass, 0 fail
- `git diff --check` -> pass
- `npm run lint:sync` -> pass
- `npm test` first run -> 1029 tests, 1022 pass, 1 fail, 6 skipped; failed `sync-browser-session preserves grok2api_timeout during mid-import hangs` with `grok2api_unreachable` instead of `grok2api_timeout`
- Rerun of exact failed Grok smoke -> 1 pass, 0 fail
- `npm test` second run -> 1029 tests, 1023 pass, 0 fail, 6 skipped
- pre-commit `npm test` -> 1029 tests, 1023 pass, 0 fail, 6 skipped

Earlier verification on head `d4b5c5eb30df8092eac6651f43bc08cbc32b1aaf`:

- `git diff --check` -> pass
- `npm run lint:sync` -> pass
- `node --test --test-name-pattern "doctor: OAuth status JSON tolerates trailing notices with braces|run: post-spawn OAuth inference 401 is mirrored into audit manifest" tests/smoke/claude-companion.smoke.test.mjs` -> 2 pass, 0 fail
- `node --test --test-name-pattern "OAuth" tests/smoke/claude-companion.smoke.test.mjs` -> 7 pass, 0 fail
- `node --test tests/smoke/claude-companion.smoke.test.mjs` -> 68 pass, 0 fail
- `node --test tests/unit/job-record.test.mjs tests/unit/process.test.mjs` -> 73 pass, 0 fail
- `npm test` -> 1027 tests, 1021 pass, 0 fail, 6 skipped
- pre-commit `npm test` -> 1027 tests, 1021 pass, 0 fail, 6 skipped

Initial recreated-PR verification before refinements:

- `git diff --name-only e452ea2dfe45dd4bb7b01e8ae0eb03fab79de7b4 HEAD` -> empty output at recreated head `89497185fbaba0a359c4c08249aa86791b1bcc74`
- `env -u ANTHROPIC_API_KEY -u CLAUDE_API_KEY claude auth status --json | node -e ...` confirmed sanitized auth-status field shape during original PR #94 verification

## Comment Resolution

- Greptile `parseJsonObjectOutput` trailing-brace comment: fixed and replied with evidence at comment IDs `3195303626` and `3195850149`; thread resolved by Greptile.
- Gemini Code Assist structured OAuth classifier comment: fixed by exporting/reusing `isOAuthInferenceRejected()` and canonical `classifyExecution()`; replied with evidence at comment IDs `3195315726` and `3195852203`; thread resolved.
- Greptile timeout assertion comment: fixed by preserving raw `spawnSync` timeout/signal `status: null` in Claude/Gemini/Kimi process helpers and updating `tests/unit/process.test.mjs`; replied with evidence at comment IDs `3195371884` and `3195851208`; thread resolved.
- SonarCloud new issues: API result after `3fe4ba2` was `total: 0`, `issues: []`; evidence posted in top-level comment `4388649159`.
- Relayed Kimi/DeepSeek blocker on `3fe4ba2` for default bare `claude` PATH lookup: fixed in `0146753` by resolving only explicit relative binaries and adding PATH-based ping and run-preflight smoke tests.
- Internal adversarial review findings after `0146753`: fixed in `229a43c` by resolving path-like relative binaries such as `bin/claude`, filtering balanced JSON candidates to auth-status-shaped objects, making `cmdPing` helper exits explicit with `return`, using optional chaining on the parsed-missing fallback, and passing a named auth-selection classifier context to `isOAuthInferenceRejected()`.

## Relayed External Review Status

Reviews relayed for stale head `3fe4ba2bad9e7480b8e188bc52708aae52b5ddd6`:

- GLM: APPROVE. No blockers.
- Claude: APPROVE. No blockers.
- Gemini: APPROVE. No blockers.
- Kimi: DO NOT APPROVE. Blocking finding: unconditional `resolvePath()` broke PATH lookup for default bare `claude`, breaking `ping`/`doctor` and silently skipping OAuth run preflight. Addressed in `0146753`.
- DeepSeek: DO NOT APPROVE. Same blocking finding: PATH binary resolution regression. Addressed in `0146753`.

Reviews relayed for stale head `d4b5c5eb30df8092eac6651f43bc08cbc32b1aaf`:

- Kimi: DO NOT APPROVE. Blocking finding: `isOAuthInferenceRejected()` failed open without invocation/auth context. Addressed in `773564b` by returning `false` when auth context is absent and adding a unit test.
- GLM: DO NOT APPROVE. Blocking finding: `review_metadata.audit_manifest.error_code` used parsed reason instead of canonical `classifyExecution()` output for non-OAuth failures. Addressed in `773564b` by exporting/reusing `classifyExecution()` and adding a smoke test for canonical `claude_error`.
- Gemini: DO NOT APPROVE. Blocking finding: OAuth inference ping probes ran from repo/caller cwd and could trigger large-repo startup/indexing timeout. Addressed in `773564b` by running inference probes in `tmpdir()` with relative binary resolution preserved and adding cwd-isolation smoke assertions.
- DeepSeek: DO NOT APPROVE. Blocking finding: OAuth diagnostic text said source was not sent even for post-spawn OAuth 401 where source transmission was `sent`. Addressed in `773564b` by removing the source-transmission claim from the generic OAuth diagnostic and updating the unit assertion.
- Claude: APPROVE on stale head `d4b5c5e`; also identified the null-auth-context footgun as non-blocking. Superseded by `773564b`.

No latest-head external/adversarial review has been run on current head `229a43cb0355105d6fb39544cdc2325442a39ea4`.