### PR TITLE
feat(review): add multi-provider status panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@
   filters by canonical workspace, and renders the provider panel without a
   manual JSON file argument.
 
+### Fixed
+
+- `operatorState` now only surfaces `approval_required` when the job status is
+  strictly `"failed"`; running or queued jobs with stale approval_required
+  error codes now correctly show their live `running`/`source_sent_waiting`
+  state instead.
+- `resultSummary` returns `"-"` for running and queued jobs before any other
+  check, preventing stale `failed_review_slot` results from leaking into the
+  panel for jobs that are still in progress.
+- `recordWorkspaceMatches` excludes records that lack workspace metadata
+  (`workspace_root` / `workspaceRoot`), instead of incorrectly admitting them
+  into workspace-filtered collections.
+
 ### Changed
 
 - Review panel rows now include Job ID, operator State, Sent, Elapsed ms,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,12 @@
   into workspace-filtered collections.
 - `recordWorkspaceMatches` skips malformed non-string workspace metadata
   instead of aborting the whole provider panel.
-- Review panel fallback discovery now matches direct-provider lexical data-root
-  hashing and companion git-root state directories, so default discovery works
-  across symlinked workspaces and git subdirectories.
+- Review panel fallback discovery now scans provider state roots and filters by
+  stored workspace metadata, so default discovery works across symlinked
+  workspaces without depending on matching slug/hash algorithms.
+- Review panel `--workspace` subdirectory matching now requires an ancestor
+  workspace record to point at a real Git repository; non-Git workspaces still
+  match when the panel is run from the exact recorded workspace path.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,19 @@
 
 ## Unreleased
 
+### Added
+
+- Added `--workspace` mode to the review panel CLI (`scripts/review-panel.mjs`)
+  that aggregates live/recent JobRecords across all provider state roots,
+  filters by canonical workspace, and renders the provider panel without a
+  manual JSON file argument.
+
 ### Changed
+
+- Review panel rows now include Job ID, operator State, Sent, Elapsed ms,
+  Timeout ms, and Result columns to surface per-job identity, operational
+  phase, configured timeout, and verdict/error summary alongside the existing
+  readiness, terminal status, semantic, inspection, and reason columns.
 
 - Added Kimi Code CLI as a third plugin with setup, preflight, review,
   adversarial-review, custom-review, rescue, status, result, cancel, mock smoke

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,16 +18,28 @@
 - `resultSummary` returns `"-"` for running and queued jobs before any other
   check, preventing stale `failed_review_slot` results from leaking into the
   panel for jobs that are still in progress.
+- Running and queued review panel rows now also suppress stale semantic failure
+  and reason fields, and failed jobs now prioritize the current `error_code`
+  over stale semantic failed-slot metadata in the Result column.
+- Failed review panel states now preserve specific pre-send operational causes
+  such as `provider_unavailable`, `auth_session_failure`, `rate_limited`, and
+  `usage_limited` before falling back to `failed_before_source_send`.
 - `recordWorkspaceMatches` excludes records that lack workspace metadata
   (`workspace_root` / `workspaceRoot`), instead of incorrectly admitting them
   into workspace-filtered collections.
+- `recordWorkspaceMatches` skips malformed non-string workspace metadata
+  instead of aborting the whole provider panel.
+- Review panel fallback discovery now matches direct-provider lexical data-root
+  hashing and companion git-root state directories, so default discovery works
+  across symlinked workspaces and git subdirectories.
 
 ### Changed
 
 - Review panel rows now include Job ID, operator State, Sent, Elapsed ms,
   Timeout ms, and Result columns to surface per-job identity, operational
   phase, configured timeout, and verdict/error summary alongside the existing
-  readiness, terminal status, semantic, inspection, and reason columns.
+  readiness, terminal status, semantic, inspection, Error Code, HTTP, and reason
+  columns.
 
 - Added Kimi Code CLI as a third plugin with setup, preflight, review,
   adversarial-review, custom-review, rescue, status, result, cancel, mock smoke

--- a/README.md
+++ b/README.md
@@ -216,6 +216,9 @@ readiness, terminal status, semantic failed-slot state, inspection state, error
 code, HTTP status, and semantic failure reasons. It aggregates Claude, Gemini,
 Kimi, Grok, and API Reviewers persisted JobRecords from their plugin data roots;
 DeepSeek and GLM appear as sub-providers from the API Reviewers root.
+When `--workspace` points inside a recorded workspace, the ancestor record is
+included only if that ancestor is a real Git repository; non-Git workspaces are
+matched by their exact recorded path.
 A provider that is running, blocked before source send, waiting after source
 send, timed out, unavailable, approval-gated, completed, or completed with a
 failed review slot must appear as an explicit row instead of being buried in

--- a/README.md
+++ b/README.md
@@ -214,7 +214,8 @@ The panel shows one row per provider job with provider, job id, operator state,
 source transmission, elapsed/configured timeout, verdict/error summary,
 readiness, terminal status, semantic failed-slot state, inspection state, error
 code, HTTP status, and semantic failure reasons. It aggregates Claude, Gemini,
-Kimi, Grok, DeepSeek, and GLM persisted JobRecords from their plugin data roots.
+Kimi, Grok, and API Reviewers persisted JobRecords from their plugin data roots;
+DeepSeek and GLM appear as sub-providers from the API Reviewers root.
 A provider that is running, blocked before source send, waiting after source
 send, timed out, unavailable, approval-gated, completed, or completed with a
 failed review slot must appear as an explicit row instead of being buried in

--- a/README.md
+++ b/README.md
@@ -204,11 +204,21 @@ Render collected JobRecords into a provider panel before judging quality:
 node scripts/review-panel.mjs /path/to/job-records.json
 ```
 
-The panel shows one row per provider with readiness, status, source
-transmission, elapsed milliseconds, semantic failed-slot state, inspection
-state, error code, HTTP status, and semantic failure reasons. A provider that
-could not inspect files, returned shallow output, or hit Grok chat/session
-readiness must appear as a failed row instead of being buried in prose.
+Render the live/recent multi-provider panel for the current workspace:
+
+```bash
+node scripts/review-panel.mjs --workspace .
+```
+
+The panel shows one row per provider job with provider, job id, operator state,
+source transmission, elapsed/configured timeout, verdict/error summary,
+readiness, terminal status, semantic failed-slot state, inspection state, error
+code, HTTP status, and semantic failure reasons. It aggregates Claude, Gemini,
+Kimi, Grok, DeepSeek, and GLM persisted JobRecords from their plugin data roots.
+A provider that is running, blocked before source send, waiting after source
+send, timed out, unavailable, approval-gated, completed, or completed with a
+failed review slot must appear as an explicit row instead of being buried in
+background terminal counts or prose.
 
 ## Install
 

--- a/docs/architecture-record.md
+++ b/docs/architecture-record.md
@@ -64,8 +64,9 @@ keys are deliberately separate so manual relay and plugin runs can use the same
 review contract without leaking expected findings into the model prompt.
 
 Provider panels are rendered from JobRecords with `scripts/review-panel.mjs`.
-The panel row is the user-facing reliability surface: provider readiness,
-terminal status, source transmission, elapsed time, semantic failed-slot state,
+The panel row is the user-facing reliability surface: provider, Job ID,
+operator State, source transmission (Sent), elapsed/configured timeout,
+verdict/error Result, readiness, terminal status, semantic failed-slot state,
 inspection state, error code, HTTP status, and semantic failure reasons must be
 visible together so broken review slots are not hidden behind result prose.
 

--- a/docs/architecture-record.md
+++ b/docs/architecture-record.md
@@ -69,9 +69,10 @@ operator State, source transmission (Sent), elapsed/configured timeout,
 verdict/error Result, readiness, terminal status, semantic failed-slot state,
 inspection state, error code, HTTP status, and semantic failure reasons must be
 visible together so broken review slots are not hidden behind result prose.
-The `--workspace` discovery path treats companion records as repo-root scoped
-and direct-provider fallback records as provider-data-root scoped, matching the
-paths each writer uses when no explicit plugin data root is configured.
+The `--workspace` discovery path scans companion state directories and filters
+by stored workspace root, while direct-provider fallback records stay
+provider-data-root scoped to match the paths each writer uses when no explicit
+plugin data root is configured.
 
 ### Identity Types Stay Distinct
 

--- a/docs/architecture-record.md
+++ b/docs/architecture-record.md
@@ -69,6 +69,9 @@ operator State, source transmission (Sent), elapsed/configured timeout,
 verdict/error Result, readiness, terminal status, semantic failed-slot state,
 inspection state, error code, HTTP status, and semantic failure reasons must be
 visible together so broken review slots are not hidden behind result prose.
+The `--workspace` discovery path treats companion records as repo-root scoped
+and direct-provider fallback records as provider-data-root scoped, matching the
+paths each writer uses when no explicit plugin data root is configured.
 
 ### Identity Types Stay Distinct
 

--- a/docs/architecture-record.md
+++ b/docs/architecture-record.md
@@ -72,7 +72,9 @@ visible together so broken review slots are not hidden behind result prose.
 The `--workspace` discovery path scans companion state directories and filters
 by stored workspace root, while direct-provider fallback records stay
 provider-data-root scoped to match the paths each writer uses when no explicit
-plugin data root is configured.
+plugin data root is configured. A record whose workspace root is an ancestor of
+the requested workspace is included only when that ancestor is a real Git
+repository; non-Git workspaces match only by exact recorded path.
 
 ### Identity Types Stay Distinct
 

--- a/scripts/lib/review-panel.mjs
+++ b/scripts/lib/review-panel.mjs
@@ -6,8 +6,8 @@ import { basename, join, resolve } from "node:path";
 
 const PROVIDER_ORDER = ["claude", "gemini", "kimi", "grok", "deepseek", "glm"];
 const VERDICT_RE = /\bVerdict:\s*(APPROVE|REQUEST CHANGES|FAIL|REJECT)\b/i;
-const PROVIDER_UNAVAILABLE_CODES = ["provider_unavailable", "spawn_failed", "claude_error", "gemini_error", "kimi_error", "tunnel_unavailable"];
-const AUTH_FAILURE_CODES = ["not_authed", "oauth_inference_rejected", "auth_not_configured", "session_expired"];
+const PROVIDER_UNAVAILABLE_CODES = new Set(["provider_unavailable", "spawn_failed", "claude_error", "gemini_error", "kimi_error", "tunnel_unavailable"]);
+const AUTH_FAILURE_CODES = new Set(["not_authed", "oauth_inference_rejected", "auth_not_configured", "session_expired"]);
 const COMPANION_PROVIDERS = [
   { provider: "claude", env: "CLAUDE_PLUGIN_DATA", fallback: "claude-companion" },
   { provider: "gemini", env: "GEMINI_PLUGIN_DATA", fallback: "gemini-companion" },
@@ -102,8 +102,8 @@ function jobId(record) {
 function failedState(sent, code) {
   if (code === "approval_required") return "approval_required";
   if (code === "timeout" && sent === "sent") return "source_sent_timeout";
-  if (PROVIDER_UNAVAILABLE_CODES.includes(code)) return "provider_unavailable";
-  if (AUTH_FAILURE_CODES.includes(code)) return "auth_session_failure";
+  if (PROVIDER_UNAVAILABLE_CODES.has(code)) return "provider_unavailable";
+  if (AUTH_FAILURE_CODES.has(code)) return "auth_session_failure";
   if (code === "rate_limited") return "rate_limited";
   if (code === "usage_limited") return "usage_limited";
   if (sent === "not_sent") return "failed_before_source_send";
@@ -198,8 +198,8 @@ function canonicalWorkspace(cwd) {
 function trimHyphens(value) {
   let start = 0;
   let end = value.length;
-  while (start < end && value.charCodeAt(start) === 45) start += 1;
-  while (end > start && value.charCodeAt(end - 1) === 45) end -= 1;
+  while (start < end && value.codePointAt(start) === 45) start += 1;
+  while (end > start && value.codePointAt(end - 1) === 45) end -= 1;
   return value.slice(start, end);
 }
 

--- a/scripts/lib/review-panel.mjs
+++ b/scripts/lib/review-panel.mjs
@@ -216,8 +216,7 @@ function recordsFromDirectProvider({ env, plugin }, cwd, processEnv) {
 function recordWorkspaceMatches(record, cwd, canonicalCwd) {
   const recordWorkspace = record.workspace_root ?? record.workspaceRoot ?? null;
   if (!recordWorkspace) return true;
-  const cwdCanonical = canonicalCwd ?? canonicalWorkspace(cwd);
-  return canonicalWorkspace(recordWorkspace) === cwdCanonical;
+  return canonicalWorkspace(recordWorkspace) === canonicalCwd;
 }
 
 function timestamp(record) {

--- a/scripts/lib/review-panel.mjs
+++ b/scripts/lib/review-panel.mjs
@@ -88,26 +88,26 @@ function operatorState(record) {
   const status = String(record.status ?? "");
   const sent = sourceTransmission(record);
   const code = String(record.error_code ?? "");
-  if (code === "approval_required") return "approval_required";
+  if (code === "approval_required" && status !== "running" && status !== "completed") return "approval_required";
   if (status === "completed" && quality(record).failed_review_slot === true) return "completed_failed_review_slot";
   if (status === "completed") return "completed";
   if ((status === "running" || status === "queued") && sent === "sent") return "source_sent_waiting";
   if (status === "running" || status === "queued") return "running";
   if (status === "failed" && code === "timeout" && sent === "sent") return "source_sent_timeout";
   if (status === "failed" && sent === "not_sent") return "failed_before_source_send";
-  if (["provider_unavailable", "spawn_failed", "claude_error", "gemini_error", "kimi_error"].includes(code)) {
+  if (status === "failed" && ["provider_unavailable", "spawn_failed", "claude_error", "gemini_error", "kimi_error", "tunnel_unavailable"].includes(code)) {
     return "provider_unavailable";
   }
-  if (["not_authed", "oauth_inference_rejected", "auth_not_configured", "session_expired"].includes(code)) {
+  if (status === "failed" && ["not_authed", "oauth_inference_rejected", "auth_not_configured", "session_expired"].includes(code)) {
     return "auth_session_failure";
   }
-  if (["usage_limited", "rate_limited"].includes(code)) return "quota_usage_limited";
+  if (status === "failed" && ["usage_limited", "rate_limited"].includes(code)) return "quota_usage_limited";
   return status || "unknown";
 }
 
 function resultSummary(record) {
   if (quality(record).failed_review_slot === true) return "failed_review_slot";
-  if (record.error_code) return record.error_code;
+  if (record.status === "failed" && record.error_code) return record.error_code;
   if (record.status === "running" || record.status === "queued") return "-";
   const verdict = /\bVerdict:\s*(APPROVE|REQUEST CHANGES|FAIL|REJECT)\b/i.exec(String(record.result ?? ""));
   if (!verdict) return "";

--- a/scripts/lib/review-panel.mjs
+++ b/scripts/lib/review-panel.mjs
@@ -158,11 +158,7 @@ function canonicalWorkspace(cwd) {
 }
 
 function trimHyphens(value) {
-  let start = 0;
-  let end = value.length;
-  while (start < end && value[start] === "-") start += 1;
-  while (end > start && value[end - 1] === "-") end -= 1;
-  return value.slice(start, end);
+  return value.replace(/^-+|-+$/g, "");
 }
 
 function companionStateId(cwd) {
@@ -176,7 +172,7 @@ function companionStateId(cwd) {
 function defaultDataRoot(pluginName, cwd) {
   const workspace = resolve(cwd);
   const slug = basename(workspace).replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 48) || "workspace";
-  const hash = createHash("sha256").update(workspace).digest("hex").slice(0, 16);
+  const hash = createHash("sha256").update(canonicalWorkspace(workspace)).digest("hex").slice(0, 16);
   return resolve(tmpdir(), "codex-plugin-multi", pluginName, `${slug}-${hash}`);
 }
 
@@ -217,10 +213,11 @@ function recordsFromDirectProvider({ env, plugin }, cwd, processEnv) {
   return recordsFromJobsDir(join(root, "jobs"));
 }
 
-function recordWorkspaceMatches(record, cwd) {
+function recordWorkspaceMatches(record, cwd, canonicalCwd) {
   const recordWorkspace = record.workspace_root ?? record.workspaceRoot ?? null;
   if (!recordWorkspace) return true;
-  return canonicalWorkspace(recordWorkspace) === canonicalWorkspace(cwd);
+  const cwdCanonical = canonicalCwd ?? canonicalWorkspace(cwd);
+  return canonicalWorkspace(recordWorkspace) === cwdCanonical;
 }
 
 function timestamp(record) {
@@ -230,10 +227,11 @@ function timestamp(record) {
 }
 
 export function collectReviewPanelRecords({ cwd = process.cwd(), env = process.env } = {}) {
+  const workspaceCanonical = canonicalWorkspace(cwd);
   const records = [
     ...COMPANION_PROVIDERS.flatMap((provider) => recordsFromCompanionProvider(provider, cwd, env)),
     ...DIRECT_ROOTS.flatMap((provider) => recordsFromDirectProvider(provider, cwd, env)),
-  ].filter((record) => recordWorkspaceMatches(record, cwd));
+  ].filter((record) => recordWorkspaceMatches(record, cwd, workspaceCanonical));
   return records.sort((left, right) => {
     const providerDiff = PROVIDER_ORDER.indexOf(providerName(left)) - PROVIDER_ORDER.indexOf(providerName(right));
     if (providerDiff !== 0) return providerDiff;

--- a/scripts/lib/review-panel.mjs
+++ b/scripts/lib/review-panel.mjs
@@ -88,7 +88,7 @@ function operatorState(record) {
   const status = String(record.status ?? "");
   const sent = sourceTransmission(record);
   const code = String(record.error_code ?? "");
-  if (code === "approval_required" && status !== "running" && status !== "completed") return "approval_required";
+  if (code === "approval_required" && status === "failed") return "approval_required";
   if (status === "completed" && quality(record).failed_review_slot === true) return "completed_failed_review_slot";
   if (status === "completed") return "completed";
   if ((status === "running" || status === "queued") && sent === "sent") return "source_sent_waiting";
@@ -106,9 +106,9 @@ function operatorState(record) {
 }
 
 function resultSummary(record) {
+  if (record.status === "running" || record.status === "queued") return "-";
   if (quality(record).failed_review_slot === true) return "failed_review_slot";
   if (record.status === "failed" && record.error_code) return record.error_code;
-  if (record.status === "running" || record.status === "queued") return "-";
   const verdict = /\bVerdict:\s*(APPROVE|REQUEST CHANGES|FAIL|REJECT)\b/i.exec(String(record.result ?? ""));
   if (!verdict) return "";
   return verdict[1].toLowerCase().replace(/\s+/g, "_");
@@ -213,9 +213,9 @@ function recordsFromDirectProvider({ env, plugin }, cwd, processEnv) {
   return recordsFromJobsDir(join(root, "jobs"));
 }
 
-function recordWorkspaceMatches(record, cwd, canonicalCwd) {
+function recordWorkspaceMatches(record, canonicalCwd) {
   const recordWorkspace = record.workspace_root ?? record.workspaceRoot ?? null;
-  if (!recordWorkspace) return true;
+  if (!recordWorkspace) return false;
   return canonicalWorkspace(recordWorkspace) === canonicalCwd;
 }
 
@@ -230,7 +230,7 @@ export function collectReviewPanelRecords({ cwd = process.cwd(), env = process.e
   const records = [
     ...COMPANION_PROVIDERS.flatMap((provider) => recordsFromCompanionProvider(provider, cwd, env)),
     ...DIRECT_ROOTS.flatMap((provider) => recordsFromDirectProvider(provider, cwd, env)),
-  ].filter((record) => recordWorkspaceMatches(record, cwd, workspaceCanonical));
+  ].filter((record) => recordWorkspaceMatches(record, workspaceCanonical));
   return records.sort((left, right) => {
     const providerDiff = PROVIDER_ORDER.indexOf(providerName(left)) - PROVIDER_ORDER.indexOf(providerName(right));
     if (providerDiff !== 0) return providerDiff;

--- a/scripts/lib/review-panel.mjs
+++ b/scripts/lib/review-panel.mjs
@@ -187,7 +187,11 @@ function canonicalWorkspace(cwd) {
 }
 
 function trimHyphens(value) {
-  return value.replace(/^-+|-+$/g, "");
+  let start = 0;
+  let end = value.length;
+  while (start < end && value.charCodeAt(start) === 45) start += 1;
+  while (end > start && value.charCodeAt(end - 1) === 45) end -= 1;
+  return value.slice(start, end);
 }
 
 function companionStateId(cwd) {

--- a/scripts/lib/review-panel.mjs
+++ b/scripts/lib/review-panel.mjs
@@ -1,3 +1,19 @@
+import { createHash } from "node:crypto";
+import { existsSync, readdirSync, readFileSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join, resolve } from "node:path";
+
+const PROVIDER_ORDER = ["claude", "gemini", "kimi", "grok", "deepseek", "glm"];
+const COMPANION_PROVIDERS = [
+  { provider: "claude", env: "CLAUDE_PLUGIN_DATA", fallback: "claude-companion" },
+  { provider: "gemini", env: "GEMINI_PLUGIN_DATA", fallback: "gemini-companion" },
+  { provider: "kimi", env: "KIMI_PLUGIN_DATA", fallback: "kimi-companion" },
+];
+const DIRECT_ROOTS = [
+  { provider: "grok", env: "GROK_PLUGIN_DATA", plugin: "grok" },
+  { provider: "api-reviewers", env: "API_REVIEWERS_PLUGIN_DATA", plugin: "api-reviewers" },
+];
+
 function valueAt(record, path, fallback = null) {
   let current = record;
   for (const key of path) {
@@ -34,6 +50,11 @@ function elapsedMs(record) {
   return typeof value === "number" && Number.isFinite(value) ? value : "";
 }
 
+function timeoutMs(record) {
+  const value = valueAt(record, ["review_metadata", "audit_manifest", "request", "timeout_ms"], null);
+  return typeof value === "number" && Number.isFinite(value) ? value : "";
+}
+
 function hasPermissionDenial(record) {
   const denials = valueAt(record, ["runtime_diagnostics", "permission_denials"], []);
   if (Array.isArray(denials) && denials.length > 0) return true;
@@ -59,6 +80,40 @@ function readiness(record) {
   return "unknown";
 }
 
+function jobId(record) {
+  return record.job_id ?? record.id ?? "";
+}
+
+function operatorState(record) {
+  const status = String(record.status ?? "");
+  const sent = sourceTransmission(record);
+  const code = String(record.error_code ?? "");
+  if (code === "approval_required") return "approval_required";
+  if (status === "completed" && quality(record).failed_review_slot === true) return "completed_failed_review_slot";
+  if (status === "completed") return "completed";
+  if ((status === "running" || status === "queued") && sent === "sent") return "source_sent_waiting";
+  if (status === "running" || status === "queued") return "running";
+  if (status === "failed" && code === "timeout" && sent === "sent") return "source_sent_timeout";
+  if (status === "failed" && sent === "not_sent") return "failed_before_source_send";
+  if (["provider_unavailable", "spawn_failed", "claude_error", "gemini_error", "kimi_error"].includes(code)) {
+    return "provider_unavailable";
+  }
+  if (["not_authed", "oauth_inference_rejected", "auth_not_configured", "session_expired"].includes(code)) {
+    return "auth_session_failure";
+  }
+  if (["usage_limited", "rate_limited"].includes(code)) return "quota_usage_limited";
+  return status || "unknown";
+}
+
+function resultSummary(record) {
+  if (quality(record).failed_review_slot === true) return "failed_review_slot";
+  if (record.error_code) return record.error_code;
+  if (record.status === "running" || record.status === "queued") return "-";
+  const verdict = /\bVerdict:\s*(APPROVE|REQUEST CHANGES|FAIL|REJECT)\b/i.exec(String(record.result ?? ""));
+  if (!verdict) return "";
+  return verdict[1].toLowerCase().replace(/\s+/g, "_");
+}
+
 function cell(value) {
   return String(value ?? "").replace(/\|/g, "\\|").replace(/\s+/g, " ").trim();
 }
@@ -75,10 +130,15 @@ export function buildReviewPanelRows(records = []) {
     const semanticFailed = quality(record).failed_review_slot === true;
     return Object.freeze({
       provider: providerName(record),
+      job_id: jobId(record),
+      state: operatorState(record),
       status: record.status ?? "",
       readiness: readiness(record),
+      sent: sourceTransmission(record),
       source_sent: sourceTransmission(record),
       elapsed_ms: elapsedMs(record),
+      timeout_ms: timeoutMs(record),
+      result: resultSummary(record),
       semantic_failed: semanticFailed,
       inspection: inspectionStatus(record),
       error_code: record.error_code ?? "",
@@ -88,14 +148,111 @@ export function buildReviewPanelRows(records = []) {
   });
 }
 
+function canonicalWorkspace(cwd) {
+  const absolute = resolve(cwd);
+  try {
+    return realpathSync.native(absolute);
+  } catch {
+    return absolute;
+  }
+}
+
+function trimHyphens(value) {
+  let start = 0;
+  let end = value.length;
+  while (start < end && value[start] === "-") start += 1;
+  while (end > start && value[end - 1] === "-") end -= 1;
+  return value.slice(start, end);
+}
+
+function companionStateId(cwd) {
+  const workspaceRoot = resolve(cwd);
+  const canonical = canonicalWorkspace(workspaceRoot);
+  const slug = trimHyphens((basename(workspaceRoot) || "workspace").replace(/[^a-zA-Z0-9._-]+/g, "-")) || "workspace";
+  const hash = createHash("sha256").update(canonical).digest("hex").slice(0, 16);
+  return `${slug}-${hash}`;
+}
+
+function defaultDataRoot(pluginName, cwd) {
+  const workspace = resolve(cwd);
+  const slug = basename(workspace).replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 48) || "workspace";
+  const hash = createHash("sha256").update(workspace).digest("hex").slice(0, 16);
+  return resolve(tmpdir(), "codex-plugin-multi", pluginName, `${slug}-${hash}`);
+}
+
+function readRecord(file) {
+  try {
+    const parsed = JSON.parse(readFileSync(file, "utf8"));
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function recordsFromJobsDir(jobsDir) {
+  if (!existsSync(jobsDir)) return [];
+  const out = [];
+  for (const entry of readdirSync(jobsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const record = readRecord(join(jobsDir, entry.name, "meta.json"));
+    if (record) out.push(record);
+  }
+  return out;
+}
+
+function recordsFromCompanionProvider({ env, fallback }, cwd, processEnv) {
+  const pluginData = processEnv[env];
+  if (!pluginData) {
+    return recordsFromJobsDir(join(tmpdir(), fallback, companionStateId(cwd), "jobs"));
+  }
+  const stateRoot = join(pluginData, "state");
+  if (!existsSync(stateRoot)) return [];
+  return readdirSync(stateRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .flatMap((entry) => recordsFromJobsDir(join(stateRoot, entry.name, "jobs")));
+}
+
+function recordsFromDirectProvider({ env, plugin }, cwd, processEnv) {
+  const root = processEnv[env] ? resolve(processEnv[env]) : defaultDataRoot(plugin, cwd);
+  return recordsFromJobsDir(join(root, "jobs"));
+}
+
+function recordWorkspaceMatches(record, cwd) {
+  const recordWorkspace = record.workspace_root ?? record.workspaceRoot ?? null;
+  if (!recordWorkspace) return true;
+  return canonicalWorkspace(recordWorkspace) === canonicalWorkspace(cwd);
+}
+
+function timestamp(record) {
+  const raw = record.updatedAt ?? record.ended_at ?? record.endedAt ?? record.started_at ?? record.startedAt ?? "";
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function collectReviewPanelRecords({ cwd = process.cwd(), env = process.env } = {}) {
+  const records = [
+    ...COMPANION_PROVIDERS.flatMap((provider) => recordsFromCompanionProvider(provider, cwd, env)),
+    ...DIRECT_ROOTS.flatMap((provider) => recordsFromDirectProvider(provider, cwd, env)),
+  ].filter((record) => recordWorkspaceMatches(record, cwd));
+  return records.sort((left, right) => {
+    const providerDiff = PROVIDER_ORDER.indexOf(providerName(left)) - PROVIDER_ORDER.indexOf(providerName(right));
+    if (providerDiff !== 0) return providerDiff;
+    return timestamp(right) - timestamp(left) || String(jobId(left)).localeCompare(String(jobId(right)));
+  });
+}
+
 export function renderReviewPanelMarkdown(records = []) {
   const rows = buildReviewPanelRows(records);
   const header = [
     "Provider",
+    "Job ID",
+    "State",
+    "Sent",
+    "Elapsed ms",
+    "Timeout ms",
+    "Result",
     "Readiness",
     "Status",
-    "Source Sent",
-    "Elapsed ms",
     "Semantic Failed",
     "Inspection",
     "Error Code",
@@ -107,10 +264,14 @@ export function renderReviewPanelMarkdown(records = []) {
     `| ${header.map(() => "---").join(" | ")} |`,
     ...rows.map((row) => [
       row.provider,
+      row.job_id,
+      row.state,
+      row.sent,
+      row.elapsed_ms,
+      row.timeout_ms,
+      row.result,
       row.readiness,
       row.status,
-      row.source_sent,
-      row.elapsed_ms,
       row.semantic_failed,
       row.inspection,
       row.error_code,

--- a/scripts/lib/review-panel.mjs
+++ b/scripts/lib/review-panel.mjs
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync, realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join, resolve } from "node:path";
@@ -48,6 +49,10 @@ function reasons(record) {
   return Array.isArray(raw) ? raw.join(",") : "";
 }
 
+function isActiveStatus(status) {
+  return status === "running" || status === "queued";
+}
+
 function elapsedMs(record) {
   const value = valueAt(record, ["review_metadata", "raw_output", "elapsed_ms"], null);
   return typeof value === "number" && Number.isFinite(value) ? value : "";
@@ -79,6 +84,9 @@ function readiness(record) {
   if (record.status === "completed" && quality(record).failed_review_slot !== true) {
     return "review-ready";
   }
+  if (record.status === "completed" && quality(record).failed_review_slot === true) {
+    return "review failed";
+  }
   if (record.status === "failed") return "review failed";
   return "unknown";
 }
@@ -94,11 +102,11 @@ function jobId(record) {
 function failedState(sent, code) {
   if (code === "approval_required") return "approval_required";
   if (code === "timeout" && sent === "sent") return "source_sent_timeout";
-  if (sent === "not_sent") return "failed_before_source_send";
   if (PROVIDER_UNAVAILABLE_CODES.includes(code)) return "provider_unavailable";
   if (AUTH_FAILURE_CODES.includes(code)) return "auth_session_failure";
   if (code === "rate_limited") return "rate_limited";
   if (code === "usage_limited") return "usage_limited";
+  if (sent === "not_sent") return "failed_before_source_send";
   return "failed";
 }
 
@@ -134,9 +142,9 @@ function operatorState(record) {
  * error_code on failure, parsed Verdict keyword, or empty string.
  */
 function resultSummary(record) {
-  if (record.status === "running" || record.status === "queued") return "-";
-  if (quality(record).failed_review_slot === true) return "failed_review_slot";
+  if (isActiveStatus(record.status)) return "-";
   if (record.status === "failed" && record.error_code) return record.error_code;
+  if (quality(record).failed_review_slot === true) return "failed_review_slot";
   const verdict = VERDICT_RE.exec(String(record.result ?? ""));
   if (!verdict) return "";
   return verdict[1].toLowerCase().replace(/\s+/g, "_");
@@ -156,7 +164,8 @@ function cell(value) {
  */
 export function buildReviewPanelRows(records = []) {
   return records.map((record) => {
-    const semanticFailed = quality(record).failed_review_slot === true;
+    const showReviewQuality = !isActiveStatus(record.status);
+    const semanticFailed = showReviewQuality && quality(record).failed_review_slot === true;
     return Object.freeze({
       provider: providerName(record),
       job_id: jobId(record),
@@ -170,9 +179,9 @@ export function buildReviewPanelRows(records = []) {
       result: resultSummary(record),
       semantic_failed: semanticFailed,
       inspection: inspectionStatus(record),
-      error_code: record.error_code ?? "",
+      error_code: record.status === "failed" ? (record.error_code ?? "") : "",
       http_status: record.http_status ?? "",
-      reasons: reasons(record),
+      reasons: showReviewQuality ? reasons(record) : "",
     });
   });
 }
@@ -195,7 +204,7 @@ function trimHyphens(value) {
 }
 
 function companionStateId(cwd) {
-  const workspaceRoot = resolve(cwd);
+  const workspaceRoot = resolvePanelWorkspaceRoot(cwd);
   const canonical = canonicalWorkspace(workspaceRoot);
   const slug = trimHyphens((basename(workspaceRoot) || "workspace").replace(/[^a-zA-Z0-9._-]+/g, "-")) || "workspace";
   const hash = createHash("sha256").update(canonical).digest("hex").slice(0, 16);
@@ -205,8 +214,21 @@ function companionStateId(cwd) {
 function defaultDataRoot(pluginName, cwd) {
   const workspace = resolve(cwd);
   const slug = basename(workspace).replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 48) || "workspace";
-  const hash = createHash("sha256").update(canonicalWorkspace(workspace)).digest("hex").slice(0, 16);
+  const hash = createHash("sha256").update(workspace).digest("hex").slice(0, 16);
   return resolve(tmpdir(), "codex-plugin-multi", pluginName, `${slug}-${hash}`);
+}
+
+function resolvePanelWorkspaceRoot(cwd) {
+  const workspace = resolve(cwd);
+  try {
+    return execFileSync("git", ["-C", workspace, "rev-parse", "--show-toplevel"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 5000,
+    }).trim();
+  } catch {
+    return workspace;
+  }
 }
 
 function readRecord(file) {
@@ -254,14 +276,15 @@ function recordsFromCompanionProvider({ env, fallback }, cwd, processEnv) {
 }
 
 function recordsFromDirectProvider({ env, plugin }, cwd, processEnv) {
-  const root = processEnv[env] ? resolve(processEnv[env]) : defaultDataRoot(plugin, cwd);
-  return recordsFromJobsDir(join(root, "jobs"));
+  if (processEnv[env]) return recordsFromJobsDir(join(resolve(processEnv[env]), "jobs"));
+  const roots = [defaultDataRoot(plugin, cwd), defaultDataRoot(plugin, canonicalWorkspace(cwd))];
+  return [...new Set(roots)].flatMap((root) => recordsFromJobsDir(join(root, "jobs")));
 }
 
-function recordWorkspaceMatches(record, canonicalCwd) {
+function recordWorkspaceMatches(record, canonicalWorkspaces) {
   const recordWorkspace = record.workspace_root ?? record.workspaceRoot ?? null;
-  if (!recordWorkspace) return false;
-  return canonicalWorkspace(recordWorkspace) === canonicalCwd;
+  if (typeof recordWorkspace !== "string" || recordWorkspace.length === 0) return false;
+  return canonicalWorkspaces.has(canonicalWorkspace(recordWorkspace));
 }
 
 function timestamp(record) {
@@ -288,11 +311,14 @@ function providerOrderIndex(provider) {
  *   then descending timestamp, then job_id.
  */
 export function collectReviewPanelRecords({ cwd = process.cwd(), env = process.env } = {}) {
-  const workspaceCanonical = canonicalWorkspace(cwd);
+  const workspaceCanonicals = new Set([
+    canonicalWorkspace(cwd),
+    canonicalWorkspace(resolvePanelWorkspaceRoot(cwd)),
+  ]);
   const records = [
     ...COMPANION_PROVIDERS.flatMap((provider) => recordsFromCompanionProvider(provider, cwd, env)),
     ...DIRECT_ROOTS.flatMap((provider) => recordsFromDirectProvider(provider, cwd, env)),
-  ].filter((record) => recordWorkspaceMatches(record, workspaceCanonical));
+  ].filter((record) => recordWorkspaceMatches(record, workspaceCanonicals));
   return records.sort((left, right) => {
     const providerDiff = providerOrderIndex(providerName(left)) - providerOrderIndex(providerName(right));
     if (providerDiff !== 0) return providerDiff;

--- a/scripts/lib/review-panel.mjs
+++ b/scripts/lib/review-panel.mjs
@@ -1,8 +1,7 @@
 import { createHash } from "node:crypto";
-import { execFileSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync, realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { basename, join, resolve } from "node:path";
+import { basename, isAbsolute, join, relative, resolve } from "node:path";
 
 const PROVIDER_ORDER = ["claude", "gemini", "kimi", "grok", "deepseek", "glm"];
 const VERDICT_RE = /\bVerdict:\s*(APPROVE|REQUEST CHANGES|FAIL|REJECT)\b/i;
@@ -195,40 +194,11 @@ function canonicalWorkspace(cwd) {
   }
 }
 
-function trimHyphens(value) {
-  let start = 0;
-  let end = value.length;
-  while (start < end && value.codePointAt(start) === 45) start += 1;
-  while (end > start && value.codePointAt(end - 1) === 45) end -= 1;
-  return value.slice(start, end);
-}
-
-function companionStateId(cwd) {
-  const workspaceRoot = resolvePanelWorkspaceRoot(cwd);
-  const canonical = canonicalWorkspace(workspaceRoot);
-  const slug = trimHyphens((basename(workspaceRoot) || "workspace").replace(/[^a-zA-Z0-9._-]+/g, "-")) || "workspace";
-  const hash = createHash("sha256").update(canonical).digest("hex").slice(0, 16);
-  return `${slug}-${hash}`;
-}
-
 function defaultDataRoot(pluginName, cwd) {
   const workspace = resolve(cwd);
   const slug = basename(workspace).replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 48) || "workspace";
   const hash = createHash("sha256").update(workspace).digest("hex").slice(0, 16);
   return resolve(tmpdir(), "codex-plugin-multi", pluginName, `${slug}-${hash}`);
-}
-
-function resolvePanelWorkspaceRoot(cwd) {
-  const workspace = resolve(cwd);
-  try {
-    return execFileSync("git", ["-C", workspace, "rev-parse", "--show-toplevel"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-      timeout: 5000,
-    }).trim();
-  } catch {
-    return workspace;
-  }
 }
 
 function readRecord(file) {
@@ -259,10 +229,7 @@ function recordsFromJobsDir(jobsDir) {
 
 function recordsFromCompanionProvider({ env, fallback }, cwd, processEnv) {
   const pluginData = processEnv[env];
-  if (!pluginData) {
-    return recordsFromJobsDir(join(tmpdir(), fallback, companionStateId(cwd), "jobs"));
-  }
-  const stateRoot = join(pluginData, "state");
+  const stateRoot = pluginData ? join(pluginData, "state") : join(tmpdir(), fallback);
   if (!existsSync(stateRoot)) return [];
   let stateEntries;
   try {
@@ -281,10 +248,12 @@ function recordsFromDirectProvider({ env, plugin }, cwd, processEnv) {
   return [...new Set(roots)].flatMap((root) => recordsFromJobsDir(join(root, "jobs")));
 }
 
-function recordWorkspaceMatches(record, canonicalWorkspaces) {
+function recordWorkspaceMatches(record, canonicalCwd) {
   const recordWorkspace = record.workspace_root ?? record.workspaceRoot ?? null;
   if (typeof recordWorkspace !== "string" || recordWorkspace.length === 0) return false;
-  return canonicalWorkspaces.has(canonicalWorkspace(recordWorkspace));
+  const recordCanonical = canonicalWorkspace(recordWorkspace);
+  const rel = relative(recordCanonical, canonicalCwd);
+  return rel === "" || (rel !== "" && !rel.startsWith("..") && !isAbsolute(rel));
 }
 
 function timestamp(record) {
@@ -311,14 +280,11 @@ function providerOrderIndex(provider) {
  *   then descending timestamp, then job_id.
  */
 export function collectReviewPanelRecords({ cwd = process.cwd(), env = process.env } = {}) {
-  const workspaceCanonicals = new Set([
-    canonicalWorkspace(cwd),
-    canonicalWorkspace(resolvePanelWorkspaceRoot(cwd)),
-  ]);
+  const workspaceCanonical = canonicalWorkspace(cwd);
   const records = [
     ...COMPANION_PROVIDERS.flatMap((provider) => recordsFromCompanionProvider(provider, cwd, env)),
     ...DIRECT_ROOTS.flatMap((provider) => recordsFromDirectProvider(provider, cwd, env)),
-  ].filter((record) => recordWorkspaceMatches(record, workspaceCanonicals));
+  ].filter((record) => recordWorkspaceMatches(record, workspaceCanonical));
   return records.sort((left, right) => {
     const providerDiff = providerOrderIndex(providerName(left)) - providerOrderIndex(providerName(right));
     if (providerDiff !== 0) return providerDiff;

--- a/scripts/lib/review-panel.mjs
+++ b/scripts/lib/review-panel.mjs
@@ -84,6 +84,17 @@ function jobId(record) {
   return record.job_id ?? record.id ?? "";
 }
 
+/**
+ * Classifies a job record into a priority-ordered operational state.
+ *
+ * The state machine checks conditions in load-bearing order: approval_required
+ * is only surfaced when status is strictly "failed" (never for running/queued
+ * jobs, even with a stale approval_required error code). Returns one of:
+ * approval_required, completed_failed_review_slot, completed,
+ * source_sent_waiting, running, source_sent_timeout,
+ * failed_before_source_send, provider_unavailable, auth_session_failure,
+ * quota_usage_limited, or the raw status as a fallback.
+ */
 function operatorState(record) {
   const status = String(record.status ?? "");
   const sent = sourceTransmission(record);
@@ -105,6 +116,14 @@ function operatorState(record) {
   return status || "unknown";
 }
 
+/**
+ * Returns a compact summary of the job outcome.
+ *
+ * Active jobs (running/queued) return "-" before any other check so that stale
+ * failed_review_slot metadata from a prior run never leaks into an in-flight
+ * row. After the active guard, priority order is: failed_review_slot, explicit
+ * error_code on failure, parsed Verdict keyword, or empty string.
+ */
 function resultSummary(record) {
   if (record.status === "running" || record.status === "queued") return "-";
   if (quality(record).failed_review_slot === true) return "failed_review_slot";

--- a/scripts/lib/review-panel.mjs
+++ b/scripts/lib/review-panel.mjs
@@ -7,7 +7,6 @@ const PROVIDER_ORDER = ["claude", "gemini", "kimi", "grok", "deepseek", "glm"];
 const VERDICT_RE = /\bVerdict:\s*(APPROVE|REQUEST CHANGES|FAIL|REJECT)\b/i;
 const PROVIDER_UNAVAILABLE_CODES = ["provider_unavailable", "spawn_failed", "claude_error", "gemini_error", "kimi_error", "tunnel_unavailable"];
 const AUTH_FAILURE_CODES = ["not_authed", "oauth_inference_rejected", "auth_not_configured", "session_expired"];
-const QUOTA_LIMITED_CODES = ["usage_limited", "rate_limited"];
 const COMPANION_PROVIDERS = [
   { provider: "claude", env: "CLAUDE_PLUGIN_DATA", fallback: "claude-companion" },
   { provider: "gemini", env: "GEMINI_PLUGIN_DATA", fallback: "gemini-companion" },
@@ -98,7 +97,8 @@ function failedState(sent, code) {
   if (sent === "not_sent") return "failed_before_source_send";
   if (PROVIDER_UNAVAILABLE_CODES.includes(code)) return "provider_unavailable";
   if (AUTH_FAILURE_CODES.includes(code)) return "auth_session_failure";
-  if (QUOTA_LIMITED_CODES.includes(code)) return "quota_usage_limited";
+  if (code === "rate_limited") return "rate_limited";
+  if (code === "usage_limited") return "usage_limited";
   return "failed";
 }
 
@@ -111,7 +111,7 @@ function failedState(sent, code) {
  * approval_required, completed_failed_review_slot, completed,
  * source_sent_waiting, running, source_sent_timeout,
  * failed_before_source_send, provider_unavailable, auth_session_failure,
- * quota_usage_limited, or the raw status as a fallback.
+ * rate_limited, usage_limited, or the raw status as a fallback.
  */
 function operatorState(record) {
   const status = String(record.status ?? "");
@@ -258,6 +258,11 @@ function timestamp(record) {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
+function providerOrderIndex(provider) {
+  const index = PROVIDER_ORDER.indexOf(provider);
+  return index === -1 ? PROVIDER_ORDER.length : index;
+}
+
 /**
  * Aggregates live/recent JobRecords across companion and direct provider state
  * roots, filters to the canonical workspace, and returns them sorted by
@@ -277,7 +282,7 @@ export function collectReviewPanelRecords({ cwd = process.cwd(), env = process.e
     ...DIRECT_ROOTS.flatMap((provider) => recordsFromDirectProvider(provider, cwd, env)),
   ].filter((record) => recordWorkspaceMatches(record, workspaceCanonical));
   return records.sort((left, right) => {
-    const providerDiff = PROVIDER_ORDER.indexOf(providerName(left)) - PROVIDER_ORDER.indexOf(providerName(right));
+    const providerDiff = providerOrderIndex(providerName(left)) - providerOrderIndex(providerName(right));
     if (providerDiff !== 0) return providerDiff;
     return timestamp(right) - timestamp(left) || String(jobId(left)).localeCompare(String(jobId(right)));
   });

--- a/scripts/lib/review-panel.mjs
+++ b/scripts/lib/review-panel.mjs
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync, realpathSync } from "node:fs";
+import { existsSync, lstatSync, readdirSync, readFileSync, realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, parse, relative, resolve } from "node:path";
 
@@ -25,6 +25,10 @@ function valueAt(record, path, fallback = null) {
     current = current[key];
   }
   return current ?? fallback;
+}
+
+function isRecordObject(record) {
+  return record && typeof record === "object" && !Array.isArray(record);
 }
 
 function providerName(record) {
@@ -163,7 +167,7 @@ function cell(value) {
  * code, HTTP status, and semantic reasons).
  */
 export function buildReviewPanelRows(records = []) {
-  return records.map((record) => {
+  return records.filter(isRecordObject).map((record) => {
     const showReviewQuality = !isActiveStatus(record.status);
     const semanticFailed = showReviewQuality && quality(record).failed_review_slot === true;
     return Object.freeze({
@@ -199,7 +203,7 @@ function canonicalWorkspace(cwd) {
 function readRecord(file) {
   try {
     const parsed = JSON.parse(readFileSync(file, "utf8"));
-    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null;
+    return isRecordObject(parsed) ? parsed : null;
   } catch {
     return null;
   }
@@ -207,6 +211,12 @@ function readRecord(file) {
 
 function recordsFromJobsDir(jobsDir) {
   if (!existsSync(jobsDir)) return [];
+  try {
+    const jobsDirStat = lstatSync(jobsDir);
+    if (!jobsDirStat.isDirectory() || jobsDirStat.isSymbolicLink()) return [];
+  } catch {
+    return [];
+  }
   const out = [];
   let entries;
   try {
@@ -214,10 +224,16 @@ function recordsFromJobsDir(jobsDir) {
   } catch {
     return [];
   }
+  const flatJobIds = new Set(
+    entries
+      .filter((entry) => !entry.isSymbolicLink() && entry.isFile() && entry.name.endsWith(".json"))
+      .map((entry) => entry.name.slice(0, -".json".length)),
+  );
   for (const entry of entries) {
     if (entry.isSymbolicLink()) continue;
     let record = null;
     if (entry.isDirectory()) {
+      if (flatJobIds.has(entry.name)) continue;
       record = readRecord(join(jobsDir, entry.name, "meta.json"));
     } else if (entry.isFile() && entry.name.endsWith(".json")) {
       record = readRecord(join(jobsDir, entry.name));
@@ -251,7 +267,7 @@ function directFallbackStateRoot(plugin) {
 }
 
 function recordsFromDirectProvider({ env, plugin }, processEnv) {
-  if (processEnv[env]) return recordsFromJobsDir(join(resolve(processEnv[env]), "jobs"));
+  if (processEnv[env] != null) return recordsFromJobsDir(join(resolve(processEnv[env]), "jobs"));
   return recordsFromStateRoot(directFallbackStateRoot(plugin));
 }
 
@@ -263,8 +279,42 @@ function isPathWithin(parent, child) {
 function isUnsafeWorkspaceAncestor(recordCanonical, canonicalCwd) {
   if (recordCanonical === canonicalCwd) return false;
   if (recordCanonical === parse(recordCanonical).root) return true;
-  if (recordCanonical === canonicalWorkspace(tmpdir())) return true;
+  if (recordCanonical === canonicalTmpdir()) return true;
   return false;
+}
+
+let canonicalTmpdirValue = null;
+function canonicalTmpdir() {
+  canonicalTmpdirValue ??= canonicalWorkspace(tmpdir());
+  return canonicalTmpdirValue;
+}
+
+function isGitRepositoryRoot(workspace) {
+  const gitPath = join(workspace, ".git");
+  let gitStat;
+  try {
+    gitStat = lstatSync(gitPath);
+  } catch {
+    return false;
+  }
+  if (gitStat.isDirectory()) return existsSync(join(gitPath, "HEAD"));
+  if (!gitStat.isFile()) return false;
+
+  let firstLine;
+  try {
+    [firstLine = ""] = readFileSync(gitPath, "utf8").split(/\r?\n/, 1);
+  } catch {
+    return false;
+  }
+  if (!firstLine.startsWith("gitdir:")) return false;
+  const rawGitDir = firstLine.slice("gitdir:".length).trim();
+  if (!rawGitDir) return false;
+  const gitDir = isAbsolute(rawGitDir) ? rawGitDir : resolve(workspace, rawGitDir);
+  try {
+    return lstatSync(gitDir).isDirectory() && existsSync(join(gitDir, "HEAD"));
+  } catch {
+    return false;
+  }
 }
 
 function recordWorkspaceMatches(record, canonicalCwd) {
@@ -274,7 +324,7 @@ function recordWorkspaceMatches(record, canonicalCwd) {
   if (!isPathWithin(recordCanonical, canonicalCwd)) return false;
   if (recordCanonical === canonicalCwd) return true;
   if (isUnsafeWorkspaceAncestor(recordCanonical, canonicalCwd)) return false;
-  return existsSync(join(recordCanonical, ".git"));
+  return isGitRepositoryRoot(recordCanonical);
 }
 
 function timestamp(record) {

--- a/scripts/lib/review-panel.mjs
+++ b/scripts/lib/review-panel.mjs
@@ -221,7 +221,13 @@ function readRecord(file) {
 function recordsFromJobsDir(jobsDir) {
   if (!existsSync(jobsDir)) return [];
   const out = [];
-  for (const entry of readdirSync(jobsDir, { withFileTypes: true })) {
+  let entries;
+  try {
+    entries = readdirSync(jobsDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  for (const entry of entries) {
     if (!entry.isDirectory()) continue;
     const record = readRecord(join(jobsDir, entry.name, "meta.json"));
     if (record) out.push(record);
@@ -236,7 +242,13 @@ function recordsFromCompanionProvider({ env, fallback }, cwd, processEnv) {
   }
   const stateRoot = join(pluginData, "state");
   if (!existsSync(stateRoot)) return [];
-  return readdirSync(stateRoot, { withFileTypes: true })
+  let stateEntries;
+  try {
+    stateEntries = readdirSync(stateRoot, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  return stateEntries
     .filter((entry) => entry.isDirectory())
     .flatMap((entry) => recordsFromJobsDir(join(stateRoot, entry.name, "jobs")));
 }

--- a/scripts/lib/review-panel.mjs
+++ b/scripts/lib/review-panel.mjs
@@ -1,7 +1,6 @@
-import { createHash } from "node:crypto";
 import { existsSync, readdirSync, readFileSync, realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { basename, isAbsolute, join, relative, resolve } from "node:path";
+import { isAbsolute, join, parse, relative, resolve } from "node:path";
 
 const PROVIDER_ORDER = ["claude", "gemini", "kimi", "grok", "deepseek", "glm"];
 const VERDICT_RE = /\bVerdict:\s*(APPROVE|REQUEST CHANGES|FAIL|REJECT)\b/i;
@@ -13,8 +12,8 @@ const COMPANION_PROVIDERS = [
   { provider: "kimi", env: "KIMI_PLUGIN_DATA", fallback: "kimi-companion" },
 ];
 const DIRECT_ROOTS = [
-  { provider: "grok", env: "GROK_PLUGIN_DATA", plugin: "grok" },
-  { provider: "api-reviewers", env: "API_REVIEWERS_PLUGIN_DATA", plugin: "api-reviewers" },
+  { env: "GROK_PLUGIN_DATA", plugin: "grok" },
+  { env: "API_REVIEWERS_PLUGIN_DATA", plugin: "api-reviewers" },
 ];
 
 function valueAt(record, path, fallback = null) {
@@ -77,16 +76,18 @@ function inspectionStatus(record) {
 
 function readiness(record) {
   const errorCode = record.error_code ?? "";
-  if (errorCode === "models_ok_chat_400" || errorCode.startsWith("grok_session_")) {
-    return "not review-ready";
-  }
   if (record.status === "completed" && quality(record).failed_review_slot !== true) {
     return "review-ready";
   }
   if (record.status === "completed" && quality(record).failed_review_slot === true) {
     return "review failed";
   }
-  if (record.status === "failed") return "review failed";
+  if (record.status === "failed") {
+    if (errorCode === "models_ok_chat_400" || errorCode.startsWith("grok_session_")) {
+      return "not review-ready";
+    }
+    return "review failed";
+  }
   return "unknown";
 }
 
@@ -137,8 +138,8 @@ function operatorState(record) {
  *
  * Active jobs (running/queued) return "-" before any other check so that stale
  * failed_review_slot metadata from a prior run never leaks into an in-flight
- * row. After the active guard, priority order is: failed_review_slot, explicit
- * error_code on failure, parsed Verdict keyword, or empty string.
+ * row. After the active guard, priority order is: explicit error_code on
+ * failure, failed_review_slot, parsed Verdict keyword, or empty string.
  */
 function resultSummary(record) {
   if (isActiveStatus(record.status)) return "-";
@@ -172,6 +173,7 @@ export function buildReviewPanelRows(records = []) {
       status: record.status ?? "",
       readiness: readiness(record),
       sent: sourceTransmission(record),
+      // Backward-compatible alias for consumers that still read the old field.
       source_sent: sourceTransmission(record),
       elapsed_ms: elapsedMs(record),
       timeout_ms: timeoutMs(record),
@@ -194,13 +196,6 @@ function canonicalWorkspace(cwd) {
   }
 }
 
-function defaultDataRoot(pluginName, cwd) {
-  const workspace = resolve(cwd);
-  const slug = basename(workspace).replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 48) || "workspace";
-  const hash = createHash("sha256").update(workspace).digest("hex").slice(0, 16);
-  return resolve(tmpdir(), "codex-plugin-multi", pluginName, `${slug}-${hash}`);
-}
-
 function readRecord(file) {
   try {
     const parsed = JSON.parse(readFileSync(file, "utf8"));
@@ -220,16 +215,19 @@ function recordsFromJobsDir(jobsDir) {
     return [];
   }
   for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    const record = readRecord(join(jobsDir, entry.name, "meta.json"));
+    if (entry.isSymbolicLink()) continue;
+    let record = null;
+    if (entry.isDirectory()) {
+      record = readRecord(join(jobsDir, entry.name, "meta.json"));
+    } else if (entry.isFile() && entry.name.endsWith(".json")) {
+      record = readRecord(join(jobsDir, entry.name));
+    }
     if (record) out.push(record);
   }
   return out;
 }
 
-function recordsFromCompanionProvider({ env, fallback }, cwd, processEnv) {
-  const pluginData = processEnv[env];
-  const stateRoot = pluginData ? join(pluginData, "state") : join(tmpdir(), fallback);
+function recordsFromStateRoot(stateRoot) {
   if (!existsSync(stateRoot)) return [];
   let stateEntries;
   try {
@@ -238,22 +236,45 @@ function recordsFromCompanionProvider({ env, fallback }, cwd, processEnv) {
     return [];
   }
   return stateEntries
-    .filter((entry) => entry.isDirectory())
+    .filter((entry) => entry.isDirectory() && !entry.isSymbolicLink())
     .flatMap((entry) => recordsFromJobsDir(join(stateRoot, entry.name, "jobs")));
 }
 
-function recordsFromDirectProvider({ env, plugin }, cwd, processEnv) {
+function recordsFromCompanionProvider({ env, fallback }, processEnv) {
+  const pluginData = processEnv[env];
+  const stateRoot = pluginData ? join(pluginData, "state") : join(tmpdir(), fallback);
+  return recordsFromStateRoot(stateRoot);
+}
+
+function directFallbackStateRoot(plugin) {
+  return resolve(tmpdir(), "codex-plugin-multi", plugin);
+}
+
+function recordsFromDirectProvider({ env, plugin }, processEnv) {
   if (processEnv[env]) return recordsFromJobsDir(join(resolve(processEnv[env]), "jobs"));
-  const roots = [defaultDataRoot(plugin, cwd), defaultDataRoot(plugin, canonicalWorkspace(cwd))];
-  return [...new Set(roots)].flatMap((root) => recordsFromJobsDir(join(root, "jobs")));
+  return recordsFromStateRoot(directFallbackStateRoot(plugin));
+}
+
+function isPathWithin(parent, child) {
+  const rel = relative(parent, child);
+  return rel === "" || (rel !== "" && !rel.startsWith("..") && !isAbsolute(rel));
+}
+
+function isUnsafeWorkspaceAncestor(recordCanonical, canonicalCwd) {
+  if (recordCanonical === canonicalCwd) return false;
+  if (recordCanonical === parse(recordCanonical).root) return true;
+  if (recordCanonical === canonicalWorkspace(tmpdir())) return true;
+  return false;
 }
 
 function recordWorkspaceMatches(record, canonicalCwd) {
   const recordWorkspace = record.workspace_root ?? record.workspaceRoot ?? null;
   if (typeof recordWorkspace !== "string" || recordWorkspace.length === 0) return false;
   const recordCanonical = canonicalWorkspace(recordWorkspace);
-  const rel = relative(recordCanonical, canonicalCwd);
-  return rel === "" || (rel !== "" && !rel.startsWith("..") && !isAbsolute(rel));
+  if (!isPathWithin(recordCanonical, canonicalCwd)) return false;
+  if (recordCanonical === canonicalCwd) return true;
+  if (isUnsafeWorkspaceAncestor(recordCanonical, canonicalCwd)) return false;
+  return existsSync(join(recordCanonical, ".git"));
 }
 
 function timestamp(record) {
@@ -282,8 +303,8 @@ function providerOrderIndex(provider) {
 export function collectReviewPanelRecords({ cwd = process.cwd(), env = process.env } = {}) {
   const workspaceCanonical = canonicalWorkspace(cwd);
   const records = [
-    ...COMPANION_PROVIDERS.flatMap((provider) => recordsFromCompanionProvider(provider, cwd, env)),
-    ...DIRECT_ROOTS.flatMap((provider) => recordsFromDirectProvider(provider, cwd, env)),
+    ...COMPANION_PROVIDERS.flatMap((provider) => recordsFromCompanionProvider(provider, env)),
+    ...DIRECT_ROOTS.flatMap((provider) => recordsFromDirectProvider(provider, env)),
   ].filter((record) => recordWorkspaceMatches(record, workspaceCanonical));
   return records.sort((left, right) => {
     const providerDiff = providerOrderIndex(providerName(left)) - providerOrderIndex(providerName(right));

--- a/scripts/lib/review-panel.mjs
+++ b/scripts/lib/review-panel.mjs
@@ -4,6 +4,10 @@ import { tmpdir } from "node:os";
 import { basename, join, resolve } from "node:path";
 
 const PROVIDER_ORDER = ["claude", "gemini", "kimi", "grok", "deepseek", "glm"];
+const VERDICT_RE = /\bVerdict:\s*(APPROVE|REQUEST CHANGES|FAIL|REJECT)\b/i;
+const PROVIDER_UNAVAILABLE_CODES = ["provider_unavailable", "spawn_failed", "claude_error", "gemini_error", "kimi_error", "tunnel_unavailable"];
+const AUTH_FAILURE_CODES = ["not_authed", "oauth_inference_rejected", "auth_not_configured", "session_expired"];
+const QUOTA_LIMITED_CODES = ["usage_limited", "rate_limited"];
 const COMPANION_PROVIDERS = [
   { provider: "claude", env: "CLAUDE_PLUGIN_DATA", fallback: "claude-companion" },
   { provider: "gemini", env: "GEMINI_PLUGIN_DATA", fallback: "gemini-companion" },
@@ -85,6 +89,20 @@ function jobId(record) {
 }
 
 /**
+ * Resolves the sub-state of a failed job from its transmission state and error
+ * code.  Called only when record.status === "failed".
+ */
+function failedState(sent, code) {
+  if (code === "approval_required") return "approval_required";
+  if (code === "timeout" && sent === "sent") return "source_sent_timeout";
+  if (sent === "not_sent") return "failed_before_source_send";
+  if (PROVIDER_UNAVAILABLE_CODES.includes(code)) return "provider_unavailable";
+  if (AUTH_FAILURE_CODES.includes(code)) return "auth_session_failure";
+  if (QUOTA_LIMITED_CODES.includes(code)) return "quota_usage_limited";
+  return "failed";
+}
+
+/**
  * Classifies a job record into a priority-ordered operational state.
  *
  * The state machine checks conditions in load-bearing order: approval_required
@@ -99,20 +117,11 @@ function operatorState(record) {
   const status = String(record.status ?? "");
   const sent = sourceTransmission(record);
   const code = String(record.error_code ?? "");
-  if (code === "approval_required" && status === "failed") return "approval_required";
+  if (status === "failed") return failedState(sent, code);
   if (status === "completed" && quality(record).failed_review_slot === true) return "completed_failed_review_slot";
   if (status === "completed") return "completed";
   if ((status === "running" || status === "queued") && sent === "sent") return "source_sent_waiting";
   if (status === "running" || status === "queued") return "running";
-  if (status === "failed" && code === "timeout" && sent === "sent") return "source_sent_timeout";
-  if (status === "failed" && sent === "not_sent") return "failed_before_source_send";
-  if (status === "failed" && ["provider_unavailable", "spawn_failed", "claude_error", "gemini_error", "kimi_error", "tunnel_unavailable"].includes(code)) {
-    return "provider_unavailable";
-  }
-  if (status === "failed" && ["not_authed", "oauth_inference_rejected", "auth_not_configured", "session_expired"].includes(code)) {
-    return "auth_session_failure";
-  }
-  if (status === "failed" && ["usage_limited", "rate_limited"].includes(code)) return "quota_usage_limited";
   return status || "unknown";
 }
 
@@ -128,7 +137,7 @@ function resultSummary(record) {
   if (record.status === "running" || record.status === "queued") return "-";
   if (quality(record).failed_review_slot === true) return "failed_review_slot";
   if (record.status === "failed" && record.error_code) return record.error_code;
-  const verdict = /\bVerdict:\s*(APPROVE|REQUEST CHANGES|FAIL|REJECT)\b/i.exec(String(record.result ?? ""));
+  const verdict = VERDICT_RE.exec(String(record.result ?? ""));
   if (!verdict) return "";
   return verdict[1].toLowerCase().replace(/\s+/g, "_");
 }

--- a/scripts/lib/review-panel.mjs
+++ b/scripts/lib/review-panel.mjs
@@ -121,9 +121,10 @@ function cell(value) {
 /**
  * Normalizes heterogeneous provider JobRecords into one provider-panel row.
  *
- * The row intentionally keeps product-state columns together: readiness,
- * transport status, source transmission, timing, semantic failure, inspection,
- * provider error code, HTTP status, and semantic reasons.
+ * The row exposes per-job identity and operational columns (Job ID, operator
+ * State, Sent, Elapsed ms, Timeout ms, Result) alongside product-state columns
+ * (readiness, terminal status, semantic failure, inspection, provider error
+ * code, HTTP status, and semantic reasons).
  */
 export function buildReviewPanelRows(records = []) {
   return records.map((record) => {
@@ -225,6 +226,18 @@ function timestamp(record) {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
+/**
+ * Aggregates live/recent JobRecords across companion and direct provider state
+ * roots, filters to the canonical workspace, and returns them sorted by
+ * provider order then timestamp.
+ *
+ * Providers scanned: Claude, Gemini, Kimi (companion), Grok, and
+ * api-reviewers (direct). Records without workspace metadata are excluded.
+ *
+ * @param {{ cwd?: string, env?: Record<string, string> }} [options]
+ * @returns {object[]} workspace-matched JobRecords sorted by provider order,
+ *   then descending timestamp, then job_id.
+ */
 export function collectReviewPanelRecords({ cwd = process.cwd(), env = process.env } = {}) {
   const workspaceCanonical = canonicalWorkspace(cwd);
   const records = [

--- a/scripts/review-panel.mjs
+++ b/scripts/review-panel.mjs
@@ -1,22 +1,40 @@
 #!/usr/bin/env node
 import { readFileSync } from "node:fs";
 
-import { renderReviewPanelMarkdown } from "./lib/review-panel.mjs";
+import { collectReviewPanelRecords, renderReviewPanelMarkdown } from "./lib/review-panel.mjs";
 
 function usage() {
   return [
     "Usage:",
     "  node scripts/review-panel.mjs <records.json>",
+    "  node scripts/review-panel.mjs --workspace <path>",
     "",
     "Input must be a JobRecord object, a JSON array of JobRecords, or an object",
     "with a records array. Use '-' to read JSON from stdin.",
   ].join("\n");
 }
 
-function readInput(path) {
-  if (!path || path === "--help" || path === "-h") {
-    return null;
+function parseArgs(argv) {
+  const out = { input: null, workspace: null, help: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === "--help" || token === "-h") {
+      out.help = true;
+      continue;
+    }
+    if (token === "--workspace") {
+      const value = argv[++i];
+      if (!value || value.startsWith("--")) throw new Error("--workspace requires a value");
+      out.workspace = value;
+      continue;
+    }
+    if (out.input) throw new Error(`unexpected argument ${token}`);
+    out.input = token;
   }
+  return out;
+}
+
+function readInput(path) {
   if (path === "-") return readFileSync(0, "utf8");
   return readFileSync(path, "utf8");
 }
@@ -29,12 +47,14 @@ function normalizeRecords(parsed) {
 }
 
 try {
-  const input = readInput(process.argv[2]);
-  if (input === null) {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help || (!args.input && !args.workspace)) {
     console.log(usage());
     process.exit(0);
   }
-  const records = normalizeRecords(JSON.parse(input));
+  const records = args.workspace
+    ? collectReviewPanelRecords({ cwd: args.workspace, env: process.env })
+    : normalizeRecords(JSON.parse(readInput(args.input)));
   console.log(renderReviewPanelMarkdown(records));
 } catch (error) {
   console.error(JSON.stringify({

--- a/scripts/review-panel.mjs
+++ b/scripts/review-panel.mjs
@@ -14,8 +14,9 @@ function usage() {
     "stdin.",
     "",
     "With --workspace, the panel auto-discovers live/recent JobRecords from all",
-    "provider state roots (Claude, Gemini, Kimi, Grok, DeepSeek, GLM) and",
-    "filters by canonical workspace, so no input file is needed.",
+    "provider state roots (Claude, Gemini, Kimi, Grok, and API Reviewers records",
+    "for DeepSeek/GLM) and filters by canonical workspace, so no input file is",
+    "needed.",
   ].join("\n");
 }
 
@@ -30,7 +31,7 @@ function parseArgs(argv) {
     if (token === "--workspace") {
       if (out.input) throw new Error("--workspace and a file argument are mutually exclusive");
       const value = argv[++i];
-      if (!value || value.startsWith("--")) throw new Error("--workspace requires a value");
+      if (!value) throw new Error("--workspace requires a value");
       out.workspace = value;
       continue;
     }

--- a/scripts/review-panel.mjs
+++ b/scripts/review-panel.mjs
@@ -9,8 +9,13 @@ function usage() {
     "  node scripts/review-panel.mjs <records.json>",
     "  node scripts/review-panel.mjs --workspace <path>",
     "",
-    "Input must be a JobRecord object, a JSON array of JobRecords, or an object",
-    "with a records array. Use '-' to read JSON from stdin.",
+    "With a file argument, input must be a JobRecord object, a JSON array of",
+    "JobRecords, or an object with a records array. Use '-' to read JSON from",
+    "stdin.",
+    "",
+    "With --workspace, the panel auto-discovers live/recent JobRecords from all",
+    "provider state roots (Claude, Gemini, Kimi, Grok, DeepSeek, GLM) and",
+    "filters by canonical workspace, so no input file is needed.",
   ].join("\n");
 }
 

--- a/scripts/review-panel.mjs
+++ b/scripts/review-panel.mjs
@@ -16,7 +16,8 @@ function usage() {
     "With --workspace, the panel auto-discovers live/recent JobRecords from all",
     "provider state roots (Claude, Gemini, Kimi, Grok, and API Reviewers records",
     "for DeepSeek/GLM) and filters by canonical workspace, so no input file is",
-    "needed.",
+    "needed. Subdirectory matches require the recorded ancestor to be a real",
+    "Git repository; non-Git workspaces match only by exact recorded path.",
   ].join("\n");
 }
 

--- a/scripts/review-panel.mjs
+++ b/scripts/review-panel.mjs
@@ -23,11 +23,13 @@ function parseArgs(argv) {
       continue;
     }
     if (token === "--workspace") {
+      if (out.input) throw new Error("--workspace and a file argument are mutually exclusive");
       const value = argv[++i];
       if (!value || value.startsWith("--")) throw new Error("--workspace requires a value");
       out.workspace = value;
       continue;
     }
+    if (out.workspace) throw new Error("--workspace and a file argument are mutually exclusive");
     if (out.input) throw new Error(`unexpected argument ${token}`);
     out.input = token;
   }

--- a/tests/unit/review-panel.test.mjs
+++ b/tests/unit/review-panel.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -214,6 +214,25 @@ test("review panel CLI renders markdown from a JSON array file", () => {
   });
 
   assert.match(output, /deepseek \|  \| completed \| sent \| 44211/);
+});
+
+test("review panel CLI rejects workspace and file arguments together", () => {
+  const dir = mkdtempSync(join(tmpdir(), "review-panel-"));
+  const file = join(dir, "records.json");
+  writeFileSync(file, JSON.stringify([]));
+
+  const res = spawnSync(process.execPath, [
+    "scripts/review-panel.mjs",
+    "--workspace", dir,
+    file,
+  ], {
+    cwd: new URL("../..", import.meta.url),
+    encoding: "utf8",
+  });
+
+  assert.equal(res.status, 1);
+  assert.equal(res.stdout, "");
+  assert.match(res.stderr, /--workspace and a file argument are mutually exclusive/);
 });
 
 function writeRecord(root, record, stateSubdir = null) {

--- a/tests/unit/review-panel.test.mjs
+++ b/tests/unit/review-panel.test.mjs
@@ -276,6 +276,26 @@ test("review panel does not show stale failed-review-slot result for active jobs
   assert.equal(row.result, "-");
 });
 
+test("review panel distinguishes transient rate limits from quota exhaustion", () => {
+  const rows = buildReviewPanelRows([
+    {
+      provider: "deepseek",
+      status: "failed",
+      error_code: "rate_limited",
+      external_review: { source_content_transmission: "sent" },
+    },
+    {
+      provider: "glm",
+      status: "failed",
+      error_code: "usage_limited",
+      external_review: { source_content_transmission: "sent" },
+    },
+  ]);
+
+  assert.equal(rows[0].state, "rate_limited");
+  assert.equal(rows[1].state, "usage_limited");
+});
+
 function writeRecord(root, record, stateSubdir = null) {
   const jobId = record.job_id ?? record.id;
   const dir = stateSubdir
@@ -436,5 +456,43 @@ test("review panel workspace collection excludes records without workspace metad
 
   assert.deepEqual(records.map((record) => record.job_id), [
     "job_aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+  ]);
+});
+
+test("review panel workspace collection sorts unknown providers after known providers", () => {
+  const workspace = mkdtempSync(join(tmpdir(), "review-panel-workspace-"));
+  const claudeData = mkdtempSync(join(tmpdir(), "review-panel-claude-"));
+  const apiData = mkdtempSync(join(tmpdir(), "review-panel-api-"));
+
+  writeRecord(apiData, {
+    id: "job_unknown-0000-4000-8000-000000000000",
+    job_id: "job_unknown-0000-4000-8000-000000000000",
+    provider: "unknown-provider",
+    status: "completed",
+    workspace_root: workspace,
+  });
+
+  writeRecord(claudeData, {
+    job_id: "job_known-0000-4000-8000-000000000000",
+    provider: "claude",
+    status: "completed",
+    workspace_root: workspace,
+  }, "workspace-a");
+
+  const records = collectReviewPanelRecords({
+    cwd: workspace,
+    env: {
+      ...process.env,
+      CLAUDE_PLUGIN_DATA: claudeData,
+      GEMINI_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-gemini-")),
+      KIMI_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-kimi-")),
+      GROK_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-grok-")),
+      API_REVIEWERS_PLUGIN_DATA: apiData,
+    },
+  });
+
+  assert.deepEqual(records.map((record) => record.provider), [
+    "claude",
+    "unknown-provider",
   ]);
 });

--- a/tests/unit/review-panel.test.mjs
+++ b/tests/unit/review-panel.test.mjs
@@ -376,6 +376,13 @@ function writeCompanionRecord(root, record, stateSubdir) {
   writeFileSync(join(dir, `${jobId}.json`), JSON.stringify(record, null, 2));
 }
 
+function writeCompanionFallbackRecord(root, record, stateSubdir) {
+  const jobId = record.job_id ?? record.id;
+  const dir = join(root, stateSubdir, "jobs");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${jobId}.json`), JSON.stringify(record, null, 2));
+}
+
 function writerDefaultDataRoot(pluginName, cwd) {
   const workspace = resolve(cwd);
   const slug = basename(workspace).replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 48) || "workspace";
@@ -513,7 +520,7 @@ test("review panel workspace collection excludes records without workspace metad
   const otherWorkspace = mkdtempSync(join(tmpdir(), "review-panel-other-"));
   const claudeData = mkdtempSync(join(tmpdir(), "review-panel-claude-"));
 
-  writeRecord(claudeData, {
+  writeCompanionRecord(claudeData, {
     job_id: "job_aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
     provider: "claude",
     status: "completed",
@@ -521,20 +528,28 @@ test("review panel workspace collection excludes records without workspace metad
     result: "Verdict: APPROVE",
   }, "workspace-a");
 
-  writeRecord(claudeData, {
+  writeCompanionRecord(claudeData, {
     job_id: "job_bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
     provider: "claude",
     status: "completed",
     result: "Verdict: APPROVE",
   }, "other-workspace-without-metadata");
 
-  writeRecord(claudeData, {
+  writeCompanionRecord(claudeData, {
     job_id: "job_cccccccc-cccc-4ccc-8ccc-cccccccccccc",
     provider: "claude",
     status: "completed",
     workspace_root: otherWorkspace,
     result: "Verdict: APPROVE",
   }, "other-workspace");
+
+  writeCompanionRecord(claudeData, {
+    job_id: "job_dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+    provider: "claude",
+    status: "completed",
+    workspaceRoot: workspace,
+    result: "Verdict: APPROVE",
+  }, "workspace-camel");
 
   const records = collectReviewPanelRecords({
     cwd: workspace,
@@ -550,6 +565,7 @@ test("review panel workspace collection excludes records without workspace metad
 
   assert.deepEqual(records.map((record) => record.job_id), [
     "job_aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    "job_dddddddd-dddd-4ddd-8ddd-dddddddddddd",
   ]);
 });
 
@@ -557,7 +573,7 @@ test("review panel skips malformed workspace metadata without aborting collectio
   const workspace = mkdtempSync(join(tmpdir(), "review-panel-workspace-"));
   const claudeData = mkdtempSync(join(tmpdir(), "review-panel-claude-"));
 
-  writeRecord(claudeData, {
+  writeCompanionRecord(claudeData, {
     job_id: "job_valid-0000-4000-8000-000000000000",
     provider: "claude",
     status: "completed",
@@ -565,7 +581,7 @@ test("review panel skips malformed workspace metadata without aborting collectio
     result: "Verdict: APPROVE",
   }, "workspace-a");
 
-  writeRecord(claudeData, {
+  writeCompanionRecord(claudeData, {
     job_id: "job_bad-0000-4000-8000-000000000000",
     provider: "claude",
     status: "completed",
@@ -646,6 +662,36 @@ test("review panel rejects non-repo ancestor workspace records", () => {
   assert.deepEqual(records.map((record) => record.job_id), []);
 });
 
+test("review panel rejects fake .git files for ancestor workspace records", () => {
+  const parentWorkspace = mkdtempSync(join(tmpdir(), "review-panel-parent-"));
+  const childWorkspace = join(parentWorkspace, "packages", "tool");
+  mkdirSync(childWorkspace, { recursive: true });
+  writeFileSync(join(parentWorkspace, ".git"), "gitdir: /not/a/real/git/dir\n");
+  const apiData = mkdtempSync(join(tmpdir(), "review-panel-api-"));
+
+  writeRecord(apiData, {
+    job_id: "job_fakegit-0000-4000-8000-000000000000",
+    provider: "deepseek",
+    status: "completed",
+    workspace_root: parentWorkspace,
+    result: "Verdict: APPROVE",
+  });
+
+  const records = collectReviewPanelRecords({
+    cwd: childWorkspace,
+    env: {
+      ...process.env,
+      CLAUDE_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-claude-")),
+      GEMINI_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-gemini-")),
+      KIMI_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-kimi-")),
+      GROK_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-grok-")),
+      API_REVIEWERS_PLUGIN_DATA: apiData,
+    },
+  });
+
+  assert.deepEqual(records.map((record) => record.job_id), []);
+});
+
 test("review panel readiness ignores stale grok error codes outside failed jobs", () => {
   const rows = buildReviewPanelRows([
     {
@@ -697,7 +743,7 @@ test("review panel direct fallback finds records written with lexical workspace 
       GEMINI_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-gemini-")),
       KIMI_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-kimi-")),
       API_REVIEWERS_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-api-")),
-      GROK_PLUGIN_DATA: "",
+      GROK_PLUGIN_DATA: undefined,
     },
   });
 
@@ -731,7 +777,7 @@ test("review panel direct fallback finds symlink-written records from canonical 
       GEMINI_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-gemini-")),
       KIMI_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-kimi-")),
       API_REVIEWERS_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-api-")),
-      GROK_PLUGIN_DATA: "",
+      GROK_PLUGIN_DATA: undefined,
     },
   });
 
@@ -748,15 +794,16 @@ test("review panel companion fallback finds records from git root when workspace
   const subdir = join(repo, "packages", "tool");
   mkdirSync(subdir, { recursive: true });
   const stateId = companionStateIdForWorkspaceRoot(repo);
-  const jobsRoot = join(tmpdir(), "claude-companion", stateId);
+  const fallbackRoot = join(tmpdir(), "claude-companion");
+  const jobsRoot = join(fallbackRoot, stateId);
 
-  writeRecord(jobsRoot, {
+  writeCompanionFallbackRecord(fallbackRoot, {
     job_id: "job_claude-0000-4000-8000-000000000000",
     provider: "claude",
     status: "completed",
     workspace_root: repo,
     result: "Verdict: APPROVE",
-  });
+  }, stateId);
 
   const records = collectReviewPanelRecords({
     cwd: subdir,
@@ -777,6 +824,125 @@ test("review panel companion fallback finds records from git root when workspace
   rmSync(jobsRoot, { recursive: true, force: true });
 });
 
+test("review panel direct providers honor explicit empty plugin data paths", () => {
+  const workspace = mkdtempSync(join(tmpdir(), "review-panel-workspace-"));
+  writeRecord(workspace, {
+    job_id: "job_empty-env-0000-4000-8000-000000000000",
+    provider: "deepseek",
+    status: "completed",
+    workspace_root: workspace,
+    result: "Verdict: APPROVE",
+  });
+
+  const previousCwd = process.cwd();
+  process.chdir(workspace);
+  try {
+    const records = collectReviewPanelRecords({
+      cwd: workspace,
+      env: {
+        ...process.env,
+        CLAUDE_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-claude-")),
+        GEMINI_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-gemini-")),
+        KIMI_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-kimi-")),
+        GROK_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-grok-")),
+        API_REVIEWERS_PLUGIN_DATA: "",
+      },
+    });
+
+    assert.deepEqual(records.map((record) => record.job_id), [
+      "job_empty-env-0000-4000-8000-000000000000",
+    ]);
+  } finally {
+    process.chdir(previousCwd);
+  }
+});
+
+test("review panel skips symlinked jobs directories", () => {
+  const workspace = mkdtempSync(join(tmpdir(), "review-panel-workspace-"));
+  const apiData = mkdtempSync(join(tmpdir(), "review-panel-api-"));
+  const outsideData = mkdtempSync(join(tmpdir(), "review-panel-outside-"));
+  writeRecord(outsideData, {
+    job_id: "job_symlink-0000-4000-8000-000000000000",
+    provider: "deepseek",
+    status: "completed",
+    workspace_root: workspace,
+    result: "Verdict: APPROVE",
+  });
+  symlinkSync(join(outsideData, "jobs"), join(apiData, "jobs"), "dir");
+
+  const records = collectReviewPanelRecords({
+    cwd: workspace,
+    env: {
+      ...process.env,
+      CLAUDE_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-claude-")),
+      GEMINI_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-gemini-")),
+      KIMI_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-kimi-")),
+      GROK_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-grok-")),
+      API_REVIEWERS_PLUGIN_DATA: apiData,
+    },
+  });
+
+  assert.deepEqual(records.map((record) => record.job_id), []);
+});
+
+test("review panel prefers flat companion records over colliding sidecar meta records", () => {
+  const workspace = mkdtempSync(join(tmpdir(), "review-panel-workspace-"));
+  const claudeData = mkdtempSync(join(tmpdir(), "review-panel-claude-"));
+  const jobId = "job_dupe-0000-4000-8000-000000000000";
+
+  writeCompanionRecord(claudeData, {
+    job_id: jobId,
+    provider: "claude",
+    status: "completed",
+    workspace_root: workspace,
+    result: "Verdict: APPROVE",
+  }, "workspace-a");
+  writeRecord(claudeData, {
+    job_id: jobId,
+    provider: "claude",
+    status: "failed",
+    error_code: "stale_sidecar_meta",
+    workspace_root: workspace,
+  }, "workspace-a");
+
+  const records = collectReviewPanelRecords({
+    cwd: workspace,
+    env: {
+      ...process.env,
+      CLAUDE_PLUGIN_DATA: claudeData,
+      GEMINI_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-gemini-")),
+      KIMI_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-kimi-")),
+      GROK_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-grok-")),
+      API_REVIEWERS_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-api-")),
+    },
+  });
+
+  assert.deepEqual(records.map((record) => record.job_id), [jobId]);
+  assert.equal(records[0].status, "completed");
+});
+
+test("review panel rendering skips non-object records from JSON arrays", () => {
+  const output = renderReviewPanelMarkdown([
+    null,
+    42,
+    {
+      provider: "claude",
+      job_id: "job_valid-array-0000-4000-8000-000000000000",
+      status: "completed",
+      result: "Verdict: REJECT",
+    },
+    {
+      provider: "gemini",
+      job_id: "job_fail-array-0000-4000-8000-000000000000",
+      status: "completed",
+      result: "Verdict: FAIL",
+    },
+  ]);
+
+  assert.match(output, /job_valid-array-0000-4000-8000-000000000000 \| completed .* reject/);
+  assert.match(output, /job_fail-array-0000-4000-8000-000000000000 \| completed .* fail/);
+});
+
 test("review panel workspace collection sorts unknown providers after known providers", () => {
   const workspace = mkdtempSync(join(tmpdir(), "review-panel-workspace-"));
   const claudeData = mkdtempSync(join(tmpdir(), "review-panel-claude-"));
@@ -790,7 +956,7 @@ test("review panel workspace collection sorts unknown providers after known prov
     workspace_root: workspace,
   });
 
-  writeRecord(claudeData, {
+  writeCompanionRecord(claudeData, {
     job_id: "job_known-0000-4000-8000-000000000000",
     provider: "claude",
     status: "completed",

--- a/tests/unit/review-panel.test.mjs
+++ b/tests/unit/review-panel.test.mjs
@@ -2,7 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdirSync, mkdtempSync, readFileSync, realpathSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join, resolve } from "node:path";
 
@@ -369,6 +369,13 @@ function writeRecord(root, record, stateSubdir = null) {
   writeFileSync(join(dir, "meta.json"), JSON.stringify(record, null, 2));
 }
 
+function writeCompanionRecord(root, record, stateSubdir) {
+  const jobId = record.job_id ?? record.id;
+  const dir = join(root, "state", stateSubdir, "jobs");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${jobId}.json`), JSON.stringify(record, null, 2));
+}
+
 function writerDefaultDataRoot(pluginName, cwd) {
   const workspace = resolve(cwd);
   const slug = basename(workspace).replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 48) || "workspace";
@@ -391,7 +398,7 @@ test("review panel CLI aggregates live and recent jobs across provider state roo
   const grokData = mkdtempSync(join(tmpdir(), "review-panel-grok-"));
   const apiData = mkdtempSync(join(tmpdir(), "review-panel-api-"));
 
-  writeRecord(claudeData, {
+  writeCompanionRecord(claudeData, {
     job_id: "job_11111111-1111-4111-8111-111111111111",
     provider: "claude",
     status: "running",
@@ -400,7 +407,7 @@ test("review panel CLI aggregates live and recent jobs across provider state roo
     review_metadata: { raw_output: { elapsed_ms: 1234 } },
   }, "workspace-a");
 
-  writeRecord(geminiData, {
+  writeCompanionRecord(geminiData, {
     job_id: "job_22222222-2222-4222-8222-222222222222",
     provider: "gemini",
     status: "failed",
@@ -420,7 +427,7 @@ test("review panel CLI aggregates live and recent jobs across provider state roo
     review_metadata: { raw_output: { elapsed_ms: 8000 } },
   });
 
-  writeRecord(kimiData, {
+  writeCompanionRecord(kimiData, {
     job_id: "job_66666666-6666-4666-8666-666666666666",
     provider: "kimi",
     status: "failed",
@@ -583,6 +590,90 @@ test("review panel skips malformed workspace metadata without aborting collectio
   ]);
 });
 
+test("review panel rejects filesystem-root workspace records", () => {
+  const workspace = mkdtempSync(join(tmpdir(), "review-panel-workspace-"));
+  const apiData = mkdtempSync(join(tmpdir(), "review-panel-api-"));
+
+  writeRecord(apiData, {
+    job_id: "job_root-0000-4000-8000-000000000000",
+    provider: "deepseek",
+    status: "completed",
+    workspace_root: "/",
+    result: "Verdict: APPROVE",
+  });
+
+  const records = collectReviewPanelRecords({
+    cwd: workspace,
+    env: {
+      ...process.env,
+      CLAUDE_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-claude-")),
+      GEMINI_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-gemini-")),
+      KIMI_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-kimi-")),
+      GROK_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-grok-")),
+      API_REVIEWERS_PLUGIN_DATA: apiData,
+    },
+  });
+
+  assert.deepEqual(records.map((record) => record.job_id), []);
+});
+
+test("review panel rejects non-repo ancestor workspace records", () => {
+  const parentWorkspace = mkdtempSync(join(tmpdir(), "review-panel-parent-"));
+  const childWorkspace = join(parentWorkspace, "packages", "tool");
+  mkdirSync(childWorkspace, { recursive: true });
+  const apiData = mkdtempSync(join(tmpdir(), "review-panel-api-"));
+
+  writeRecord(apiData, {
+    job_id: "job_parent-0000-4000-8000-000000000000",
+    provider: "deepseek",
+    status: "completed",
+    workspace_root: parentWorkspace,
+    result: "Verdict: APPROVE",
+  });
+
+  const records = collectReviewPanelRecords({
+    cwd: childWorkspace,
+    env: {
+      ...process.env,
+      CLAUDE_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-claude-")),
+      GEMINI_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-gemini-")),
+      KIMI_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-kimi-")),
+      GROK_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-grok-")),
+      API_REVIEWERS_PLUGIN_DATA: apiData,
+    },
+  });
+
+  assert.deepEqual(records.map((record) => record.job_id), []);
+});
+
+test("review panel readiness ignores stale grok error codes outside failed jobs", () => {
+  const rows = buildReviewPanelRows([
+    {
+      provider: "grok",
+      status: "running",
+      error_code: "grok_session_expired",
+      external_review: { source_content_transmission: "sent" },
+    },
+    {
+      provider: "grok",
+      status: "completed",
+      error_code: "models_ok_chat_400",
+      external_review: { source_content_transmission: "sent" },
+      review_metadata: {
+        audit_manifest: {
+          review_quality: { failed_review_slot: false, semantic_failure_reasons: [] },
+        },
+      },
+      result: "Verdict: APPROVE",
+    },
+  ]);
+
+  assert.equal(rows[0].readiness, "unknown");
+  assert.equal(rows[0].error_code, "");
+  assert.equal(rows[1].readiness, "review-ready");
+  assert.equal(rows[1].error_code, "");
+});
+
 test("review panel direct fallback finds records written with lexical workspace hashes", () => {
   const realWorkspace = mkdtempSync(join(tmpdir(), "review-panel-real-"));
   const linkParent = mkdtempSync(join(tmpdir(), "review-panel-link-parent-"));
@@ -613,6 +704,42 @@ test("review panel direct fallback finds records written with lexical workspace 
   assert.deepEqual(records.map((record) => record.job_id), [
     "job_grok-0000-4000-8000-000000000000",
   ]);
+
+  rmSync(grokData, { recursive: true, force: true });
+});
+
+test("review panel direct fallback finds symlink-written records from canonical cwd", () => {
+  const realWorkspace = mkdtempSync(join(tmpdir(), "review-panel-real-"));
+  const linkParent = mkdtempSync(join(tmpdir(), "review-panel-link-parent-"));
+  const linkWorkspace = join(linkParent, "workspace-link");
+  symlinkSync(realWorkspace, linkWorkspace, "dir");
+  const grokData = writerDefaultDataRoot("grok", linkWorkspace);
+
+  writeRecord(grokData, {
+    job_id: "job_grok-canonical-4000-8000-000000000000",
+    provider: "grok",
+    status: "completed",
+    workspace_root: realWorkspace,
+    result: "Verdict: APPROVE",
+  });
+
+  const records = collectReviewPanelRecords({
+    cwd: realWorkspace,
+    env: {
+      ...process.env,
+      CLAUDE_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-claude-")),
+      GEMINI_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-gemini-")),
+      KIMI_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-kimi-")),
+      API_REVIEWERS_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-api-")),
+      GROK_PLUGIN_DATA: "",
+    },
+  });
+
+  assert.deepEqual(records.map((record) => record.job_id), [
+    "job_grok-canonical-4000-8000-000000000000",
+  ]);
+
+  rmSync(grokData, { recursive: true, force: true });
 });
 
 test("review panel companion fallback finds records from git root when workspace is a subdir", () => {
@@ -646,6 +773,8 @@ test("review panel companion fallback finds records from git root when workspace
   assert.deepEqual(records.map((record) => record.job_id), [
     "job_claude-0000-4000-8000-000000000000",
   ]);
+
+  rmSync(jobsRoot, { recursive: true, force: true });
 });
 
 test("review panel workspace collection sorts unknown providers after known providers", () => {

--- a/tests/unit/review-panel.test.mjs
+++ b/tests/unit/review-panel.test.mjs
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -10,6 +10,11 @@ import {
   collectReviewPanelRecords,
   renderReviewPanelMarkdown,
 } from "../../scripts/lib/review-panel.mjs";
+
+test("review panel slug trimming avoids Sonar-flagged boundary alternation regex", () => {
+  const source = readFileSync(new URL("../../scripts/lib/review-panel.mjs", import.meta.url), "utf8");
+  assert.doesNotMatch(source, /value\.replace\(\s*\/\^-\+\|-\+\$\/g/);
+});
 
 test("review panel rows expose operational and semantic review state", () => {
   const rows = buildReviewPanelRows([

--- a/tests/unit/review-panel.test.mjs
+++ b/tests/unit/review-panel.test.mjs
@@ -7,6 +7,7 @@ import { join } from "node:path";
 
 import {
   buildReviewPanelRows,
+  collectReviewPanelRecords,
   renderReviewPanelMarkdown,
 } from "../../scripts/lib/review-panel.mjs";
 
@@ -235,6 +236,41 @@ test("review panel CLI rejects workspace and file arguments together", () => {
   assert.match(res.stderr, /--workspace and a file argument are mutually exclusive/);
 });
 
+test("review panel treats queued jobs as active even with stale approval error code", () => {
+  const [row] = buildReviewPanelRows([
+    {
+      provider: "deepseek",
+      status: "queued",
+      error_code: "approval_required",
+      external_review: { source_content_transmission: "not_sent" },
+    },
+  ]);
+
+  assert.equal(row.state, "running");
+  assert.equal(row.result, "-");
+});
+
+test("review panel does not show stale failed-review-slot result for active jobs", () => {
+  const [row] = buildReviewPanelRows([
+    {
+      provider: "claude",
+      status: "running",
+      external_review: { source_content_transmission: "sent" },
+      review_metadata: {
+        audit_manifest: {
+          review_quality: {
+            failed_review_slot: true,
+            semantic_failure_reasons: ["missing_verdict"],
+          },
+        },
+      },
+    },
+  ]);
+
+  assert.equal(row.state, "source_sent_waiting");
+  assert.equal(row.result, "-");
+});
+
 function writeRecord(root, record, stateSubdir = null) {
   const jobId = record.job_id ?? record.id;
   const dir = stateSubdir
@@ -360,4 +396,40 @@ test("review panel CLI aggregates live and recent jobs across provider state roo
   assert.match(output, /deepseek \| job_44444444-4444-4444-8444-444444444444 \| approval_required \| not_sent \| 34 \|  \| approval_required/);
   assert.match(output, /glm \| job_55555555-5555-4555-8555-555555555555 \| completed \| sent \| 45422 \|  \| approve/);
   assert.match(output, /glm \| job_77777777-7777-4777-8777-777777777777 \| completed_failed_review_slot \| sent \| 91 \|  \| failed_review_slot/);
+});
+
+test("review panel workspace collection excludes records without workspace metadata from scanned state roots", () => {
+  const workspace = mkdtempSync(join(tmpdir(), "review-panel-workspace-"));
+  const claudeData = mkdtempSync(join(tmpdir(), "review-panel-claude-"));
+
+  writeRecord(claudeData, {
+    job_id: "job_aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    provider: "claude",
+    status: "completed",
+    workspace_root: workspace,
+    result: "Verdict: APPROVE",
+  }, "workspace-a");
+
+  writeRecord(claudeData, {
+    job_id: "job_bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    provider: "claude",
+    status: "completed",
+    result: "Verdict: APPROVE",
+  }, "other-workspace-without-metadata");
+
+  const records = collectReviewPanelRecords({
+    cwd: workspace,
+    env: {
+      ...process.env,
+      CLAUDE_PLUGIN_DATA: claudeData,
+      GEMINI_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-gemini-")),
+      KIMI_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-kimi-")),
+      GROK_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-grok-")),
+      API_REVIEWERS_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-api-")),
+    },
+  });
+
+  assert.deepEqual(records.map((record) => record.job_id), [
+    "job_aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+  ]);
 });

--- a/tests/unit/review-panel.test.mjs
+++ b/tests/unit/review-panel.test.mjs
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -84,10 +84,15 @@ test("review panel rows expose operational and semantic review state", () => {
   assert.deepEqual(rows, [
     {
       provider: "claude",
+      job_id: "",
+      state: "failed",
       status: "failed",
       readiness: "review failed",
+      sent: "sent",
       source_sent: "sent",
       elapsed_ms: 337917,
+      timeout_ms: "",
+      result: "failed_review_slot",
       semantic_failed: true,
       inspection: "blocked",
       error_code: "review_not_completed",
@@ -96,10 +101,15 @@ test("review panel rows expose operational and semantic review state", () => {
     },
     {
       provider: "grok",
+      job_id: "",
+      state: "failed_before_source_send",
       status: "failed",
       readiness: "not review-ready",
+      sent: "not_sent",
       source_sent: "not_sent",
       elapsed_ms: 554,
+      timeout_ms: "",
+      result: "failed_review_slot",
       semantic_failed: true,
       inspection: "unknown",
       error_code: "models_ok_chat_400",
@@ -108,10 +118,15 @@ test("review panel rows expose operational and semantic review state", () => {
     },
     {
       provider: "glm",
+      job_id: "",
+      state: "completed",
       status: "completed",
       readiness: "review-ready",
+      sent: "sent",
       source_sent: "sent",
       elapsed_ms: 45422,
+      timeout_ms: "",
+      result: "request_changes",
       semantic_failed: false,
       inspection: "inspected",
       error_code: "",
@@ -141,8 +156,8 @@ test("review panel markdown renders one visibly explicit provider row per record
     },
   ]);
 
-  assert.match(markdown, /Provider \| Readiness \| Status \| Source Sent \| Elapsed/);
-  assert.match(markdown, /claude \| review failed \| failed \| sent \| 70906/);
+  assert.match(markdown, /Provider \| Job ID \| State \| Sent \| Elapsed/);
+  assert.match(markdown, /claude \|  \| failed \| sent \| 70906/);
   assert.match(markdown, /review_not_completed/);
   assert.match(markdown, /not_reviewed/);
 });
@@ -198,5 +213,132 @@ test("review panel CLI renders markdown from a JSON array file", () => {
     encoding: "utf8",
   });
 
-  assert.match(output, /deepseek \| review-ready \| completed \| sent \| 44211/);
+  assert.match(output, /deepseek \|  \| completed \| sent \| 44211/);
+});
+
+function writeRecord(root, record, stateSubdir = null) {
+  const jobId = record.job_id ?? record.id;
+  const dir = stateSubdir
+    ? join(root, "state", stateSubdir, "jobs", jobId)
+    : join(root, "jobs", jobId);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "meta.json"), JSON.stringify(record, null, 2));
+}
+
+test("review panel CLI aggregates live and recent jobs across provider state roots", () => {
+  const workspace = mkdtempSync(join(tmpdir(), "review-panel-workspace-"));
+  const claudeData = mkdtempSync(join(tmpdir(), "review-panel-claude-"));
+  const geminiData = mkdtempSync(join(tmpdir(), "review-panel-gemini-"));
+  const kimiData = mkdtempSync(join(tmpdir(), "review-panel-kimi-"));
+  const grokData = mkdtempSync(join(tmpdir(), "review-panel-grok-"));
+  const apiData = mkdtempSync(join(tmpdir(), "review-panel-api-"));
+
+  writeRecord(claudeData, {
+    job_id: "job_11111111-1111-4111-8111-111111111111",
+    provider: "claude",
+    status: "running",
+    workspace_root: workspace,
+    external_review: { source_content_transmission: "sent" },
+    review_metadata: { raw_output: { elapsed_ms: 1234 } },
+  }, "workspace-a");
+
+  writeRecord(geminiData, {
+    job_id: "job_22222222-2222-4222-8222-222222222222",
+    provider: "gemini",
+    status: "failed",
+    error_code: "timeout",
+    workspace_root: workspace,
+    external_review: { source_content_transmission: "sent" },
+    review_metadata: { raw_output: { elapsed_ms: 600000 } },
+  }, "workspace-a");
+
+  writeRecord(grokData, {
+    job_id: "job_33333333-3333-4333-8333-333333333333",
+    provider: "grok",
+    status: "failed",
+    error_code: "tunnel_unavailable",
+    workspace_root: workspace,
+    external_review: { source_content_transmission: "not_sent" },
+    review_metadata: { raw_output: { elapsed_ms: 8000 } },
+  });
+
+  writeRecord(kimiData, {
+    job_id: "job_66666666-6666-4666-8666-666666666666",
+    provider: "kimi",
+    status: "failed",
+    error_code: "provider_unavailable",
+    workspace_root: workspace,
+    external_review: { source_content_transmission: "sent" },
+    review_metadata: { raw_output: { elapsed_ms: 99 } },
+  }, "workspace-a");
+
+  writeRecord(apiData, {
+    id: "job_44444444-4444-4444-8444-444444444444",
+    job_id: "job_44444444-4444-4444-8444-444444444444",
+    provider: "deepseek",
+    status: "failed",
+    error_code: "approval_required",
+    workspace_root: workspace,
+    external_review: { source_content_transmission: "not_sent" },
+    review_metadata: { raw_output: { elapsed_ms: 34 } },
+  });
+
+  writeRecord(apiData, {
+    id: "job_55555555-5555-4555-8555-555555555555",
+    job_id: "job_55555555-5555-4555-8555-555555555555",
+    provider: "glm",
+    status: "completed",
+    http_status: 200,
+    workspace_root: workspace,
+    external_review: { source_content_transmission: "sent" },
+    review_metadata: {
+      raw_output: { elapsed_ms: 45422 },
+      audit_manifest: { review_quality: { failed_review_slot: false, semantic_failure_reasons: [] } },
+    },
+    result: "Verdict: APPROVE\nInspection status\n- I inspected the selected file.",
+  });
+
+  writeRecord(apiData, {
+    id: "job_77777777-7777-4777-8777-777777777777",
+    job_id: "job_77777777-7777-4777-8777-777777777777",
+    provider: "glm",
+    status: "completed",
+    workspace_root: workspace,
+    external_review: { source_content_transmission: "sent" },
+    review_metadata: {
+      raw_output: { elapsed_ms: 91 },
+      audit_manifest: {
+        review_quality: {
+          failed_review_slot: true,
+          semantic_failure_reasons: ["shallow_output", "missing_verdict"],
+        },
+      },
+    },
+    result: "No actionable review.",
+  });
+
+  const output = execFileSync(process.execPath, [
+    "scripts/review-panel.mjs",
+    "--workspace", workspace,
+  ], {
+    cwd: new URL("../..", import.meta.url),
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CLAUDE_PLUGIN_DATA: claudeData,
+      GEMINI_PLUGIN_DATA: geminiData,
+      KIMI_PLUGIN_DATA: kimiData,
+      GROK_PLUGIN_DATA: grokData,
+      API_REVIEWERS_PLUGIN_DATA: apiData,
+    },
+  });
+
+  assert.match(output, /Provider \| Job ID \| State \| Sent \| Elapsed ms \| Timeout ms \| Result/);
+  assert.match(output, /claude \| job_11111111-1111-4111-8111-111111111111 \| source_sent_waiting \| sent \| 1234 \|  \| -/);
+  assert.match(output, /gemini \| job_22222222-2222-4222-8222-222222222222 \| source_sent_timeout \| sent \| 600000 \|  \| timeout/);
+  assert.match(output, /kimi \| job_66666666-6666-4666-8666-666666666666 \| provider_unavailable \| sent \| 99 \|  \| provider_unavailable/);
+  assert.match(output, /grok \| job_33333333-3333-4333-8333-333333333333 \| failed_before_source_send \| not_sent \| 8000 \|  \| tunnel_unavailable/);
+  assert.match(output, /deepseek \| job_44444444-4444-4444-8444-444444444444 \| approval_required \| not_sent \| 34 \|  \| approval_required/);
+  assert.match(output, /glm \| job_55555555-5555-4555-8555-555555555555 \| completed \| sent \| 45422 \|  \| approve/);
+  assert.match(output, /glm \| job_77777777-7777-4777-8777-777777777777 \| completed_failed_review_slot \| sent \| 91 \|  \| failed_review_slot/);
 });

--- a/tests/unit/review-panel.test.mjs
+++ b/tests/unit/review-panel.test.mjs
@@ -1,9 +1,10 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join, resolve } from "node:path";
 
 import {
   buildReviewPanelRows,
@@ -98,7 +99,7 @@ test("review panel rows expose operational and semantic review state", () => {
       source_sent: "sent",
       elapsed_ms: 337917,
       timeout_ms: "",
-      result: "failed_review_slot",
+      result: "review_not_completed",
       semantic_failed: true,
       inspection: "blocked",
       error_code: "review_not_completed",
@@ -115,7 +116,7 @@ test("review panel rows expose operational and semantic review state", () => {
       source_sent: "not_sent",
       elapsed_ms: 554,
       timeout_ms: "",
-      result: "failed_review_slot",
+      result: "models_ok_chat_400",
       semantic_failed: true,
       inspection: "unknown",
       error_code: "models_ok_chat_400",
@@ -241,6 +242,31 @@ test("review panel CLI rejects workspace and file arguments together", () => {
   assert.match(res.stderr, /--workspace and a file argument are mutually exclusive/);
 });
 
+test("review panel CLI accepts workspace paths that start with dashes", () => {
+  const parent = mkdtempSync(join(tmpdir(), "review-panel-dash-parent-"));
+  const workspace = join(parent, "--staging");
+  mkdirSync(workspace);
+
+  const res = spawnSync(process.execPath, [
+    resolve("scripts/review-panel.mjs"),
+    "--workspace", "--staging",
+  ], {
+    cwd: parent,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CLAUDE_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-claude-")),
+      GEMINI_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-gemini-")),
+      KIMI_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-kimi-")),
+      GROK_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-grok-")),
+      API_REVIEWERS_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-api-")),
+    },
+  });
+
+  assert.equal(res.status, 0);
+  assert.match(res.stdout, /Provider \| Job ID \| State/);
+});
+
 test("review panel treats queued jobs as active even with stale approval error code", () => {
   const [row] = buildReviewPanelRows([
     {
@@ -274,6 +300,30 @@ test("review panel does not show stale failed-review-slot result for active jobs
 
   assert.equal(row.state, "source_sent_waiting");
   assert.equal(row.result, "-");
+  assert.equal(row.semantic_failed, false);
+  assert.equal(row.reasons, "");
+});
+
+test("review panel prioritizes failed error codes over stale failed-review-slot metadata", () => {
+  const [row] = buildReviewPanelRows([
+    {
+      provider: "gemini",
+      status: "failed",
+      error_code: "timeout",
+      external_review: { source_content_transmission: "sent" },
+      review_metadata: {
+        audit_manifest: {
+          review_quality: {
+            failed_review_slot: true,
+            semantic_failure_reasons: ["missing_verdict"],
+          },
+        },
+      },
+    },
+  ]);
+
+  assert.equal(row.state, "source_sent_timeout");
+  assert.equal(row.result, "timeout");
 });
 
 test("review panel distinguishes transient rate limits from quota exhaustion", () => {
@@ -282,18 +332,32 @@ test("review panel distinguishes transient rate limits from quota exhaustion", (
       provider: "deepseek",
       status: "failed",
       error_code: "rate_limited",
-      external_review: { source_content_transmission: "sent" },
+      external_review: { source_content_transmission: "not_sent" },
     },
     {
       provider: "glm",
       status: "failed",
       error_code: "usage_limited",
-      external_review: { source_content_transmission: "sent" },
+      external_review: { source_content_transmission: "not_sent" },
+    },
+    {
+      provider: "grok",
+      status: "failed",
+      error_code: "tunnel_unavailable",
+      external_review: { source_content_transmission: "not_sent" },
+    },
+    {
+      provider: "claude",
+      status: "failed",
+      error_code: "session_expired",
+      external_review: { source_content_transmission: "not_sent" },
     },
   ]);
 
   assert.equal(rows[0].state, "rate_limited");
   assert.equal(rows[1].state, "usage_limited");
+  assert.equal(rows[2].state, "provider_unavailable");
+  assert.equal(rows[3].state, "auth_session_failure");
 });
 
 function writeRecord(root, record, stateSubdir = null) {
@@ -303,6 +367,20 @@ function writeRecord(root, record, stateSubdir = null) {
     : join(root, "jobs", jobId);
   mkdirSync(dir, { recursive: true });
   writeFileSync(join(dir, "meta.json"), JSON.stringify(record, null, 2));
+}
+
+function writerDefaultDataRoot(pluginName, cwd) {
+  const workspace = resolve(cwd);
+  const slug = basename(workspace).replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 48) || "workspace";
+  const hash = createHash("sha256").update(workspace).digest("hex").slice(0, 16);
+  return resolve(tmpdir(), "codex-plugin-multi", pluginName, `${slug}-${hash}`);
+}
+
+function companionStateIdForWorkspaceRoot(workspaceRoot) {
+  const canonical = realpathSync.native(resolve(workspaceRoot));
+  const slug = (basename(workspaceRoot) || "workspace").replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "workspace";
+  const hash = createHash("sha256").update(canonical).digest("hex").slice(0, 16);
+  return `${slug}-${hash}`;
 }
 
 test("review panel CLI aggregates live and recent jobs across provider state roots", () => {
@@ -417,7 +495,7 @@ test("review panel CLI aggregates live and recent jobs across provider state roo
   assert.match(output, /claude \| job_11111111-1111-4111-8111-111111111111 \| source_sent_waiting \| sent \| 1234 \|  \| -/);
   assert.match(output, /gemini \| job_22222222-2222-4222-8222-222222222222 \| source_sent_timeout \| sent \| 600000 \|  \| timeout/);
   assert.match(output, /kimi \| job_66666666-6666-4666-8666-666666666666 \| provider_unavailable \| sent \| 99 \|  \| provider_unavailable/);
-  assert.match(output, /grok \| job_33333333-3333-4333-8333-333333333333 \| failed_before_source_send \| not_sent \| 8000 \|  \| tunnel_unavailable/);
+  assert.match(output, /grok \| job_33333333-3333-4333-8333-333333333333 \| provider_unavailable \| not_sent \| 8000 \|  \| tunnel_unavailable/);
   assert.match(output, /deepseek \| job_44444444-4444-4444-8444-444444444444 \| approval_required \| not_sent \| 34 \|  \| approval_required/);
   assert.match(output, /glm \| job_55555555-5555-4555-8555-555555555555 \| completed \| sent \| 45422 \|  \| approve/);
   assert.match(output, /glm \| job_77777777-7777-4777-8777-777777777777 \| completed_failed_review_slot \| sent \| 91 \|  \| failed_review_slot/);
@@ -425,6 +503,7 @@ test("review panel CLI aggregates live and recent jobs across provider state roo
 
 test("review panel workspace collection excludes records without workspace metadata from scanned state roots", () => {
   const workspace = mkdtempSync(join(tmpdir(), "review-panel-workspace-"));
+  const otherWorkspace = mkdtempSync(join(tmpdir(), "review-panel-other-"));
   const claudeData = mkdtempSync(join(tmpdir(), "review-panel-claude-"));
 
   writeRecord(claudeData, {
@@ -442,6 +521,14 @@ test("review panel workspace collection excludes records without workspace metad
     result: "Verdict: APPROVE",
   }, "other-workspace-without-metadata");
 
+  writeRecord(claudeData, {
+    job_id: "job_cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+    provider: "claude",
+    status: "completed",
+    workspace_root: otherWorkspace,
+    result: "Verdict: APPROVE",
+  }, "other-workspace");
+
   const records = collectReviewPanelRecords({
     cwd: workspace,
     env: {
@@ -456,6 +543,108 @@ test("review panel workspace collection excludes records without workspace metad
 
   assert.deepEqual(records.map((record) => record.job_id), [
     "job_aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+  ]);
+});
+
+test("review panel skips malformed workspace metadata without aborting collection", () => {
+  const workspace = mkdtempSync(join(tmpdir(), "review-panel-workspace-"));
+  const claudeData = mkdtempSync(join(tmpdir(), "review-panel-claude-"));
+
+  writeRecord(claudeData, {
+    job_id: "job_valid-0000-4000-8000-000000000000",
+    provider: "claude",
+    status: "completed",
+    workspace_root: workspace,
+    result: "Verdict: APPROVE",
+  }, "workspace-a");
+
+  writeRecord(claudeData, {
+    job_id: "job_bad-0000-4000-8000-000000000000",
+    provider: "claude",
+    status: "completed",
+    workspace_root: [workspace],
+    result: "Verdict: APPROVE",
+  }, "workspace-a");
+
+  const records = collectReviewPanelRecords({
+    cwd: workspace,
+    env: {
+      ...process.env,
+      CLAUDE_PLUGIN_DATA: claudeData,
+      GEMINI_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-gemini-")),
+      KIMI_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-kimi-")),
+      GROK_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-grok-")),
+      API_REVIEWERS_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-api-")),
+    },
+  });
+
+  assert.deepEqual(records.map((record) => record.job_id), [
+    "job_valid-0000-4000-8000-000000000000",
+  ]);
+});
+
+test("review panel direct fallback finds records written with lexical workspace hashes", () => {
+  const realWorkspace = mkdtempSync(join(tmpdir(), "review-panel-real-"));
+  const linkParent = mkdtempSync(join(tmpdir(), "review-panel-link-parent-"));
+  const linkWorkspace = join(linkParent, "workspace-link");
+  symlinkSync(realWorkspace, linkWorkspace, "dir");
+  const grokData = writerDefaultDataRoot("grok", linkWorkspace);
+
+  writeRecord(grokData, {
+    job_id: "job_grok-0000-4000-8000-000000000000",
+    provider: "grok",
+    status: "completed",
+    workspace_root: realWorkspace,
+    result: "Verdict: APPROVE",
+  });
+
+  const records = collectReviewPanelRecords({
+    cwd: linkWorkspace,
+    env: {
+      ...process.env,
+      CLAUDE_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-claude-")),
+      GEMINI_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-gemini-")),
+      KIMI_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-kimi-")),
+      API_REVIEWERS_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-api-")),
+      GROK_PLUGIN_DATA: "",
+    },
+  });
+
+  assert.deepEqual(records.map((record) => record.job_id), [
+    "job_grok-0000-4000-8000-000000000000",
+  ]);
+});
+
+test("review panel companion fallback finds records from git root when workspace is a subdir", () => {
+  const repo = mkdtempSync(join(tmpdir(), "review-panel-repo-"));
+  execFileSync("git", ["init"], { cwd: repo, stdio: "ignore" });
+  const subdir = join(repo, "packages", "tool");
+  mkdirSync(subdir, { recursive: true });
+  const stateId = companionStateIdForWorkspaceRoot(repo);
+  const jobsRoot = join(tmpdir(), "claude-companion", stateId);
+
+  writeRecord(jobsRoot, {
+    job_id: "job_claude-0000-4000-8000-000000000000",
+    provider: "claude",
+    status: "completed",
+    workspace_root: repo,
+    result: "Verdict: APPROVE",
+  });
+
+  const records = collectReviewPanelRecords({
+    cwd: subdir,
+    env: {
+      ...process.env,
+      GEMINI_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-gemini-")),
+      KIMI_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-kimi-")),
+      GROK_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-grok-")),
+      API_REVIEWERS_PLUGIN_DATA: mkdtempSync(join(tmpdir(), "review-panel-empty-api-")),
+      CLAUDE_PLUGIN_DATA: "",
+    },
+  });
+
+  assert.deepEqual(records.map((record) => record.job_id), [
+    "job_claude-0000-4000-8000-000000000000",
   ]);
 });
 


### PR DESCRIPTION
Closes #97.

Summary:
- Adds --workspace mode to scripts/review-panel.mjs so operator can aggregate persisted Claude, Gemini, Kimi, Grok, DeepSeek, and GLM JobRecords without hand-building JSON.
- Adds explicit operator states: running, source_sent_waiting, failed_before_source_send, source_sent_timeout, provider_unavailable, auth_session_failure, quota_usage_limited, approval_required, completed, completed_failed_review_slot.
- Keeps output privacy-preserving: summary fields only, no prompts, source bodies, secrets, cookies, or raw provider payloads.
- Documents status panel usage in README.

Verification:
- node --test --test-reporter=spec tests/unit/review-panel.test.mjs: 5 pass, 0 fail.
- npm run lint: pass.
- npm test: 1582 tests, 1576 pass, 0 fail, 6 skipped.
- pre-commit npm test: 1582 tests, 1576 pass, 0 fail, 6 skipped.