### PR TITLE
#133: add .no-mistakes.yaml with deterministic test/lint commands

### DIFF
--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -7,11 +7,17 @@
 # a per-developer choice rather than a repo-wide one.
 
 commands:
-  # Fast subset (~40s) so the pre-commit gate stays under 60s.
-  # Set `CODEX_PLUGIN_FULL_TESTS=1` (or use `npm run test:full`) for the
-  # full unit matrix — see CLAUDE.md for the rationale.
-  test: "npm test"
+  # Full unit matrix (~140s+) — matches CLAUDE.md's "run npm run test:full
+  # locally before opening a PR" guidance. no-mistakes runs at the
+  # `git push` gate, so this is the right place for the strict gate.
+  # The faster `npm test` (default fast subset, ~40s) still runs in the
+  # pre-commit hook for incremental commits.
+  test: "npm run test:full"
 
   # Manifest/sync linter — verifies generated artifacts and config
   # invariants. See package.json:scripts.lint.
   lint: "npm run lint"
+  # commands.format intentionally omitted — repo has no formatter
+  # configured (no `format` script in package.json, no prettier/biome
+  # config). If a formatter is adopted later, wire it here so AI-driven
+  # auto-fixes normalize before commit.

--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -1,0 +1,17 @@
+# no-mistakes per-repo configuration
+# See: https://kunchenguid.github.io/no-mistakes/reference/repo-config/
+#
+# `agent:` is intentionally omitted so the gate inherits from
+# `~/.no-mistakes/config.yaml`'s global `agent:` field. That keeps the
+# active agent (e.g., pi → GLM Coding Plan, acp:kimi → Kimi Coding Plan)
+# a per-developer choice rather than a repo-wide one.
+
+commands:
+  # Fast subset (~40s) so the pre-commit gate stays under 60s.
+  # Set `CODEX_PLUGIN_FULL_TESTS=1` (or use `npm run test:full`) for the
+  # full unit matrix — see CLAUDE.md for the rationale.
+  test: "npm test"
+
+  # Manifest/sync linter — verifies generated artifacts and config
+  # invariants. See package.json:scripts.lint.
+  lint: "npm run lint"


### PR DESCRIPTION
## Summary

Adds `.no-mistakes.yaml` at the repo root that binds the no-mistakes pipeline's `test` and `lint` steps to deterministic `package.json` scripts:

```yaml
commands:
  test: "npm run test:full"
  lint: "npm run lint"
```

`agent:` is intentionally omitted — the gate inherits from each developer's global `~/.no-mistakes/config.yaml`, so per-developer agent choice (pi/GLM, acp:kimi, claude, codex) is preserved.

## Why

Without this file, `no-mistakes rerun` falls back to "ask the agent to figure out tests/lint" — a fragile agent-driven path that burns reasoning tokens and previously failed end-to-end on `fix/131-review-quality`:

```text
run 01KR5HB42PGSMN6YKSTPT97JNY:
  step test failed: agent run tests: acpx exited: signal: killed
```

The failure was downstream at the test step where no deterministic command was wired. Binding `commands.test` to `npm run test:full` removes the agent-driven discovery path and uses the repository's full test command as the exit-code contract.

Closes #133.

## Test plan

- [x] `npm run test:full` is the merged no-mistakes test command.
- [x] `npm run lint` is the merged no-mistakes lint command.
- [x] Follow-up branch `fix/131-review-quality` updates `npm run lint` to include `lint:sync`, so the no-mistakes lint command covers manifest and sync checks.
- [x] Follow-up branch `fix/131-review-quality` updates `.no-mistakes.yaml` test command to `npm ci && npm run lint && npm run test:full`, so dependencies are bootstrapped and sync checks run before the full matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)