### PR TITLE
chore: gitignore spec-kit and per-developer agent artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,17 @@ coverage/
 .env.*
 !.env.example
 .claude/findings/
+
+# Per-developer agent tooling (spec-kit, mattpocock skills, aider cache)
+.specify/
+.opencode/
+.pi/
+.gemini/
+.claude/skills/speckit-*
+.codex/prompts/speckit-*
+.agents/
+AGENTS.md
+GEMINI.md
+.aider.chat.history.md
+.aider.input.history
+.aider.tags.cache.v4/


### PR DESCRIPTION
## Summary

Project is intended for OSS distribution, so per-developer tooling shouldn't be tracked. Adds gitignore patterns covering spec-kit artifacts, mattpocock skills, and aider local cache.

The earlier transient commit (d489bbd) that tracked these was reset locally and replaced with this gitignore-only commit.

## Patterns added to .gitignore

- spec-kit artifacts (per-developer tooling)
- mattpocock skills directory
- spec-kit context appendix files (AGENTS.md, GEMINI.md)
- aider local cache files

## Context

Tooling install for spec-kit + plandex + skills was applied to bolt-v2, claude-config, and this repo during the same session. Full log at seungpyoson/claude-config#764.

## Test plan

- [ ] After merge, `git status` in a fresh clone with spec-kit installed shows clean working tree
- [ ] Spec-kit slash commands still work locally (files exist on disk, just not tracked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
