### PR TITLE
Fix external review default reliability

### DIFF
--- a/plugins/api-reviewers/scripts/api-reviewer.mjs
+++ b/plugins/api-reviewers/scripts/api-reviewer.mjs
@@ -108,6 +108,44 @@ function printLifecycleJson(obj, lifecycleEvents) {
   else printJson(obj);
 }
 
+function externalReviewProgressEvent(invocation, { sequence, elapsedMs }) {
+  return {
+    event: "external_review_progress",
+    job_id: invocation.job_id,
+    target: invocation.target,
+    status: "running",
+    mode: invocation.mode ?? null,
+    run_kind: "foreground",
+    heartbeat: sequence,
+    elapsed_ms: Math.max(0, Math.trunc(elapsedMs ?? 0)),
+  };
+}
+
+function lifecycleHeartbeatIntervalMs(env = process.env) {
+  const raw = env.CODEX_PLUGIN_EXTERNAL_REVIEW_HEARTBEAT_MS;
+  if (raw === undefined || raw === null || raw === "") return 30000;
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : 30000;
+}
+
+function startLifecycleHeartbeat(invocation, lifecycleEvents, intervalMs = lifecycleHeartbeatIntervalMs()) {
+  if (lifecycleEvents !== "jsonl") return () => {};
+  const started = Date.now();
+  let sequence = 0;
+  const timer = setInterval(() => {
+    sequence += 1;
+    printLifecycleJson(
+      externalReviewProgressEvent(invocation, {
+        sequence,
+        elapsedMs: Date.now() - started,
+      }),
+      lifecycleEvents,
+    );
+  }, intervalMs);
+  timer.unref?.();
+  return () => clearInterval(timer);
+}
+
 function parseLifecycleEventsMode(value) {
   if (value == null || value === false) return null;
   if (value === "jsonl") return "jsonl";
@@ -2192,22 +2230,25 @@ async function cmdRun(options) {
     if (execution) {
       // handled below by the terminal JobRecord path without a launch event
     } else {
-    if (lifecycleEvents) {
-      printLifecycleJson({
-        event: "external_review_launched",
-        job_id: jobId,
-        target: provider,
-        status: "launched",
-        external_review: buildLaunchExternalReview({ cfg, mode, options: runOptions, scopeInfo }),
-      }, lifecycleEvents);
-    }
-    try {
-      execution = await callProvider(provider, cfg, renderedPrompt);
-      execution.prompt = renderedPrompt;
-    } catch (e) {
-      execution = providerFailure("provider_unavailable", redactor(process.env)(e?.message ?? String(e)), null, null, null);
-      execution.prompt = renderedPrompt;
-    }
+      if (lifecycleEvents) {
+        printLifecycleJson({
+          event: "external_review_launched",
+          job_id: jobId,
+          target: provider,
+          status: "launched",
+          external_review: buildLaunchExternalReview({ cfg, mode, options: runOptions, scopeInfo }),
+        }, lifecycleEvents);
+      }
+      const stopHeartbeat = startLifecycleHeartbeat({ job_id: jobId, target: provider, mode }, lifecycleEvents);
+      try {
+        execution = await callProvider(provider, cfg, renderedPrompt);
+        execution.prompt = renderedPrompt;
+      } catch (e) {
+        execution = providerFailure("provider_unavailable", redactor(process.env)(e?.message ?? String(e)), null, null, null);
+        execution.prompt = renderedPrompt;
+      } finally {
+        stopHeartbeat();
+      }
     }
   }
   const record = redactRecord(buildRecord({

--- a/plugins/api-reviewers/scripts/api-reviewer.mjs
+++ b/plugins/api-reviewers/scripts/api-reviewer.mjs
@@ -95,17 +95,17 @@ const MIN_SECRET_REDACTION_LENGTH = 8;
 const ACCOUNT_PAYMENT_TOKEN_RE = /\b(?:stripe-[^\s,;:)]+|cus_[A-Za-z0-9]{6,}|acct_(?:test_)?[A-Za-z0-9]{5,}|cs_(?:test|live)_[A-Za-z0-9]{6,}|(?:pi|sub|in|ii|ch|seti|setp|price|prod|iv)_(?=[A-Za-z0-9]*\d)[A-Za-z0-9]{5,})/gi;
 const ACCOUNT_PAYMENT_DIAGNOSTIC_RE = /^(?:stripe-.+|cus_[A-Za-z0-9]{6,}|acct_(?:test_)?[A-Za-z0-9]{5,}|cs_(?:test|live)_[A-Za-z0-9]{6,}|(?:pi|sub|in|ii|ch|seti|setp|price|prod|iv)_(?=[A-Za-z0-9]*\d)[A-Za-z0-9]{5,})$/i;
 
-function printJson(obj) {
-  process.stdout.write(`${JSON.stringify(obj, null, 2)}\n`);
+function printJson(obj, output = process.stdout) {
+  output.write(`${JSON.stringify(obj, null, 2)}\n`);
 }
 
-function printJsonLine(obj) {
-  process.stdout.write(`${JSON.stringify(obj)}\n`);
+function printJsonLine(obj, output = process.stdout) {
+  output.write(`${JSON.stringify(obj)}\n`);
 }
 
-function printLifecycleJson(obj, lifecycleEvents) {
-  if (lifecycleEvents === "jsonl") printJsonLine(obj);
-  else printJson(obj);
+function printLifecycleJson(obj, lifecycleEvents, output = process.stdout) {
+  if (lifecycleEvents === "jsonl") printJsonLine(obj, output);
+  else printJson(obj, output);
 }
 
 function externalReviewProgressEvent(invocation, { sequence, elapsedMs }) {
@@ -128,18 +128,23 @@ function lifecycleHeartbeatIntervalMs(env = process.env) {
   return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : 30000;
 }
 
-function startLifecycleHeartbeat(invocation, lifecycleEvents, intervalMs = lifecycleHeartbeatIntervalMs()) {
+function startLifecycleHeartbeat(
+  invocation,
+  lifecycleEvents,
+  { intervalMs = lifecycleHeartbeatIntervalMs(), output = null, now = Date.now } = {},
+) {
   if (lifecycleEvents !== "jsonl") return () => {};
-  const started = Date.now();
+  const started = now();
   let sequence = 0;
   const timer = setInterval(() => {
     sequence += 1;
     printLifecycleJson(
       externalReviewProgressEvent(invocation, {
         sequence,
-        elapsedMs: Date.now() - started,
+        elapsedMs: now() - started,
       }),
       lifecycleEvents,
+      output ?? undefined,
     );
   }, intervalMs);
   timer.unref?.();

--- a/plugins/api-reviewers/scripts/api-reviewer.mjs
+++ b/plugins/api-reviewers/scripts/api-reviewer.mjs
@@ -95,12 +95,16 @@ const MIN_SECRET_REDACTION_LENGTH = 8;
 const ACCOUNT_PAYMENT_TOKEN_RE = /\b(?:stripe-[^\s,;:)]+|cus_[A-Za-z0-9]{6,}|acct_(?:test_)?[A-Za-z0-9]{5,}|cs_(?:test|live)_[A-Za-z0-9]{6,}|(?:pi|sub|in|ii|ch|seti|setp|price|prod|iv)_(?=[A-Za-z0-9]*\d)[A-Za-z0-9]{5,})/gi;
 const ACCOUNT_PAYMENT_DIAGNOSTIC_RE = /^(?:stripe-.+|cus_[A-Za-z0-9]{6,}|acct_(?:test_)?[A-Za-z0-9]{5,}|cs_(?:test|live)_[A-Za-z0-9]{6,}|(?:pi|sub|in|ii|ch|seti|setp|price|prod|iv)_(?=[A-Za-z0-9]*\d)[A-Za-z0-9]{5,})$/i;
 
+function writableOutput(output) {
+  return output && typeof output.write === "function" ? output : process.stdout;
+}
+
 function printJson(obj, output = process.stdout) {
-  output.write(`${JSON.stringify(obj, null, 2)}\n`);
+  writableOutput(output).write(`${JSON.stringify(obj, null, 2)}\n`);
 }
 
 function printJsonLine(obj, output = process.stdout) {
-  output.write(`${JSON.stringify(obj)}\n`);
+  writableOutput(output).write(`${JSON.stringify(obj)}\n`);
 }
 
 function printLifecycleJson(obj, lifecycleEvents, output = process.stdout) {
@@ -115,7 +119,7 @@ function externalReviewProgressEvent(invocation, { sequence, elapsedMs }) {
     target: invocation.target,
     status: "running",
     mode: invocation.mode ?? null,
-    run_kind: "foreground",
+    run_kind: invocation.run_kind ?? "foreground",
     heartbeat: sequence,
     elapsed_ms: Math.max(0, Math.trunc(elapsedMs ?? 0)),
   };
@@ -131,9 +135,10 @@ function lifecycleHeartbeatIntervalMs(env = process.env) {
 function startLifecycleHeartbeat(
   invocation,
   lifecycleEvents,
-  { intervalMs = lifecycleHeartbeatIntervalMs(), output = null, now = Date.now } = {},
+  { intervalMs = lifecycleHeartbeatIntervalMs(), output = process.stdout, now = Date.now } = {},
 ) {
   if (lifecycleEvents !== "jsonl") return () => {};
+  const interval = Number.isSafeInteger(intervalMs) && intervalMs > 0 ? intervalMs : lifecycleHeartbeatIntervalMs();
   const started = now();
   let sequence = 0;
   const timer = setInterval(() => {
@@ -144,9 +149,9 @@ function startLifecycleHeartbeat(
         elapsedMs: now() - started,
       }),
       lifecycleEvents,
-      output ?? undefined,
+      output,
     );
-  }, intervalMs);
+  }, interval);
   timer.unref?.();
   return () => clearInterval(timer);
 }

--- a/plugins/api-reviewers/scripts/lib/review-prompt.mjs
+++ b/plugins/api-reviewers/scripts/lib/review-prompt.mjs
@@ -620,6 +620,7 @@ export function buildReviewPrompt({
     "- Distinguish real blocking code findings from missing supplied evidence, runtime/tool limitations, and stale or unavailable external comments.",
     "- For every checklist item, report PASS, FAIL, or NOT REVIEWED.",
     "- Blocking findings first, with concrete file/function/control-flow evidence.",
+    "- Start the first line with exactly one verdict marker: \"Verdict: APPROVE\", \"Verdict: REQUEST_CHANGES\", or \"Verdict: NOT_REVIEWED\".",
     "- A usable review must name the selected file path(s) inspected; bare numbered answers or section bodies such as only 'None' are shallow and invalid.",
     "- If a section has no findings, write a complete sentence that names the relevant selected file or scope and explains why no finding applies.",
     "- For control-flow and security code, explicitly inspect overlapping predicates, early returns, and branch ordering before concluding no blocker exists.",

--- a/plugins/api-reviewers/skills/api-reviewers-delegation/SKILL.md
+++ b/plugins/api-reviewers/skills/api-reviewers-delegation/SKILL.md
@@ -58,6 +58,7 @@ Do not print API-key values.
 ## Rendering Contract
 Render companion JSON directly.
 If `external_review_launched` is present, render it immediately.
+`external_review_progress` is a heartbeat for long foreground runs; keep the existing launch card visible and do not render it as a terminal result.
 If a background launch envelope has `event: "launched"` with an `external_review` field, render the same launch card immediately with session pending.
 If `external_review` is present, render it before normal prose.
 Launch cards should include provider, job, session, run kind, and scope when those fields are present.

--- a/plugins/claude/commands/claude-adversarial-review.md
+++ b/plugins/claude/commands/claude-adversarial-review.md
@@ -35,6 +35,7 @@ Use custom-review for explicit file bundles. Scope validation must complete befo
 ## Rendering Contract
 Render companion JSON directly.
 If `external_review_launched` is present, render it immediately.
+`external_review_progress` is a heartbeat for long foreground runs; keep the existing launch card visible and do not render it as a terminal result.
 If a background launch envelope has `event: "launched"` with an `external_review` field, render the same launch card immediately with session pending.
 If `external_review` is present, render it before normal prose.
 Launch cards should include provider, job, session, run kind, and scope when those fields are present.

--- a/plugins/claude/commands/claude-cancel.md
+++ b/plugins/claude/commands/claude-cancel.md
@@ -13,6 +13,7 @@ EXTERNAL_MODEL_CONTRACT_VERSION=1
 Run `node "<plugin-root>/scripts/claude-companion.mjs" cancel --job "$ARGUMENTS" --cwd "<workspace>"`.
 This command is for background jobs only. Foreground runs are owned by the active terminal; interrupt them with Ctrl+C.
 The companion does not signal attached foreground processes.
+For no_pid_info or unverifiable, render `suggested_action` when present and do not invent a PID kill command without an ownership check.
 
 Statuses:
 - status: "signaled"

--- a/plugins/claude/commands/claude-rescue.md
+++ b/plugins/claude/commands/claude-rescue.md
@@ -31,6 +31,7 @@ Failed or incomplete rescue is not success. Report the failed state and the next
 ## Rendering Contract
 Render companion JSON directly.
 If `external_review_launched` is present, render it immediately.
+`external_review_progress` is a heartbeat for long foreground runs; keep the existing launch card visible and do not render it as a terminal result.
 If a background launch envelope has `event: "launched"` with an `external_review` field, render the same launch card immediately with session pending.
 If `external_review` is present, render it before normal prose.
 Launch cards should include provider, job, session, run kind, and scope when those fields are present.

--- a/plugins/claude/commands/claude-review.md
+++ b/plugins/claude/commands/claude-review.md
@@ -35,6 +35,7 @@ Use custom-review for explicit file bundles. Scope validation must complete befo
 ## Rendering Contract
 Render companion JSON directly.
 If `external_review_launched` is present, render it immediately.
+`external_review_progress` is a heartbeat for long foreground runs; keep the existing launch card visible and do not render it as a terminal result.
 If a background launch envelope has `event: "launched"` with an `external_review` field, render the same launch card immediately with session pending.
 If `external_review` is present, render it before normal prose.
 Launch cards should include provider, job, session, run kind, and scope when those fields are present.

--- a/plugins/claude/scripts/claude-companion.mjs
+++ b/plugins/claude/scripts/claude-companion.mjs
@@ -57,7 +57,10 @@ import {
 import { CLAUDE_PROVIDER_API_KEY_ENV } from "./lib/claude-provider-keys.mjs";
 import {
   PING_PROMPT,
+  cancelNoPidInfoSuggestedAction,
+  cancelUnverifiableSuggestedAction,
   consumePromptSidecar,
+  effectiveProfileForOptions,
   externalReviewBackgroundLaunchedEvent,
   externalReviewLaunchedEvent,
   gitStatusLines,
@@ -590,25 +593,6 @@ function failBackgroundPromptSidecarWrite(workspaceRoot, invocation, error) {
   writeJobFile(workspaceRoot, invocation.job_id, errorRecord);
   upsertJob(workspaceRoot, errorRecord);
   fail("sidecar_failed", message, { error_code: error?.code ?? null });
-}
-
-function effectiveProfileForOptions(profile, options) {
-  if (profile.name === "review" && options["scope-base"] !== undefined) {
-    return Object.freeze({ ...profile, scope: "branch-diff" });
-  }
-  return profile;
-}
-
-function cancelUnverifiableSuggestedAction(pid) {
-  return (
-    "Retry cancel from a less restricted shell where process inspection works. " +
-    `If you manually inspect pid ${pid} and confirm ownership matches this job, ` +
-    "terminate it outside the sandbox; otherwise leave it running and use status/result after it exits."
-  );
-}
-
-function cancelNoPidInfoSuggestedAction() {
-  return "Use status/result to refresh the job record. Do not signal manually unless you can independently verify process ownership.";
 }
 
 // ——— subcommand: preflight ———

--- a/plugins/claude/scripts/claude-companion.mjs
+++ b/plugins/claude/scripts/claude-companion.mjs
@@ -71,6 +71,7 @@ import {
   printJson,
   printLifecycleJson,
   runKindFromRecord,
+  scopeBaseForOptions,
   startExternalReviewHeartbeat,
   summarizeScopeDirectory,
   writePromptSidecar,
@@ -619,12 +620,13 @@ function cmdPreflight(rest) {
   const profile = effectiveProfileForOptions(resolveProfile(mode), options);
   const workspaceRoot = resolveWorkspaceRoot(cwd);
   const scopePaths = parseScopePathsOption(options["scope-paths"]);
+  const scopeBase = scopeBaseForOptions(options);
   let containment = null;
   let exitCode = 0;
   try {
     containment = setupContainment(profile, cwd);
     populateScope(profile, cwd, containment.path, {
-      scopeBase: options["scope-base"] ?? null,
+      scopeBase,
       scopePaths,
       workspaceRoot,
     }, containment);
@@ -639,7 +641,7 @@ function cmdPreflight(rest) {
       workspace_root: workspaceRoot,
       containment: profile.containment,
       scope: profile.scope,
-      scope_base: options["scope-base"] ?? null,
+      scope_base: scopeBase,
       scope_paths: scopePaths,
       ...summary,
       ...preflightSafetyFields(),
@@ -657,7 +659,7 @@ function cmdPreflight(rest) {
       workspace_root: workspaceRoot,
       containment: profile.containment,
       scope: profile.scope,
-      scope_base: options["scope-base"] ?? null,
+      scope_base: scopeBase,
       scope_paths: scopePaths,
       error,
       error_message: e.message,
@@ -689,6 +691,7 @@ async function cmdRun(rest) {
   // Mode → profile, resolved EXACTLY ONCE at entry (spec §21.2). No downstream
   // code branches on `mode` to pick a flag — everything flows from `profile`.
   const profile = effectiveProfileForOptions(resolveProfile(mode), options);
+  const scopeBase = scopeBaseForOptions(options);
 
   // Model resolution goes through the profile's tier — the historical
   // ternary that branched on mode but returned "default" on both sides
@@ -754,7 +757,7 @@ async function cmdRun(rest) {
     containment: profile.containment,
     scope: profile.scope,
     dispose_effective: disposeEffective,
-    scope_base: options["scope-base"] ?? null,
+    scope_base: scopeBase,
     scope_paths: scopePaths,
     prompt_head: prompt.slice(0, 200),          // §21.3.1 — no full prompt
     review_prompt_contract_version: profile.name === "rescue" ? null : REVIEW_PROMPT_CONTRACT_VERSION,
@@ -873,6 +876,7 @@ async function executeRun(invocation, prompt, { foreground, lifecycleEvents = nu
       runtimeDiagnostics,
       resumeId,
       authSelection,
+      stopHeartbeat,
     });
   } finally {
     stopHeartbeat();
@@ -1085,6 +1089,7 @@ async function spawnClaudeOrExit(invocation, profile, prompt, executionScope, mu
     writeJobFile(invocation.workspace_root, invocation.job_id, errorRecord);
     upsertJob(invocation.workspace_root, errorRecord);
     cleanupExecutionResources(executionScope, mutationContext);
+    options.stopHeartbeat?.();
     if (options.foreground) printLifecycleJson(errorRecord, options.lifecycleEvents);
     process.exit(2);
   }

--- a/plugins/claude/scripts/claude-companion.mjs
+++ b/plugins/claude/scripts/claude-companion.mjs
@@ -68,6 +68,7 @@ import {
   printJson,
   printLifecycleJson,
   runKindFromRecord,
+  startExternalReviewHeartbeat,
   summarizeScopeDirectory,
   writePromptSidecar,
 } from "./lib/companion-common.mjs";
@@ -591,6 +592,25 @@ function failBackgroundPromptSidecarWrite(workspaceRoot, invocation, error) {
   fail("sidecar_failed", message, { error_code: error?.code ?? null });
 }
 
+function effectiveProfileForOptions(profile, options) {
+  if (profile.name === "review" && options["scope-base"] !== undefined) {
+    return Object.freeze({ ...profile, scope: "branch-diff" });
+  }
+  return profile;
+}
+
+function cancelUnverifiableSuggestedAction(pid) {
+  return (
+    "Retry cancel from a less restricted shell where process inspection works. " +
+    `If you manually inspect pid ${pid} and confirm ownership matches this job, ` +
+    "terminate it outside the sandbox; otherwise leave it running and use status/result after it exits."
+  );
+}
+
+function cancelNoPidInfoSuggestedAction() {
+  return "Use status/result to refresh the job record. Do not signal manually unless you can independently verify process ownership.";
+}
+
 // ——— subcommand: preflight ———
 function cmdPreflight(rest) {
   const { options } = parseArgs(rest, {
@@ -612,7 +632,7 @@ function cmdPreflight(rest) {
     });
   }
 
-  const profile = resolveProfile(mode);
+  const profile = effectiveProfileForOptions(resolveProfile(mode), options);
   const workspaceRoot = resolveWorkspaceRoot(cwd);
   const scopePaths = parseScopePathsOption(options["scope-paths"]);
   let containment = null;
@@ -684,7 +704,7 @@ async function cmdRun(rest) {
 
   // Mode → profile, resolved EXACTLY ONCE at entry (spec §21.2). No downstream
   // code branches on `mode` to pick a flag — everything flows from `profile`.
-  const profile = resolveProfile(mode);
+  const profile = effectiveProfileForOptions(resolveProfile(mode), options);
 
   // Model resolution goes through the profile's tier — the historical
   // ternary that branched on mode but returned "default" on both sides
@@ -860,13 +880,19 @@ async function executeRun(invocation, prompt, { foreground, lifecycleEvents = nu
     );
   }
 
-  const execution = await spawnClaudeOrExit(invocation, profile, prompt, executionScope, mutationContext, {
-    foreground,
-    lifecycleEvents,
-    runtimeDiagnostics,
-    resumeId,
-    authSelection,
-  });
+  const stopHeartbeat = foreground ? startExternalReviewHeartbeat(invocation, lifecycleEvents) : () => {};
+  let execution;
+  try {
+    execution = await spawnClaudeOrExit(invocation, profile, prompt, executionScope, mutationContext, {
+      foreground,
+      lifecycleEvents,
+      runtimeDiagnostics,
+      resumeId,
+      authSelection,
+    });
+  } finally {
+    stopHeartbeat();
+  }
 
   recordPostRunMutations(invocation, mutationContext);
 
@@ -2022,17 +2048,31 @@ async function cmdCancel(rest) {
       status: "no_pid_info",
       detail: "job has no pid_info; cannot safely signal (legacy record or race)",
       job_id: options.job,
+      suggested_action: cancelNoPidInfoSuggestedAction(),
     });
     process.exit(2);
   }
-  if (pidInfo.capture_error || !pidInfo.starttime || !pidInfo.argv0) {
+  if (pidInfo.capture_error) {
+    printJson({
+      ok: false,
+      status: "unverifiable",
+      detail: "could not verify pid ownership because process inspection was blocked; refusing to signal",
+      job_id: options.job,
+      pid: pidInfo.pid,
+      capture_error: pidInfo.capture_error,
+      suggested_action: cancelUnverifiableSuggestedAction(pidInfo.pid),
+    });
+    process.exit(2);
+  }
+  if (!pidInfo.starttime || !pidInfo.argv0) {
     printJson({
       ok: false,
       status: "no_pid_info",
       detail: "job has pid but no complete ownership proof; refusing to signal",
       job_id: options.job,
       pid: pidInfo.pid,
-      capture_error: pidInfo.capture_error ?? null,
+      capture_error: null,
+      suggested_action: cancelNoPidInfoSuggestedAction(),
     });
     process.exit(2);
   }
@@ -2062,6 +2102,7 @@ async function cmdCancel(rest) {
         detail: "could not verify pid ownership; refusing to signal",
         job_id: options.job,
         pid: pidInfo.pid,
+        suggested_action: cancelUnverifiableSuggestedAction(pidInfo.pid),
       });
       process.exit(2);
     }

--- a/plugins/claude/scripts/lib/companion-common.mjs
+++ b/plugins/claude/scripts/lib/companion-common.mjs
@@ -94,6 +94,25 @@ export function startExternalReviewHeartbeat(
   return () => clearInterval(timer);
 }
 
+export function effectiveProfileForOptions(profile, options) {
+  if (profile.name === "review" && options["scope-base"] != null && options["scope-base"] !== "") {
+    return Object.freeze({ ...profile, scope: "branch-diff" });
+  }
+  return profile;
+}
+
+export function cancelUnverifiableSuggestedAction(pid) {
+  return (
+    "Retry cancel from a less restricted shell where process inspection works. " +
+    `If you manually inspect pid ${pid} and confirm ownership matches this job, ` +
+    "terminate it outside the sandbox; otherwise leave it running and use status/result after it exits."
+  );
+}
+
+export function cancelNoPidInfoSuggestedAction() {
+  return "Use status/result to refresh the job record. Do not signal manually unless you can independently verify process ownership.";
+}
+
 export function parseScopePathsOption(value) {
   return value
     ? String(value).split(",").map((s) => s.trim()).filter(Boolean)

--- a/plugins/claude/scripts/lib/companion-common.mjs
+++ b/plugins/claude/scripts/lib/companion-common.mjs
@@ -32,6 +32,19 @@ export function externalReviewLaunchedEvent(invocation, externalReview) {
   };
 }
 
+export function externalReviewProgressEvent(invocation, { sequence, elapsedMs }) {
+  return {
+    event: "external_review_progress",
+    job_id: invocation.job_id,
+    target: invocation.target,
+    status: "running",
+    mode: invocation.mode ?? null,
+    run_kind: invocation.run_kind ?? "foreground",
+    heartbeat: sequence,
+    elapsed_ms: Math.max(0, Math.trunc(elapsedMs ?? 0)),
+  };
+}
+
 export function externalReviewBackgroundLaunchedEvent(invocation, pid, externalReview) {
   return {
     event: "launched",
@@ -48,6 +61,37 @@ export function externalReviewBackgroundLaunchedEvent(invocation, pid, externalR
 export function printLifecycleJson(obj, lifecycleEvents, output = process.stdout) {
   if (lifecycleEvents === "jsonl") printJsonLine(obj, output);
   else printJson(obj, output);
+}
+
+export function externalReviewHeartbeatIntervalMs(env = process.env) {
+  const raw = env.CODEX_PLUGIN_EXTERNAL_REVIEW_HEARTBEAT_MS;
+  if (raw === undefined || raw === null || raw === "") return 30000;
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : 30000;
+}
+
+export function startExternalReviewHeartbeat(
+  invocation,
+  lifecycleEvents,
+  { intervalMs = externalReviewHeartbeatIntervalMs(), output = process.stdout, now = Date.now } = {},
+) {
+  if (lifecycleEvents !== "jsonl") return () => {};
+  const interval = Number.isSafeInteger(intervalMs) && intervalMs > 0 ? intervalMs : externalReviewHeartbeatIntervalMs();
+  const started = now();
+  let sequence = 0;
+  const timer = setInterval(() => {
+    sequence += 1;
+    printLifecycleJson(
+      externalReviewProgressEvent(invocation, {
+        sequence,
+        elapsedMs: now() - started,
+      }),
+      lifecycleEvents,
+      output,
+    );
+  }, interval);
+  timer.unref?.();
+  return () => clearInterval(timer);
 }
 
 export function parseScopePathsOption(value) {

--- a/plugins/claude/scripts/lib/companion-common.mjs
+++ b/plugins/claude/scripts/lib/companion-common.mjs
@@ -8,12 +8,16 @@ import { resolve as resolvePath, sep } from "node:path";
 export const PING_PROMPT =
   "reply with exactly: pong. Do not use any tools, do not read files, and do not explore the workspace.";
 
+function writableOutput(output) {
+  return output && typeof output.write === "function" ? output : process.stdout;
+}
+
 export function printJson(obj, output = process.stdout) {
-  output.write(`${JSON.stringify(obj, null, 2)}\n`);
+  writableOutput(output).write(`${JSON.stringify(obj, null, 2)}\n`);
 }
 
 export function printJsonLine(obj, output = process.stdout) {
-  output.write(`${JSON.stringify(obj)}\n`);
+  writableOutput(output).write(`${JSON.stringify(obj)}\n`);
 }
 
 export function parseLifecycleEventsMode(value) {
@@ -95,10 +99,16 @@ export function startExternalReviewHeartbeat(
 }
 
 export function effectiveProfileForOptions(profile, options) {
-  if (profile.name === "review" && options["scope-base"] != null && options["scope-base"] !== "") {
+  if (profile.name === "review" && scopeBaseForOptions(options) !== null) {
     return Object.freeze({ ...profile, scope: "branch-diff" });
   }
   return profile;
+}
+
+export function scopeBaseForOptions(options) {
+  const value = options["scope-base"];
+  if (value == null) return null;
+  return String(value).trim() === "" ? null : String(value);
 }
 
 export function cancelUnverifiableSuggestedAction(pid) {

--- a/plugins/claude/scripts/lib/review-prompt.mjs
+++ b/plugins/claude/scripts/lib/review-prompt.mjs
@@ -620,6 +620,7 @@ export function buildReviewPrompt({
     "- Distinguish real blocking code findings from missing supplied evidence, runtime/tool limitations, and stale or unavailable external comments.",
     "- For every checklist item, report PASS, FAIL, or NOT REVIEWED.",
     "- Blocking findings first, with concrete file/function/control-flow evidence.",
+    "- Start the first line with exactly one verdict marker: \"Verdict: APPROVE\", \"Verdict: REQUEST_CHANGES\", or \"Verdict: NOT_REVIEWED\".",
     "- A usable review must name the selected file path(s) inspected; bare numbered answers or section bodies such as only 'None' are shallow and invalid.",
     "- If a section has no findings, write a complete sentence that names the relevant selected file or scope and explains why no finding applies.",
     "- For control-flow and security code, explicitly inspect overlapping predicates, early returns, and branch ordering before concluding no blocker exists.",

--- a/plugins/claude/scripts/lib/scope.mjs
+++ b/plugins/claude/scripts/lib/scope.mjs
@@ -227,8 +227,7 @@ function isIgnoredLiveRel(ignored, rel) {
   const normalized = rel.replace(/\\/g, "/");
   if (ignored.has(normalized)) return true;
   const relPrefix = `${normalized}/`;
-  for (const rawIgnoredRel of ignored) {
-    const ignoredRel = rawIgnoredRel.replace(/\\/g, "/");
+  for (const ignoredRel of ignored) {
     const ignoredPrefix = ignoredRel.endsWith("/") ? ignoredRel : `${ignoredRel}/`;
     if (normalized.startsWith(ignoredPrefix)) return true;
     if (ignoredRel.startsWith(relPrefix)) return true;

--- a/plugins/claude/scripts/lib/scope.mjs
+++ b/plugins/claude/scripts/lib/scope.mjs
@@ -226,9 +226,12 @@ function isIgnoredLiveRel(ignored, rel) {
   if (ignored == null || rel === "") return false;
   const normalized = rel.replace(/\\/g, "/");
   if (ignored.has(normalized)) return true;
-  const prefix = `${normalized}/`;
-  for (const ignoredRel of ignored) {
-    if (ignoredRel.startsWith(prefix)) return true;
+  const relPrefix = `${normalized}/`;
+  for (const rawIgnoredRel of ignored) {
+    const ignoredRel = rawIgnoredRel.replace(/\\/g, "/");
+    const ignoredPrefix = ignoredRel.endsWith("/") ? ignoredRel : `${ignoredRel}/`;
+    if (normalized.startsWith(ignoredPrefix)) return true;
+    if (ignoredRel.startsWith(relPrefix)) return true;
   }
   return false;
 }

--- a/plugins/claude/skills/claude-adversarial-review/SKILL.md
+++ b/plugins/claude/skills/claude-adversarial-review/SKILL.md
@@ -32,6 +32,7 @@ custom-review uses explicit relative paths. Scope validation must complete befor
 ## Rendering Contract
 Render companion JSON directly.
 If `external_review_launched` is present, render it immediately.
+`external_review_progress` is a heartbeat for long foreground runs; keep the existing launch card visible and do not render it as a terminal result.
 If a background launch envelope has `event: "launched"` with an `external_review` field, render the same launch card immediately with session pending.
 If `external_review` is present, render it before normal prose.
 Launch cards should include provider, job, session, run kind, and scope when those fields are present.

--- a/plugins/claude/skills/claude-cancel/SKILL.md
+++ b/plugins/claude/skills/claude-cancel/SKILL.md
@@ -15,6 +15,7 @@ EXTERNAL_MODEL_CONTRACT_VERSION=1
 Run `node "<plugin-root>/scripts/claude-companion.mjs" cancel --job "<job-id>" --cwd "<workspace>"`.
 Cancel is for background jobs only.
 Foreground runs are owned by the active terminal; interrupt them with Ctrl+C.
+For no_pid_info or unverifiable, render `suggested_action` when present and do not invent a PID kill command without an ownership check.
 ## Secret Safety
 Do not print raw OAuth tokens, API-key values, session cookies, tunnel API keys, bearer tokens, or raw secret values.
 Credential diagnostics may show key names only.

--- a/plugins/claude/skills/claude-cli-runtime/SKILL.md
+++ b/plugins/claude/skills/claude-cli-runtime/SKILL.md
@@ -18,6 +18,7 @@ For cancel, foreground runs are owned by the active terminal; interrupt them wit
 ## Rendering Contract
 Render companion JSON directly.
 If `external_review_launched` is present, render it immediately.
+`external_review_progress` is a heartbeat for long foreground runs; keep the existing launch card visible and do not render it as a terminal result.
 If a background launch envelope has `event: "launched"` with an `external_review` field, render the same launch card immediately with session pending.
 If `external_review` is present, render it before normal prose.
 Launch cards should include provider, job, session, run kind, and scope when those fields are present.

--- a/plugins/claude/skills/claude-delegation/SKILL.md
+++ b/plugins/claude/skills/claude-delegation/SKILL.md
@@ -57,6 +57,7 @@ Failed or incomplete rescue is not success. Report the failed state and the next
 ## Rendering Contract
 Render companion JSON directly.
 If `external_review_launched` is present, render it immediately.
+`external_review_progress` is a heartbeat for long foreground runs; keep the existing launch card visible and do not render it as a terminal result.
 If a background launch envelope has `event: "launched"` with an `external_review` field, render the same launch card immediately with session pending.
 If `external_review` is present, render it before normal prose.
 Launch cards should include provider, job, session, run kind, and scope when those fields are present.

--- a/plugins/claude/skills/claude-rescue/SKILL.md
+++ b/plugins/claude/skills/claude-rescue/SKILL.md
@@ -26,6 +26,7 @@ Failed or incomplete rescue is not success. Report the failed state and the next
 ## Rendering Contract
 Render companion JSON directly.
 If `external_review_launched` is present, render it immediately.
+`external_review_progress` is a heartbeat for long foreground runs; keep the existing launch card visible and do not render it as a terminal result.
 If a background launch envelope has `event: "launched"` with an `external_review` field, render the same launch card immediately with session pending.
 If `external_review` is present, render it before normal prose.
 Launch cards should include provider, job, session, run kind, and scope when those fields are present.

--- a/plugins/claude/skills/claude-result-handling/SKILL.md
+++ b/plugins/claude/skills/claude-result-handling/SKILL.md
@@ -73,6 +73,7 @@ For `source_content_transmission: "may_be_sent"`, say the runtime could not prov
 ## Rendering Contract
 Render companion JSON directly.
 If `external_review_launched` is present, render it immediately.
+`external_review_progress` is a heartbeat for long foreground runs; keep the existing launch card visible and do not render it as a terminal result.
 If a background launch envelope has `event: "launched"` with an `external_review` field, render the same launch card immediately with session pending.
 If `external_review` is present, render it before normal prose.
 Launch cards should include provider, job, session, run kind, and scope when those fields are present.

--- a/plugins/claude/skills/claude-review/SKILL.md
+++ b/plugins/claude/skills/claude-review/SKILL.md
@@ -32,6 +32,7 @@ custom-review uses explicit relative paths. Scope validation must complete befor
 ## Rendering Contract
 Render companion JSON directly.
 If `external_review_launched` is present, render it immediately.
+`external_review_progress` is a heartbeat for long foreground runs; keep the existing launch card visible and do not render it as a terminal result.
 If a background launch envelope has `event: "launched"` with an `external_review` field, render the same launch card immediately with session pending.
 If `external_review` is present, render it before normal prose.
 Launch cards should include provider, job, session, run kind, and scope when those fields are present.

--- a/plugins/gemini/commands/gemini-adversarial-review.md
+++ b/plugins/gemini/commands/gemini-adversarial-review.md
@@ -35,6 +35,7 @@ Use custom-review for explicit file bundles. Scope validation must complete befo
 ## Rendering Contract
 Render companion JSON directly.
 If `external_review_launched` is present, render it immediately.
+`external_review_progress` is a heartbeat for long foreground runs; keep the existing launch card visible and do not render it as a terminal result.
 If a background launch envelope has `event: "launched"` with an `external_review` field, render the same launch card immediately with session pending.
 If `external_review` is present, render it before normal prose.
 Launch cards should include provider, job, session, run kind, and scope when those fields are present.

--- a/plugins/gemini/commands/gemini-cancel.md
+++ b/plugins/gemini/commands/gemini-cancel.md
@@ -13,6 +13,7 @@ EXTERNAL_MODEL_CONTRACT_VERSION=1
 Run `node "<plugin-root>/scripts/gemini-companion.mjs" cancel --job "$ARGUMENTS" --cwd "<workspace>"`.
 This command is for background jobs only. Foreground runs are owned by the active terminal; interrupt them with Ctrl+C.
 The companion does not signal attached foreground processes.
+For no_pid_info or unverifiable, render `suggested_action` when present and do not invent a PID kill command without an ownership check.
 
 Statuses:
 - status: "signaled"

--- a/plugins/gemini/commands/gemini-rescue.md
+++ b/plugins/gemini/commands/gemini-rescue.md
@@ -31,6 +31,7 @@ Failed or incomplete rescue is not success. Report the failed state and the next
 ## Rendering Contract
 Render companion JSON directly.
 If `external_review_launched` is present, render it immediately.
+`external_review_progress` is a heartbeat for long foreground runs; keep the existing launch card visible and do not render it as a terminal result.
 If a background launch envelope has `event: "launched"` with an `external_review` field, render the same launch card immediately with session pending.
 If `external_review` is present, render it before normal prose.
 Launch cards should include provider, job, session, run kind, and scope when those fields are present.

--- a/plugins/gemini/commands/gemini-review.md
+++ b/plugins/gemini/commands/gemini-review.md
@@ -35,6 +35,7 @@ Use custom-review for explicit file bundles. Scope validation must complete befo
 ## Rendering Contract
 Render companion JSON directly.
 If `external_review_launched` is present, render it immediately.
+`external_review_progress` is a heartbeat for long foreground runs; keep the existing launch card visible and do not render it as a terminal result.
 If a background launch envelope has `event: "launched"` with an `external_review` field, render the same launch card immediately with session pending.
 If `external_review` is present, render it before normal prose.
 Launch cards should include provider, job, session, run kind, and scope when those fields are present.

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -45,6 +45,7 @@ import {
   printJson,
   printLifecycleJson,
   runKindFromRecord,
+  scopeBaseForOptions,
   startExternalReviewHeartbeat,
   summarizeScopeDirectory,
   writePromptSidecar,
@@ -516,12 +517,13 @@ function cmdPreflight(rest) {
   const profile = effectiveProfileForOptions(resolveProfile(mode), options);
   const workspaceRoot = resolveWorkspaceRoot(cwd);
   const scopePaths = parseScopePathsOption(options["scope-paths"]);
+  const scopeBase = scopeBaseForOptions(options);
   let containment = null;
   let exitCode = 0;
   try {
     containment = setupContainment(profile, cwd);
     populateScope(profile, cwd, containment.path, {
-      scopeBase: options["scope-base"] ?? null,
+      scopeBase,
       scopePaths,
       workspaceRoot,
     }, containment);
@@ -536,7 +538,7 @@ function cmdPreflight(rest) {
       workspace_root: workspaceRoot,
       containment: profile.containment,
       scope: profile.scope,
-      scope_base: options["scope-base"] ?? null,
+      scope_base: scopeBase,
       scope_paths: scopePaths,
       ...summary,
       ...preflightSafetyFields(),
@@ -554,7 +556,7 @@ function cmdPreflight(rest) {
       workspace_root: workspaceRoot,
       containment: profile.containment,
       scope: profile.scope,
-      scope_base: options["scope-base"] ?? null,
+      scope_base: scopeBase,
       scope_paths: scopePaths,
       error,
       error_message: e.message,
@@ -580,6 +582,7 @@ async function cmdRun(rest) {
     fail("bad_args", "--background and --foreground are mutually exclusive");
   }
   const profile = effectiveProfileForOptions(resolveProfile(mode), options);
+  const scopeBase = scopeBaseForOptions(options);
   const model = options.model ?? resolveModelForProfile(profile, loadModels()) ?? null;
   if (!model) fail("no_model", "no model resolved; pass --model or populate config/models.json");
 
@@ -622,7 +625,7 @@ async function cmdRun(rest) {
     containment: profile.containment,
     scope: profile.scope,
     dispose_effective: disposeEffective,
-    scope_base: options["scope-base"] ?? null,
+    scope_base: scopeBase,
     scope_paths: scopePaths,
     prompt_head: prompt.slice(0, 200),
     review_prompt_contract_version: profile.name === "rescue" ? null : REVIEW_PROMPT_CONTRACT_VERSION,
@@ -727,7 +730,7 @@ async function executeRun(invocation, prompt, { foreground, lifecycleEvents = nu
       prompt,
       executionScope,
       mutationContext,
-      { foreground, lifecycleEvents, resumeId, authSelection },
+      { foreground, lifecycleEvents, resumeId, authSelection, stopHeartbeat },
     ));
   } finally {
     stopHeartbeat();
@@ -855,6 +858,7 @@ async function spawnGeminiOrExit(invocation, profile, prompt, executionScope, mu
     writeJobFile(invocation.workspace_root, invocation.job_id, errorRecord);
     upsertJob(invocation.workspace_root, errorRecord);
     cleanupExecutionResources(executionScope, mutationContext);
+    options.stopHeartbeat?.();
     if (options.foreground) printLifecycleJson(errorRecord, options.lifecycleEvents);
     process.exit(2);
   }

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -31,7 +31,10 @@ import {
 } from "./lib/auth-selection.mjs";
 import {
   PING_PROMPT,
+  cancelNoPidInfoSuggestedAction,
+  cancelUnverifiableSuggestedAction,
   consumePromptSidecar,
+  effectiveProfileForOptions,
   externalReviewBackgroundLaunchedEvent,
   externalReviewLaunchedEvent,
   gitStatusLines,
@@ -490,25 +493,6 @@ function failBackgroundPromptSidecarWrite(workspaceRoot, invocation, error) {
   writeJobFile(workspaceRoot, invocation.job_id, errorRecord);
   upsertJob(workspaceRoot, errorRecord);
   fail("sidecar_failed", message, { error_code: error?.code ?? null });
-}
-
-function effectiveProfileForOptions(profile, options) {
-  if (profile.name === "review" && options["scope-base"] !== undefined) {
-    return Object.freeze({ ...profile, scope: "branch-diff" });
-  }
-  return profile;
-}
-
-function cancelUnverifiableSuggestedAction(pid) {
-  return (
-    "Retry cancel from a less restricted shell where process inspection works. " +
-    `If you manually inspect pid ${pid} and confirm ownership matches this job, ` +
-    "terminate it outside the sandbox; otherwise leave it running and use status/result after it exits."
-  );
-}
-
-function cancelNoPidInfoSuggestedAction() {
-  return "Use status/result to refresh the job record. Do not signal manually unless you can independently verify process ownership.";
 }
 
 function cmdPreflight(rest) {

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -42,6 +42,7 @@ import {
   printJson,
   printLifecycleJson,
   runKindFromRecord,
+  startExternalReviewHeartbeat,
   summarizeScopeDirectory,
   writePromptSidecar,
 } from "./lib/companion-common.mjs";
@@ -491,6 +492,25 @@ function failBackgroundPromptSidecarWrite(workspaceRoot, invocation, error) {
   fail("sidecar_failed", message, { error_code: error?.code ?? null });
 }
 
+function effectiveProfileForOptions(profile, options) {
+  if (profile.name === "review" && options["scope-base"] !== undefined) {
+    return Object.freeze({ ...profile, scope: "branch-diff" });
+  }
+  return profile;
+}
+
+function cancelUnverifiableSuggestedAction(pid) {
+  return (
+    "Retry cancel from a less restricted shell where process inspection works. " +
+    `If you manually inspect pid ${pid} and confirm ownership matches this job, ` +
+    "terminate it outside the sandbox; otherwise leave it running and use status/result after it exits."
+  );
+}
+
+function cancelNoPidInfoSuggestedAction() {
+  return "Use status/result to refresh the job record. Do not signal manually unless you can independently verify process ownership.";
+}
+
 function cmdPreflight(rest) {
   const { options } = parseArgs(rest, {
     valueOptions: ["mode", "cwd", "scope-base", "scope-paths", "binary"],
@@ -509,7 +529,7 @@ function cmdPreflight(rest) {
     });
   }
 
-  const profile = resolveProfile(mode);
+  const profile = effectiveProfileForOptions(resolveProfile(mode), options);
   const workspaceRoot = resolveWorkspaceRoot(cwd);
   const scopePaths = parseScopePathsOption(options["scope-paths"]);
   let containment = null;
@@ -575,7 +595,7 @@ async function cmdRun(rest) {
   if (options.background && options.foreground) {
     fail("bad_args", "--background and --foreground are mutually exclusive");
   }
-  const profile = resolveProfile(mode);
+  const profile = effectiveProfileForOptions(resolveProfile(mode), options);
   const model = options.model ?? resolveModelForProfile(profile, loadModels()) ?? null;
   if (!model) fail("no_model", "no model resolved; pass --model or populate config/models.json");
 
@@ -713,14 +733,21 @@ async function executeRun(invocation, prompt, { foreground, lifecycleEvents = nu
     );
   }
 
-  const { execution, executedInvocation } = await spawnGeminiOrExit(
-    invocation,
-    profile,
-    prompt,
-    executionScope,
-    mutationContext,
-    { foreground, lifecycleEvents, resumeId, authSelection },
-  );
+  const stopHeartbeat = foreground ? startExternalReviewHeartbeat(invocation, lifecycleEvents) : () => {};
+  let execution;
+  let executedInvocation;
+  try {
+    ({ execution, executedInvocation } = await spawnGeminiOrExit(
+      invocation,
+      profile,
+      prompt,
+      executionScope,
+      mutationContext,
+      { foreground, lifecycleEvents, resumeId, authSelection },
+    ));
+  } finally {
+    stopHeartbeat();
+  }
 
   recordPostRunMutations(invocation, mutationContext);
 
@@ -1570,17 +1597,31 @@ async function cmdCancel(rest) {
       status: "no_pid_info",
       detail: "job has no pid_info; cannot safely signal (legacy record or race)",
       job_id: options.job,
+      suggested_action: cancelNoPidInfoSuggestedAction(),
     });
     process.exit(2);
   }
-  if (pidInfo.capture_error || !pidInfo.starttime || !pidInfo.argv0) {
+  if (pidInfo.capture_error) {
+    printJson({
+      ok: false,
+      status: "unverifiable",
+      detail: "could not verify pid ownership because process inspection was blocked; refusing to signal",
+      job_id: options.job,
+      pid: pidInfo.pid,
+      capture_error: pidInfo.capture_error,
+      suggested_action: cancelUnverifiableSuggestedAction(pidInfo.pid),
+    });
+    process.exit(2);
+  }
+  if (!pidInfo.starttime || !pidInfo.argv0) {
     printJson({
       ok: false,
       status: "no_pid_info",
       detail: "job has pid but no complete ownership proof; refusing to signal",
       job_id: options.job,
       pid: pidInfo.pid,
-      capture_error: pidInfo.capture_error ?? null,
+      capture_error: null,
+      suggested_action: cancelNoPidInfoSuggestedAction(),
     });
     process.exit(2);
   }
@@ -1605,6 +1646,7 @@ async function cmdCancel(rest) {
         detail: "could not verify pid ownership; refusing to signal",
         job_id: options.job,
         pid: pidInfo.pid,
+        suggested_action: cancelUnverifiableSuggestedAction(pidInfo.pid),
       });
       process.exit(2);
     }

--- a/plugins/gemini/scripts/lib/companion-common.mjs
+++ b/plugins/gemini/scripts/lib/companion-common.mjs
@@ -94,6 +94,25 @@ export function startExternalReviewHeartbeat(
   return () => clearInterval(timer);
 }
 
+export function effectiveProfileForOptions(profile, options) {
+  if (profile.name === "review" && options["scope-base"] != null && options["scope-base"] !== "") {
+    return Object.freeze({ ...profile, scope: "branch-diff" });
+  }
+  return profile;
+}
+
+export function cancelUnverifiableSuggestedAction(pid) {
+  return (
+    "Retry cancel from a less restricted shell where process inspection works. " +
+    `If you manually inspect pid ${pid} and confirm ownership matches this job, ` +
+    "terminate it outside the sandbox; otherwise leave it running and use status/result after it exits."
+  );
+}
+
+export function cancelNoPidInfoSuggestedAction() {
+  return "Use status/result to refresh the job record. Do not signal manually unless you can independently verify process ownership.";
+}
+
 export function parseScopePathsOption(value) {
   return value
     ? String(value).split(",").map((s) => s.trim()).filter(Boolean)

--- a/plugins/gemini/scripts/lib/companion-common.mjs
+++ b/plugins/gemini/scripts/lib/companion-common.mjs
@@ -32,6 +32,19 @@ export function externalReviewLaunchedEvent(invocation, externalReview) {
   };
 }
 
+export function externalReviewProgressEvent(invocation, { sequence, elapsedMs }) {
+  return {
+    event: "external_review_progress",
+    job_id: invocation.job_id,
+    target: invocation.target,
+    status: "running",
+    mode: invocation.mode ?? null,
+    run_kind: invocation.run_kind ?? "foreground",
+    heartbeat: sequence,
+    elapsed_ms: Math.max(0, Math.trunc(elapsedMs ?? 0)),
+  };
+}
+
 export function externalReviewBackgroundLaunchedEvent(invocation, pid, externalReview) {
   return {
     event: "launched",
@@ -48,6 +61,37 @@ export function externalReviewBackgroundLaunchedEvent(invocation, pid, externalR
 export function printLifecycleJson(obj, lifecycleEvents, output = process.stdout) {
   if (lifecycleEvents === "jsonl") printJsonLine(obj, output);
   else printJson(obj, output);
+}
+
+export function externalReviewHeartbeatIntervalMs(env = process.env) {
+  const raw = env.CODEX_PLUGIN_EXTERNAL_REVIEW_HEARTBEAT_MS;
+  if (raw === undefined || raw === null || raw === "") return 30000;
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : 30000;
+}
+
+export function startExternalReviewHeartbeat(
+  invocation,
+  lifecycleEvents,
+  { intervalMs = externalReviewHeartbeatIntervalMs(), output = process.stdout, now = Date.now } = {},
+) {
+  if (lifecycleEvents !== "jsonl") return () => {};
+  const interval = Number.isSafeInteger(intervalMs) && intervalMs > 0 ? intervalMs : externalReviewHeartbeatIntervalMs();
+  const started = now();
+  let sequence = 0;
+  const timer = setInterval(() => {
+    sequence += 1;
+    printLifecycleJson(
+      externalReviewProgressEvent(invocation, {
+        sequence,
+        elapsedMs: now() - started,
+      }),
+      lifecycleEvents,
+      output,
+    );
+  }, interval);
+  timer.unref?.();
+  return () => clearInterval(timer);
 }
 
 export function parseScopePathsOption(value) {

--- a/plugins/gemini/scripts/lib/companion-common.mjs
+++ b/plugins/gemini/scripts/lib/companion-common.mjs
@@ -8,12 +8,16 @@ import { resolve as resolvePath, sep } from "node:path";
 export const PING_PROMPT =
   "reply with exactly: pong. Do not use any tools, do not read files, and do not explore the workspace.";
 
+function writableOutput(output) {
+  return output && typeof output.write === "function" ? output : process.stdout;
+}
+
 export function printJson(obj, output = process.stdout) {
-  output.write(`${JSON.stringify(obj, null, 2)}\n`);
+  writableOutput(output).write(`${JSON.stringify(obj, null, 2)}\n`);
 }
 
 export function printJsonLine(obj, output = process.stdout) {
-  output.write(`${JSON.stringify(obj)}\n`);
+  writableOutput(output).write(`${JSON.stringify(obj)}\n`);
 }
 
 export function parseLifecycleEventsMode(value) {
@@ -95,10 +99,16 @@ export function startExternalReviewHeartbeat(
 }
 
 export function effectiveProfileForOptions(profile, options) {
-  if (profile.name === "review" && options["scope-base"] != null && options["scope-base"] !== "") {
+  if (profile.name === "review" && scopeBaseForOptions(options) !== null) {
     return Object.freeze({ ...profile, scope: "branch-diff" });
   }
   return profile;
+}
+
+export function scopeBaseForOptions(options) {
+  const value = options["scope-base"];
+  if (value == null) return null;
+  return String(value).trim() === "" ? null : String(value);
 }
 
 export function cancelUnverifiableSuggestedAction(pid) {

--- a/plugins/gemini/scripts/lib/review-prompt.mjs
+++ b/plugins/gemini/scripts/lib/review-prompt.mjs
@@ -620,6 +620,7 @@ export function buildReviewPrompt({
     "- Distinguish real blocking code findings from missing supplied evidence, runtime/tool limitations, and stale or unavailable external comments.",
     "- For every checklist item, report PASS, FAIL, or NOT REVIEWED.",
     "- Blocking findings first, with concrete file/function/control-flow evidence.",
+    "- Start the first line with exactly one verdict marker: \"Verdict: APPROVE\", \"Verdict: REQUEST_CHANGES\", or \"Verdict: NOT_REVIEWED\".",
     "- A usable review must name the selected file path(s) inspected; bare numbered answers or section bodies such as only 'None' are shallow and invalid.",
     "- If a section has no findings, write a complete sentence that names the relevant selected file or scope and explains why no finding applies.",
     "- For control-flow and security code, explicitly inspect overlapping predicates, early returns, and branch ordering before concluding no blocker exists.",

--- a/plugins/gemini/scripts/lib/scope.mjs
+++ b/plugins/gemini/scripts/lib/scope.mjs
@@ -227,8 +227,7 @@ function isIgnoredLiveRel(ignored, rel) {
   const normalized = rel.replace(/\\/g, "/");
   if (ignored.has(normalized)) return true;
   const relPrefix = `${normalized}/`;
-  for (const rawIgnoredRel of ignored) {
-    const ignoredRel = rawIgnoredRel.replace(/\\/g, "/");
+  for (const ignoredRel of ignored) {
     const ignoredPrefix = ignoredRel.endsWith("/") ? ignoredRel : `${ignoredRel}/`;
     if (normalized.startsWith(ignoredPrefix)) return true;
     if (ignoredRel.startsWith(relPrefix)) return true;

--- a/plugins/gemini/scripts/lib/scope.mjs
+++ b/plugins/gemini/scripts/lib/scope.mjs
@@ -226,9 +226,12 @@ function isIgnoredLiveRel(ignored, rel) {
   if (ignored == null || rel === "") return false;
   const normalized = rel.replace(/\\/g, "/");
   if (ignored.has(normalized)) return true;
-  const prefix = `${normalized}/`;
-  for (const ignoredRel of ignored) {
-    if (ignoredRel.startsWith(prefix)) return true;
+  const relPrefix = `${normalized}/`;
+  for (const rawIgnoredRel of ignored) {
+    const ignoredRel = rawIgnoredRel.replace(/\\/g, "/");
+    const ignoredPrefix = ignoredRel.endsWith("/") ? ignoredRel : `${ignoredRel}/`;
+    if (normalized.startsWith(ignoredPrefix)) return true;
+    if (ignoredRel.startsWith(relPrefix)) return true;
   }
   return false;
 }

--- a/plugins/gemini/skills/gemini-adversarial-review/SKILL.md
+++ b/plugins/gemini/skills/gemini-adversarial-review/SKILL.md
@@ -32,6 +32,7 @@ custom-review uses explicit relative paths. Scope validation must complete befor
 ## Rendering Contract
 Render companion JSON directly.
 If `external_review_launched` is present, render it immediately.
+`external_review_progress` is a heartbeat for long foreground runs; keep the existing launch card visible and do not render it as a terminal result.
 If a background launch envelope has `event: "launched"` with an `external_review` field, render the same launch card immediately with session pending.
 If `external_review` is present, render it before normal prose.
 Launch cards should include provider, job, session, run kind, and scope when those fields are present.

--- a/plugins/gemini/skills/gemini-cancel/SKILL.md
+++ b/plugins/gemini/skills/gemini-cancel/SKILL.md
@@ -15,6 +15,7 @@ EXTERNAL_MODEL_CONTRACT_VERSION=1
 Run `node "<plugin-root>/scripts/gemini-companion.mjs" cancel --job "<job-id>" --cwd "<workspace>"`.
 Cancel is for background jobs only.
 Foreground runs are owned by the active terminal; interrupt them with Ctrl+C.
+For no_pid_info or unverifiable, render `suggested_action` when present and do not invent a PID kill command without an ownership check.
 ## Secret Safety
 Do not print raw OAuth tokens, API-key values, session cookies, tunnel API keys, bearer tokens, or raw secret values.
 Credential diagnostics may show key names only.

--- a/plugins/gemini/skills/gemini-delegation/SKILL.md
+++ b/plugins/gemini/skills/gemini-delegation/SKILL.md
@@ -57,6 +57,7 @@ Failed or incomplete rescue is not success. Report the failed state and the next
 ## Rendering Contract
 Render companion JSON directly.
 If `external_review_launched` is present, render it immediately.
+`external_review_progress` is a heartbeat for long foreground runs; keep the existing launch card visible and do not render it as a terminal result.
 If a background launch envelope has `event: "launched"` with an `external_review` field, render the same launch card immediately with session pending.
 If `external_review` is present, render it before normal prose.
 Launch cards should include provider, job, session, run kind, and scope when those fields are present.

--- a/plugins/gemini/skills/gemini-rescue/SKILL.md
+++ b/plugins/gemini/skills/gemini-rescue/SKILL.md
@@ -26,6 +26,7 @@ Failed or incomplete rescue is not success. Report the failed state and the next
 ## Rendering Contract
 Render companion JSON directly.
 If `external_review_launched` is present, render it immediately.
+`external_review_progress` is a heartbeat for long foreground runs; keep the existing launch card visible and do not render it as a terminal result.
 If a background launch envelope has `event: "launched"` with an `external_review` field, render the same launch card immediately with session pending.
 If `external_review` is present, render it before normal prose.
 Launch cards should include provider, job, session, run kind, and scope when those fields are present.

--- a/plugins/gemini/skills/gemini-review/SKILL.md
+++ b/plugins/gemini/skills/gemini-review/SKILL.md
@@ -32,6 +32,7 @@ custom-review uses explicit relative paths. Scope validation must complete befor
 ## Rendering Contract
 Render companion JSON directly.
 If `external_review_launched` is present, render it immediately.
+`external_review_progress` is a heartbeat for long foreground runs; keep the existing launch card visible and do not render it as a terminal result.
 If a background launch envelope has `event: "launched"` with an `external_review` field, render the same launch card immediately with session pending.
 If `external_review` is present, render it before normal prose.
 Launch cards should include provider, job, session, run kind, and scope when those fields are present.

--- a/plugins/grok/scripts/grok-web-reviewer.mjs
+++ b/plugins/grok/scripts/grok-web-reviewer.mjs
@@ -102,12 +102,16 @@ const GROK_EXPECTED_KEYS = Object.freeze([
   "schema_version",
 ]);
 
+function writableOutput(output) {
+  return output && typeof output.write === "function" ? output : process.stdout;
+}
+
 function printJson(obj, output = process.stdout) {
-  output.write(`${JSON.stringify(obj, null, 2)}\n`);
+  writableOutput(output).write(`${JSON.stringify(obj, null, 2)}\n`);
 }
 
 function printJsonLine(obj, output = process.stdout) {
-  output.write(`${JSON.stringify(obj)}\n`);
+  writableOutput(output).write(`${JSON.stringify(obj)}\n`);
 }
 
 function printLifecycleJson(obj, lifecycleEvents, output = process.stdout) {
@@ -122,7 +126,7 @@ function externalReviewProgressEvent(invocation, { sequence, elapsedMs }) {
     target: invocation.target,
     status: "running",
     mode: invocation.mode ?? null,
-    run_kind: "foreground",
+    run_kind: invocation.run_kind ?? "foreground",
     heartbeat: sequence,
     elapsed_ms: Math.max(0, Math.trunc(elapsedMs ?? 0)),
   };
@@ -138,9 +142,10 @@ function lifecycleHeartbeatIntervalMs(env = process.env) {
 function startLifecycleHeartbeat(
   invocation,
   lifecycleEvents,
-  { intervalMs = lifecycleHeartbeatIntervalMs(), output = null, now = Date.now } = {},
+  { intervalMs = lifecycleHeartbeatIntervalMs(), output = process.stdout, now = Date.now } = {},
 ) {
   if (lifecycleEvents !== "jsonl") return () => {};
+  const interval = Number.isSafeInteger(intervalMs) && intervalMs > 0 ? intervalMs : lifecycleHeartbeatIntervalMs();
   const started = now();
   let sequence = 0;
   const timer = setInterval(() => {
@@ -151,9 +156,9 @@ function startLifecycleHeartbeat(
         elapsedMs: now() - started,
       }),
       lifecycleEvents,
-      output ?? undefined,
+      output,
     );
-  }, intervalMs);
+  }, interval);
   timer.unref?.();
   return () => clearInterval(timer);
 }

--- a/plugins/grok/scripts/grok-web-reviewer.mjs
+++ b/plugins/grok/scripts/grok-web-reviewer.mjs
@@ -102,17 +102,17 @@ const GROK_EXPECTED_KEYS = Object.freeze([
   "schema_version",
 ]);
 
-function printJson(obj) {
-  process.stdout.write(`${JSON.stringify(obj, null, 2)}\n`);
+function printJson(obj, output = process.stdout) {
+  output.write(`${JSON.stringify(obj, null, 2)}\n`);
 }
 
-function printJsonLine(obj) {
-  process.stdout.write(`${JSON.stringify(obj)}\n`);
+function printJsonLine(obj, output = process.stdout) {
+  output.write(`${JSON.stringify(obj)}\n`);
 }
 
-function printLifecycleJson(obj, lifecycleEvents) {
-  if (lifecycleEvents === "jsonl") printJsonLine(obj);
-  else printJson(obj);
+function printLifecycleJson(obj, lifecycleEvents, output = process.stdout) {
+  if (lifecycleEvents === "jsonl") printJsonLine(obj, output);
+  else printJson(obj, output);
 }
 
 function externalReviewProgressEvent(invocation, { sequence, elapsedMs }) {
@@ -135,18 +135,23 @@ function lifecycleHeartbeatIntervalMs(env = process.env) {
   return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : 30000;
 }
 
-function startLifecycleHeartbeat(invocation, lifecycleEvents, intervalMs = lifecycleHeartbeatIntervalMs()) {
+function startLifecycleHeartbeat(
+  invocation,
+  lifecycleEvents,
+  { intervalMs = lifecycleHeartbeatIntervalMs(), output = null, now = Date.now } = {},
+) {
   if (lifecycleEvents !== "jsonl") return () => {};
-  const started = Date.now();
+  const started = now();
   let sequence = 0;
   const timer = setInterval(() => {
     sequence += 1;
     printLifecycleJson(
       externalReviewProgressEvent(invocation, {
         sequence,
-        elapsedMs: Date.now() - started,
+        elapsedMs: now() - started,
       }),
       lifecycleEvents,
+      output ?? undefined,
     );
   }, intervalMs);
   timer.unref?.();

--- a/plugins/grok/scripts/grok-web-reviewer.mjs
+++ b/plugins/grok/scripts/grok-web-reviewer.mjs
@@ -115,6 +115,44 @@ function printLifecycleJson(obj, lifecycleEvents) {
   else printJson(obj);
 }
 
+function externalReviewProgressEvent(invocation, { sequence, elapsedMs }) {
+  return {
+    event: "external_review_progress",
+    job_id: invocation.job_id,
+    target: invocation.target,
+    status: "running",
+    mode: invocation.mode ?? null,
+    run_kind: "foreground",
+    heartbeat: sequence,
+    elapsed_ms: Math.max(0, Math.trunc(elapsedMs ?? 0)),
+  };
+}
+
+function lifecycleHeartbeatIntervalMs(env = process.env) {
+  const raw = env.CODEX_PLUGIN_EXTERNAL_REVIEW_HEARTBEAT_MS;
+  if (raw === undefined || raw === null || raw === "") return 30000;
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : 30000;
+}
+
+function startLifecycleHeartbeat(invocation, lifecycleEvents, intervalMs = lifecycleHeartbeatIntervalMs()) {
+  if (lifecycleEvents !== "jsonl") return () => {};
+  const started = Date.now();
+  let sequence = 0;
+  const timer = setInterval(() => {
+    sequence += 1;
+    printLifecycleJson(
+      externalReviewProgressEvent(invocation, {
+        sequence,
+        elapsedMs: Date.now() - started,
+      }),
+      lifecycleEvents,
+    );
+  }, intervalMs);
+  timer.unref?.();
+  return () => clearInterval(timer);
+}
+
 function parseLifecycleEventsMode(value) {
   if (value == null || value === false) return null;
   if (value === "jsonl") return "jsonl";
@@ -2537,8 +2575,13 @@ async function cmdRun(options) {
         }, lifecycleEvents);
       }
       if (!execution) {
-        promptSentToTunnel = true;
-        execution = await callGrokTunnel(cfg, prompt);
+        const stopHeartbeat = startLifecycleHeartbeat({ job_id: jobId, target: "grok-web", mode }, lifecycleEvents);
+        try {
+          promptSentToTunnel = true;
+          execution = await callGrokTunnel(cfg, prompt);
+        } finally {
+          stopHeartbeat();
+        }
       }
       execution.diagnostics = {
         ...(execution.diagnostics ?? {}),

--- a/plugins/grok/scripts/lib/review-prompt.mjs
+++ b/plugins/grok/scripts/lib/review-prompt.mjs
@@ -620,6 +620,7 @@ export function buildReviewPrompt({
     "- Distinguish real blocking code findings from missing supplied evidence, runtime/tool limitations, and stale or unavailable external comments.",
     "- For every checklist item, report PASS, FAIL, or NOT REVIEWED.",
     "- Blocking findings first, with concrete file/function/control-flow evidence.",
+    "- Start the first line with exactly one verdict marker: \"Verdict: APPROVE\", \"Verdict: REQUEST_CHANGES\", or \"Verdict: NOT_REVIEWED\".",
     "- A usable review must name the selected file path(s) inspected; bare numbered answers or section bodies such as only 'None' are shallow and invalid.",
     "- If a section has no findings, write a complete sentence that names the relevant selected file or scope and explains why no finding applies.",
     "- For control-flow and security code, explicitly inspect overlapping predicates, early returns, and branch ordering before concluding no blocker exists.",

--- a/plugins/grok/skills/grok-delegation/SKILL.md
+++ b/plugins/grok/skills/grok-delegation/SKILL.md
@@ -47,6 +47,7 @@ Rendered prompts above `GROK_WEB_MAX_PROMPT_CHARS` fail before tunnel launch wit
 ## Rendering Contract
 Render companion JSON directly.
 If `external_review_launched` is present, render it immediately.
+`external_review_progress` is a heartbeat for long foreground runs; keep the existing launch card visible and do not render it as a terminal result.
 If a background launch envelope has `event: "launched"` with an `external_review` field, render the same launch card immediately with session pending.
 If `external_review` is present, render it before normal prose.
 Launch cards should include provider, job, session, run kind, and scope when those fields are present.

--- a/plugins/kimi/commands/kimi-adversarial-review.md
+++ b/plugins/kimi/commands/kimi-adversarial-review.md
@@ -36,6 +36,7 @@ Use custom-review for explicit file bundles. Scope validation must complete befo
 ## Rendering Contract
 Render companion JSON directly.
 If `external_review_launched` is present, render it immediately.
+`external_review_progress` is a heartbeat for long foreground runs; keep the existing launch card visible and do not render it as a terminal result.
 If a background launch envelope has `event: "launched"` with an `external_review` field, render the same launch card immediately with session pending.
 If `external_review` is present, render it before normal prose.
 Launch cards should include provider, job, session, run kind, and scope when those fields are present.

--- a/plugins/kimi/commands/kimi-cancel.md
+++ b/plugins/kimi/commands/kimi-cancel.md
@@ -13,6 +13,7 @@ EXTERNAL_MODEL_CONTRACT_VERSION=1
 Run `node "<plugin-root>/scripts/kimi-companion.mjs" cancel --job "$ARGUMENTS" --cwd "<workspace>"`.
 This command is for background jobs only. Foreground runs are owned by the active terminal; interrupt them with Ctrl+C.
 The companion does not signal attached foreground processes.
+For no_pid_info or unverifiable, render `suggested_action` when present and do not invent a PID kill command without an ownership check.
 
 Statuses:
 - status: "signaled"

--- a/plugins/kimi/commands/kimi-rescue.md
+++ b/plugins/kimi/commands/kimi-rescue.md
@@ -31,6 +31,7 @@ Failed or incomplete rescue is not success. Report the failed state and the next
 ## Rendering Contract
 Render companion JSON directly.
 If `external_review_launched` is present, render it immediately.
+`external_review_progress` is a heartbeat for long foreground runs; keep the existing launch card visible and do not render it as a terminal result.
 If a background launch envelope has `event: "launched"` with an `external_review` field, render the same launch card immediately with session pending.
 If `external_review` is present, render it before normal prose.
 Launch cards should include provider, job, session, run kind, and scope when those fields are present.

--- a/plugins/kimi/commands/kimi-review.md
+++ b/plugins/kimi/commands/kimi-review.md
@@ -36,6 +36,7 @@ Use custom-review for explicit file bundles. Scope validation must complete befo
 ## Rendering Contract
 Render companion JSON directly.
 If `external_review_launched` is present, render it immediately.
+`external_review_progress` is a heartbeat for long foreground runs; keep the existing launch card visible and do not render it as a terminal result.
 If a background launch envelope has `event: "launched"` with an `external_review` field, render the same launch card immediately with session pending.
 If `external_review` is present, render it before normal prose.
 Launch cards should include provider, job, session, run kind, and scope when those fields are present.

--- a/plugins/kimi/scripts/kimi-companion.mjs
+++ b/plugins/kimi/scripts/kimi-companion.mjs
@@ -24,8 +24,11 @@ import { writeCancelMarker, consumeCancelMarker } from "./lib/cancel-marker.mjs"
 import { isCodexSandbox } from "./lib/codex-env.mjs";
 import {
   PING_PROMPT,
+  cancelNoPidInfoSuggestedAction,
+  cancelUnverifiableSuggestedAction,
   consumePromptSidecar,
   credentialNameDiagnostics,
+  effectiveProfileForOptions,
   externalReviewBackgroundLaunchedEvent,
   externalReviewLaunchedEvent,
   gitStatusLines,
@@ -549,25 +552,6 @@ function failBackgroundPromptSidecarWrite(workspaceRoot, invocation, error) {
   writeJobFile(workspaceRoot, invocation.job_id, errorRecord);
   upsertJob(workspaceRoot, errorRecord);
   fail("sidecar_failed", message, { error_code: error?.code ?? null });
-}
-
-function effectiveProfileForOptions(profile, options) {
-  if (profile.name === "review" && options["scope-base"] !== undefined) {
-    return Object.freeze({ ...profile, scope: "branch-diff" });
-  }
-  return profile;
-}
-
-function cancelUnverifiableSuggestedAction(pid) {
-  return (
-    "Retry cancel from a less restricted shell where process inspection works. " +
-    `If you manually inspect pid ${pid} and confirm ownership matches this job, ` +
-    "terminate it outside the sandbox; otherwise leave it running and use status/result after it exits."
-  );
-}
-
-function cancelNoPidInfoSuggestedAction() {
-  return "Use status/result to refresh the job record. Do not signal manually unless you can independently verify process ownership.";
 }
 
 function cmdPreflight(rest) {

--- a/plugins/kimi/scripts/kimi-companion.mjs
+++ b/plugins/kimi/scripts/kimi-companion.mjs
@@ -39,6 +39,7 @@ import {
   printJson,
   printLifecycleJson,
   runKindFromRecord,
+  scopeBaseForOptions,
   startExternalReviewHeartbeat,
   summarizeScopeDirectory,
   writePromptSidecar,
@@ -575,12 +576,13 @@ function cmdPreflight(rest) {
   const profile = effectiveProfileForOptions(resolveProfile(mode), options);
   const workspaceRoot = resolveWorkspaceRoot(cwd);
   const scopePaths = parseScopePathsOption(options["scope-paths"]);
+  const scopeBase = scopeBaseForOptions(options);
   let containment = null;
   let exitCode = 0;
   try {
     containment = setupContainment(profile, cwd);
     populateScope(profile, cwd, containment.path, {
-      scopeBase: options["scope-base"] ?? null,
+      scopeBase,
       scopePaths,
       workspaceRoot,
     }, containment);
@@ -595,7 +597,7 @@ function cmdPreflight(rest) {
       workspace_root: workspaceRoot,
       containment: profile.containment,
       scope: profile.scope,
-      scope_base: options["scope-base"] ?? null,
+      scope_base: scopeBase,
       scope_paths: scopePaths,
       ...summary,
       ...preflightSafetyFields(),
@@ -613,7 +615,7 @@ function cmdPreflight(rest) {
       workspace_root: workspaceRoot,
       containment: profile.containment,
       scope: profile.scope,
-      scope_base: options["scope-base"] ?? null,
+      scope_base: scopeBase,
       scope_paths: scopePaths,
       error,
       error_message: e.message,
@@ -639,6 +641,7 @@ async function cmdRun(rest) {
     fail("bad_args", "--background and --foreground are mutually exclusive");
   }
   const profile = effectiveProfileForOptions(resolveProfile(mode), options);
+  const scopeBase = scopeBaseForOptions(options);
   const model = options.model ?? resolveModelForProfile(profile, loadModels()) ?? null;
   if (!model) fail("no_model", "no model resolved; pass --model or populate config/models.json");
 
@@ -683,7 +686,7 @@ async function cmdRun(rest) {
     containment: profile.containment,
     scope: profile.scope,
     dispose_effective: disposeEffective,
-    scope_base: options["scope-base"] ?? null,
+    scope_base: scopeBase,
     scope_paths: scopePaths,
     prompt_head: prompt.slice(0, 200),
     review_prompt_contract_version: profile.name === "rescue" ? null : REVIEW_PROMPT_CONTRACT_VERSION,
@@ -885,6 +888,7 @@ async function executeRun(invocation, prompt, { foreground, lifecycleEvents = nu
     upsertJob(workspaceRoot, errorRecord);
     if (neutralCwd) rmSync(neutralCwd, { recursive: true, force: true });
     if (disposeEffective) containment.cleanup();
+    stopHeartbeat();
     if (foreground) printLifecycleJson(errorRecord, lifecycleEvents);
     process.exit(2);
   } finally {

--- a/plugins/kimi/scripts/kimi-companion.mjs
+++ b/plugins/kimi/scripts/kimi-companion.mjs
@@ -36,6 +36,7 @@ import {
   printJson,
   printLifecycleJson,
   runKindFromRecord,
+  startExternalReviewHeartbeat,
   summarizeScopeDirectory,
   writePromptSidecar,
 } from "./lib/companion-common.mjs";
@@ -550,6 +551,25 @@ function failBackgroundPromptSidecarWrite(workspaceRoot, invocation, error) {
   fail("sidecar_failed", message, { error_code: error?.code ?? null });
 }
 
+function effectiveProfileForOptions(profile, options) {
+  if (profile.name === "review" && options["scope-base"] !== undefined) {
+    return Object.freeze({ ...profile, scope: "branch-diff" });
+  }
+  return profile;
+}
+
+function cancelUnverifiableSuggestedAction(pid) {
+  return (
+    "Retry cancel from a less restricted shell where process inspection works. " +
+    `If you manually inspect pid ${pid} and confirm ownership matches this job, ` +
+    "terminate it outside the sandbox; otherwise leave it running and use status/result after it exits."
+  );
+}
+
+function cancelNoPidInfoSuggestedAction() {
+  return "Use status/result to refresh the job record. Do not signal manually unless you can independently verify process ownership.";
+}
+
 function cmdPreflight(rest) {
   const { options } = parseArgs(rest, {
     valueOptions: ["mode", "cwd", "scope-base", "scope-paths", "binary"],
@@ -568,7 +588,7 @@ function cmdPreflight(rest) {
     });
   }
 
-  const profile = resolveProfile(mode);
+  const profile = effectiveProfileForOptions(resolveProfile(mode), options);
   const workspaceRoot = resolveWorkspaceRoot(cwd);
   const scopePaths = parseScopePathsOption(options["scope-paths"]);
   let containment = null;
@@ -634,7 +654,7 @@ async function cmdRun(rest) {
   if (options.background && options.foreground) {
     fail("bad_args", "--background and --foreground are mutually exclusive");
   }
-  const profile = resolveProfile(mode);
+  const profile = effectiveProfileForOptions(resolveProfile(mode), options);
   const model = options.model ?? resolveModelForProfile(profile, loadModels()) ?? null;
   if (!model) fail("no_model", "no model resolved; pass --model or populate config/models.json");
 
@@ -831,6 +851,7 @@ async function executeRun(invocation, prompt, { foreground, lifecycleEvents = nu
 
   let execution;
   let executedInvocation = invocation;
+  const stopHeartbeat = foreground ? startExternalReviewHeartbeat(invocation, lifecycleEvents) : () => {};
   try {
     const modelCandidates = modelCandidatesForInvocation(profile, invocation);
     for (let i = 0; i < modelCandidates.length; i++) {
@@ -882,6 +903,8 @@ async function executeRun(invocation, prompt, { foreground, lifecycleEvents = nu
     if (disposeEffective) containment.cleanup();
     if (foreground) printLifecycleJson(errorRecord, lifecycleEvents);
     process.exit(2);
+  } finally {
+    stopHeartbeat();
   }
 
   // ——— finalization (#16 follow-up 1) ————————————————————————————————
@@ -1507,17 +1530,31 @@ async function cmdCancel(rest) {
       status: "no_pid_info",
       detail: "job has no pid_info; cannot safely signal (legacy record or race)",
       job_id: options.job,
+      suggested_action: cancelNoPidInfoSuggestedAction(),
     });
     process.exit(2);
   }
-  if (pidInfo.capture_error || !pidInfo.starttime || !pidInfo.argv0) {
+  if (pidInfo.capture_error) {
+    printJson({
+      ok: false,
+      status: "unverifiable",
+      detail: "could not verify pid ownership because process inspection was blocked; refusing to signal",
+      job_id: options.job,
+      pid: pidInfo.pid,
+      capture_error: pidInfo.capture_error,
+      suggested_action: cancelUnverifiableSuggestedAction(pidInfo.pid),
+    });
+    process.exit(2);
+  }
+  if (!pidInfo.starttime || !pidInfo.argv0) {
     printJson({
       ok: false,
       status: "no_pid_info",
       detail: "job has pid but no complete ownership proof; refusing to signal",
       job_id: options.job,
       pid: pidInfo.pid,
-      capture_error: pidInfo.capture_error ?? null,
+      capture_error: null,
+      suggested_action: cancelNoPidInfoSuggestedAction(),
     });
     process.exit(2);
   }
@@ -1542,6 +1579,7 @@ async function cmdCancel(rest) {
         detail: "could not verify pid ownership; refusing to signal",
         job_id: options.job,
         pid: pidInfo.pid,
+        suggested_action: cancelUnverifiableSuggestedAction(pidInfo.pid),
       });
       process.exit(2);
     }

--- a/plugins/kimi/scripts/lib/companion-common.mjs
+++ b/plugins/kimi/scripts/lib/companion-common.mjs
@@ -94,6 +94,25 @@ export function startExternalReviewHeartbeat(
   return () => clearInterval(timer);
 }
 
+export function effectiveProfileForOptions(profile, options) {
+  if (profile.name === "review" && options["scope-base"] != null && options["scope-base"] !== "") {
+    return Object.freeze({ ...profile, scope: "branch-diff" });
+  }
+  return profile;
+}
+
+export function cancelUnverifiableSuggestedAction(pid) {
+  return (
+    "Retry cancel from a less restricted shell where process inspection works. " +
+    `If you manually inspect pid ${pid} and confirm ownership matches this job, ` +
+    "terminate it outside the sandbox; otherwise leave it running and use status/result after it exits."
+  );
+}
+
+export function cancelNoPidInfoSuggestedAction() {
+  return "Use status/result to refresh the job record. Do not signal manually unless you can independently verify process ownership.";
+}
+
 export function parseScopePathsOption(value) {
   return value
     ? String(value).split(",").map((s) => s.trim()).filter(Boolean)

--- a/plugins/kimi/scripts/lib/companion-common.mjs
+++ b/plugins/kimi/scripts/lib/companion-common.mjs
@@ -32,6 +32,19 @@ export function externalReviewLaunchedEvent(invocation, externalReview) {
   };
 }
 
+export function externalReviewProgressEvent(invocation, { sequence, elapsedMs }) {
+  return {
+    event: "external_review_progress",
+    job_id: invocation.job_id,
+    target: invocation.target,
+    status: "running",
+    mode: invocation.mode ?? null,
+    run_kind: invocation.run_kind ?? "foreground",
+    heartbeat: sequence,
+    elapsed_ms: Math.max(0, Math.trunc(elapsedMs ?? 0)),
+  };
+}
+
 export function externalReviewBackgroundLaunchedEvent(invocation, pid, externalReview) {
   return {
     event: "launched",
@@ -48,6 +61,37 @@ export function externalReviewBackgroundLaunchedEvent(invocation, pid, externalR
 export function printLifecycleJson(obj, lifecycleEvents, output = process.stdout) {
   if (lifecycleEvents === "jsonl") printJsonLine(obj, output);
   else printJson(obj, output);
+}
+
+export function externalReviewHeartbeatIntervalMs(env = process.env) {
+  const raw = env.CODEX_PLUGIN_EXTERNAL_REVIEW_HEARTBEAT_MS;
+  if (raw === undefined || raw === null || raw === "") return 30000;
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : 30000;
+}
+
+export function startExternalReviewHeartbeat(
+  invocation,
+  lifecycleEvents,
+  { intervalMs = externalReviewHeartbeatIntervalMs(), output = process.stdout, now = Date.now } = {},
+) {
+  if (lifecycleEvents !== "jsonl") return () => {};
+  const interval = Number.isSafeInteger(intervalMs) && intervalMs > 0 ? intervalMs : externalReviewHeartbeatIntervalMs();
+  const started = now();
+  let sequence = 0;
+  const timer = setInterval(() => {
+    sequence += 1;
+    printLifecycleJson(
+      externalReviewProgressEvent(invocation, {
+        sequence,
+        elapsedMs: now() - started,
+      }),
+      lifecycleEvents,
+      output,
+    );
+  }, interval);
+  timer.unref?.();
+  return () => clearInterval(timer);
 }
 
 export function parseScopePathsOption(value) {

--- a/plugins/kimi/scripts/lib/companion-common.mjs
+++ b/plugins/kimi/scripts/lib/companion-common.mjs
@@ -8,12 +8,16 @@ import { resolve as resolvePath, sep } from "node:path";
 export const PING_PROMPT =
   "reply with exactly: pong. Do not use any tools, do not read files, and do not explore the workspace.";
 
+function writableOutput(output) {
+  return output && typeof output.write === "function" ? output : process.stdout;
+}
+
 export function printJson(obj, output = process.stdout) {
-  output.write(`${JSON.stringify(obj, null, 2)}\n`);
+  writableOutput(output).write(`${JSON.stringify(obj, null, 2)}\n`);
 }
 
 export function printJsonLine(obj, output = process.stdout) {
-  output.write(`${JSON.stringify(obj)}\n`);
+  writableOutput(output).write(`${JSON.stringify(obj)}\n`);
 }
 
 export function parseLifecycleEventsMode(value) {
@@ -95,10 +99,16 @@ export function startExternalReviewHeartbeat(
 }
 
 export function effectiveProfileForOptions(profile, options) {
-  if (profile.name === "review" && options["scope-base"] != null && options["scope-base"] !== "") {
+  if (profile.name === "review" && scopeBaseForOptions(options) !== null) {
     return Object.freeze({ ...profile, scope: "branch-diff" });
   }
   return profile;
+}
+
+export function scopeBaseForOptions(options) {
+  const value = options["scope-base"];
+  if (value == null) return null;
+  return String(value).trim() === "" ? null : String(value);
 }
 
 export function cancelUnverifiableSuggestedAction(pid) {

--- a/plugins/kimi/scripts/lib/review-prompt.mjs
+++ b/plugins/kimi/scripts/lib/review-prompt.mjs
@@ -620,6 +620,7 @@ export function buildReviewPrompt({
     "- Distinguish real blocking code findings from missing supplied evidence, runtime/tool limitations, and stale or unavailable external comments.",
     "- For every checklist item, report PASS, FAIL, or NOT REVIEWED.",
     "- Blocking findings first, with concrete file/function/control-flow evidence.",
+    "- Start the first line with exactly one verdict marker: \"Verdict: APPROVE\", \"Verdict: REQUEST_CHANGES\", or \"Verdict: NOT_REVIEWED\".",
     "- A usable review must name the selected file path(s) inspected; bare numbered answers or section bodies such as only 'None' are shallow and invalid.",
     "- If a section has no findings, write a complete sentence that names the relevant selected file or scope and explains why no finding applies.",
     "- For control-flow and security code, explicitly inspect overlapping predicates, early returns, and branch ordering before concluding no blocker exists.",

--- a/plugins/kimi/scripts/lib/scope.mjs
+++ b/plugins/kimi/scripts/lib/scope.mjs
@@ -227,8 +227,7 @@ function isIgnoredLiveRel(ignored, rel) {
   const normalized = rel.replace(/\\/g, "/");
   if (ignored.has(normalized)) return true;
   const relPrefix = `${normalized}/`;
-  for (const rawIgnoredRel of ignored) {
-    const ignoredRel = rawIgnoredRel.replace(/\\/g, "/");
+  for (const ignoredRel of ignored) {
     const ignoredPrefix = ignoredRel.endsWith("/") ? ignoredRel : `${ignoredRel}/`;
     if (normalized.startsWith(ignoredPrefix)) return true;
     if (ignoredRel.startsWith(relPrefix)) return true;

--- a/plugins/kimi/scripts/lib/scope.mjs
+++ b/plugins/kimi/scripts/lib/scope.mjs
@@ -226,9 +226,12 @@ function isIgnoredLiveRel(ignored, rel) {
   if (ignored == null || rel === "") return false;
   const normalized = rel.replace(/\\/g, "/");
   if (ignored.has(normalized)) return true;
-  const prefix = `${normalized}/`;
-  for (const ignoredRel of ignored) {
-    if (ignoredRel.startsWith(prefix)) return true;
+  const relPrefix = `${normalized}/`;
+  for (const rawIgnoredRel of ignored) {
+    const ignoredRel = rawIgnoredRel.replace(/\\/g, "/");
+    const ignoredPrefix = ignoredRel.endsWith("/") ? ignoredRel : `${ignoredRel}/`;
+    if (normalized.startsWith(ignoredPrefix)) return true;
+    if (ignoredRel.startsWith(relPrefix)) return true;
   }
   return false;
 }

--- a/plugins/kimi/skills/kimi-adversarial-review/SKILL.md
+++ b/plugins/kimi/skills/kimi-adversarial-review/SKILL.md
@@ -32,6 +32,7 @@ custom-review uses explicit relative paths. Scope validation must complete befor
 ## Rendering Contract
 Render companion JSON directly.
 If `external_review_launched` is present, render it immediately.
+`external_review_progress` is a heartbeat for long foreground runs; keep the existing launch card visible and do not render it as a terminal result.
 If a background launch envelope has `event: "launched"` with an `external_review` field, render the same launch card immediately with session pending.
 If `external_review` is present, render it before normal prose.
 Launch cards should include provider, job, session, run kind, and scope when those fields are present.

--- a/plugins/kimi/skills/kimi-cancel/SKILL.md
+++ b/plugins/kimi/skills/kimi-cancel/SKILL.md
@@ -15,6 +15,7 @@ EXTERNAL_MODEL_CONTRACT_VERSION=1
 Run `node "<plugin-root>/scripts/kimi-companion.mjs" cancel --job "<job-id>" --cwd "<workspace>"`.
 Cancel is for background jobs only.
 Foreground runs are owned by the active terminal; interrupt them with Ctrl+C.
+For no_pid_info or unverifiable, render `suggested_action` when present and do not invent a PID kill command without an ownership check.
 ## Secret Safety
 Do not print raw OAuth tokens, API-key values, session cookies, tunnel API keys, bearer tokens, or raw secret values.
 Credential diagnostics may show key names only.

--- a/plugins/kimi/skills/kimi-delegation/SKILL.md
+++ b/plugins/kimi/skills/kimi-delegation/SKILL.md
@@ -59,6 +59,7 @@ Failed or incomplete rescue is not success. Report the failed state and the next
 ## Rendering Contract
 Render companion JSON directly.
 If `external_review_launched` is present, render it immediately.
+`external_review_progress` is a heartbeat for long foreground runs; keep the existing launch card visible and do not render it as a terminal result.
 If a background launch envelope has `event: "launched"` with an `external_review` field, render the same launch card immediately with session pending.
 If `external_review` is present, render it before normal prose.
 Launch cards should include provider, job, session, run kind, and scope when those fields are present.

--- a/plugins/kimi/skills/kimi-rescue/SKILL.md
+++ b/plugins/kimi/skills/kimi-rescue/SKILL.md
@@ -26,6 +26,7 @@ Failed or incomplete rescue is not success. Report the failed state and the next
 ## Rendering Contract
 Render companion JSON directly.
 If `external_review_launched` is present, render it immediately.
+`external_review_progress` is a heartbeat for long foreground runs; keep the existing launch card visible and do not render it as a terminal result.
 If a background launch envelope has `event: "launched"` with an `external_review` field, render the same launch card immediately with session pending.
 If `external_review` is present, render it before normal prose.
 Launch cards should include provider, job, session, run kind, and scope when those fields are present.

--- a/plugins/kimi/skills/kimi-review/SKILL.md
+++ b/plugins/kimi/skills/kimi-review/SKILL.md
@@ -32,6 +32,7 @@ custom-review uses explicit relative paths. Scope validation must complete befor
 ## Rendering Contract
 Render companion JSON directly.
 If `external_review_launched` is present, render it immediately.
+`external_review_progress` is a heartbeat for long foreground runs; keep the existing launch card visible and do not render it as a terminal result.
 If a background launch envelope has `event: "launched"` with an `external_review` field, render the same launch card immediately with session pending.
 If `external_review` is present, render it before normal prose.
 Launch cards should include provider, job, session, run kind, and scope when those fields are present.

--- a/scripts/lib/companion-common.mjs
+++ b/scripts/lib/companion-common.mjs
@@ -94,6 +94,25 @@ export function startExternalReviewHeartbeat(
   return () => clearInterval(timer);
 }
 
+export function effectiveProfileForOptions(profile, options) {
+  if (profile.name === "review" && options["scope-base"] != null && options["scope-base"] !== "") {
+    return Object.freeze({ ...profile, scope: "branch-diff" });
+  }
+  return profile;
+}
+
+export function cancelUnverifiableSuggestedAction(pid) {
+  return (
+    "Retry cancel from a less restricted shell where process inspection works. " +
+    `If you manually inspect pid ${pid} and confirm ownership matches this job, ` +
+    "terminate it outside the sandbox; otherwise leave it running and use status/result after it exits."
+  );
+}
+
+export function cancelNoPidInfoSuggestedAction() {
+  return "Use status/result to refresh the job record. Do not signal manually unless you can independently verify process ownership.";
+}
+
 export function parseScopePathsOption(value) {
   return value
     ? String(value).split(",").map((s) => s.trim()).filter(Boolean)

--- a/scripts/lib/companion-common.mjs
+++ b/scripts/lib/companion-common.mjs
@@ -32,6 +32,19 @@ export function externalReviewLaunchedEvent(invocation, externalReview) {
   };
 }
 
+export function externalReviewProgressEvent(invocation, { sequence, elapsedMs }) {
+  return {
+    event: "external_review_progress",
+    job_id: invocation.job_id,
+    target: invocation.target,
+    status: "running",
+    mode: invocation.mode ?? null,
+    run_kind: invocation.run_kind ?? "foreground",
+    heartbeat: sequence,
+    elapsed_ms: Math.max(0, Math.trunc(elapsedMs ?? 0)),
+  };
+}
+
 export function externalReviewBackgroundLaunchedEvent(invocation, pid, externalReview) {
   return {
     event: "launched",
@@ -48,6 +61,37 @@ export function externalReviewBackgroundLaunchedEvent(invocation, pid, externalR
 export function printLifecycleJson(obj, lifecycleEvents, output = process.stdout) {
   if (lifecycleEvents === "jsonl") printJsonLine(obj, output);
   else printJson(obj, output);
+}
+
+export function externalReviewHeartbeatIntervalMs(env = process.env) {
+  const raw = env.CODEX_PLUGIN_EXTERNAL_REVIEW_HEARTBEAT_MS;
+  if (raw === undefined || raw === null || raw === "") return 30000;
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : 30000;
+}
+
+export function startExternalReviewHeartbeat(
+  invocation,
+  lifecycleEvents,
+  { intervalMs = externalReviewHeartbeatIntervalMs(), output = process.stdout, now = Date.now } = {},
+) {
+  if (lifecycleEvents !== "jsonl") return () => {};
+  const interval = Number.isSafeInteger(intervalMs) && intervalMs > 0 ? intervalMs : externalReviewHeartbeatIntervalMs();
+  const started = now();
+  let sequence = 0;
+  const timer = setInterval(() => {
+    sequence += 1;
+    printLifecycleJson(
+      externalReviewProgressEvent(invocation, {
+        sequence,
+        elapsedMs: now() - started,
+      }),
+      lifecycleEvents,
+      output,
+    );
+  }, interval);
+  timer.unref?.();
+  return () => clearInterval(timer);
 }
 
 export function parseScopePathsOption(value) {

--- a/scripts/lib/companion-common.mjs
+++ b/scripts/lib/companion-common.mjs
@@ -8,12 +8,16 @@ import { resolve as resolvePath, sep } from "node:path";
 export const PING_PROMPT =
   "reply with exactly: pong. Do not use any tools, do not read files, and do not explore the workspace.";
 
+function writableOutput(output) {
+  return output && typeof output.write === "function" ? output : process.stdout;
+}
+
 export function printJson(obj, output = process.stdout) {
-  output.write(`${JSON.stringify(obj, null, 2)}\n`);
+  writableOutput(output).write(`${JSON.stringify(obj, null, 2)}\n`);
 }
 
 export function printJsonLine(obj, output = process.stdout) {
-  output.write(`${JSON.stringify(obj)}\n`);
+  writableOutput(output).write(`${JSON.stringify(obj)}\n`);
 }
 
 export function parseLifecycleEventsMode(value) {
@@ -95,10 +99,16 @@ export function startExternalReviewHeartbeat(
 }
 
 export function effectiveProfileForOptions(profile, options) {
-  if (profile.name === "review" && options["scope-base"] != null && options["scope-base"] !== "") {
+  if (profile.name === "review" && scopeBaseForOptions(options) !== null) {
     return Object.freeze({ ...profile, scope: "branch-diff" });
   }
   return profile;
+}
+
+export function scopeBaseForOptions(options) {
+  const value = options["scope-base"];
+  if (value == null) return null;
+  return String(value).trim() === "" ? null : String(value);
 }
 
 export function cancelUnverifiableSuggestedAction(pid) {

--- a/scripts/lib/external-model-contracts.mjs
+++ b/scripts/lib/external-model-contracts.mjs
@@ -427,6 +427,7 @@ function renderCompanionCommandBody(provider, workflow, commandName) {
       `Run \`node "<plugin-root>/scripts/${provider.binary}" cancel --job "$ARGUMENTS" --cwd "<workspace>"\`.`,
       "This command is for background jobs only. Foreground runs are owned by the active terminal; interrupt them with Ctrl+C.",
       "The companion does not signal attached foreground processes.",
+      "For no_pid_info or unverifiable, render `suggested_action` when present and do not invent a PID kill command without an ownership check.",
       "",
       "Statuses:",
       statusRows,
@@ -546,6 +547,7 @@ function renderCompanionSkillBody(provider, workflow, skillName) {
       `Run \`node "<plugin-root>/scripts/${provider.binary}" cancel --job "<job-id>" --cwd "<workspace>"\`.`,
       "Cancel is for background jobs only.",
       "Foreground runs are owned by the active terminal; interrupt them with Ctrl+C.",
+      "For no_pid_info or unverifiable, render `suggested_action` when present and do not invent a PID kill command without an ownership check.",
       secretSafetyContract(),
     );
   }

--- a/scripts/lib/external-model-contracts.mjs
+++ b/scripts/lib/external-model-contracts.mjs
@@ -245,6 +245,7 @@ function lifecycleRenderingContract() {
     "## Rendering Contract",
     "Render companion JSON directly.",
     "If `external_review_launched` is present, render it immediately.",
+    "`external_review_progress` is a heartbeat for long foreground runs; keep the existing launch card visible and do not render it as a terminal result.",
     "If a background launch envelope has `event: \"launched\"` with an `external_review` field, render the same launch card immediately with session pending.",
     "If `external_review` is present, render it before normal prose.",
     "Launch cards should include provider, job, session, run kind, and scope when those fields are present.",

--- a/scripts/lib/review-prompt.mjs
+++ b/scripts/lib/review-prompt.mjs
@@ -620,6 +620,7 @@ export function buildReviewPrompt({
     "- Distinguish real blocking code findings from missing supplied evidence, runtime/tool limitations, and stale or unavailable external comments.",
     "- For every checklist item, report PASS, FAIL, or NOT REVIEWED.",
     "- Blocking findings first, with concrete file/function/control-flow evidence.",
+    "- Start the first line with exactly one verdict marker: \"Verdict: APPROVE\", \"Verdict: REQUEST_CHANGES\", or \"Verdict: NOT_REVIEWED\".",
     "- A usable review must name the selected file path(s) inspected; bare numbered answers or section bodies such as only 'None' are shallow and invalid.",
     "- If a section has no findings, write a complete sentence that names the relevant selected file or scope and explains why no finding applies.",
     "- For control-flow and security code, explicitly inspect overlapping predicates, early returns, and branch ordering before concluding no blocker exists.",

--- a/tests/smoke/api-reviewers.smoke.test.mjs
+++ b/tests/smoke/api-reviewers.smoke.test.mjs
@@ -126,6 +126,10 @@ async function waitForValue(fn, { timeoutMs = 2000, intervalMs = 25 } = {}) {
   assert.fail("timed out waiting for expected value");
 }
 
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 function mockResponse(model, id = "chatcmpl-test", content = substantiveReviewFixture(`Provider model: ${model}`)) {
   return JSON.stringify({
     id,
@@ -3200,35 +3204,56 @@ test("branch-diff rejects oversized committed scope files before provider delive
 
 test("direct API reviewers lifecycle jsonl emits launch before terminal record", async () => {
   const cwd = makeWorkspace();
-  const result = await run([
-    "run",
-    "--provider", "deepseek",
-    "--mode", "custom-review",
-    "--scope", "custom",
-    "--scope-paths", "seed.txt",
-    "--foreground",
-    "--lifecycle-events", "jsonl",
-    "--prompt", "Check this file.",
-  ], {
-    cwd,
-    env: {
-      API_REVIEWERS_MOCK_RESPONSE: mockResponse("deepseek-v4-pro"),
-      DEEPSEEK_API_KEY: "secret-test-value",
-    },
+  const pluginRoot = makeInstalledApiReviewersRoot();
+  const server = await startChatServer(async (req, res) => {
+    req.resume();
+    await sleep(25);
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(mockResponse("deepseek-v4-pro"));
   });
-  assert.equal(result.status, 0, result.stderr || result.stdout);
-  const lines = parseJsonLines(result.stdout);
-  assert.equal(lines.length, 2);
-  const [launch, record] = lines;
-  assert.deepEqual(launch, externalReviewLaunchedEvent({
-    job_id: launch.job_id,
-    target: "deepseek",
-  }, launch.external_review));
-  assert.equal(launch.external_review.provider, "DeepSeek");
-  assert.equal(launch.external_review.source_content_transmission, "may_be_sent");
-  assert.equal(record.status, "completed");
-  assert.equal(record.external_review.source_content_transmission, "sent");
-  assert.doesNotMatch(result.stdout, /secret-test-value/);
+  try {
+    const { port } = server.address();
+    writeDeepSeekProviderConfig(pluginRoot, `http://127.0.0.1:${port}`);
+    const result = await run([
+      "run",
+      "--provider", "deepseek",
+      "--mode", "custom-review",
+      "--scope", "custom",
+      "--scope-paths", "seed.txt",
+      "--foreground",
+      "--lifecycle-events", "jsonl",
+      "--prompt", "Check this file.",
+    ], {
+      companion: path.join(pluginRoot, "scripts", "api-reviewer.mjs"),
+      cwd,
+      env: {
+        CODEX_PLUGIN_EXTERNAL_REVIEW_HEARTBEAT_MS: "5",
+        DEEPSEEK_API_KEY: "secret-test-value",
+      },
+    });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const lines = parseJsonLines(result.stdout);
+    assert.ok(lines.length >= 3, result.stdout);
+    const [launch] = lines;
+    const progress = lines.find((line) => line.event === "external_review_progress");
+    const record = lines.at(-1);
+    assert.deepEqual(launch, externalReviewLaunchedEvent({
+      job_id: launch.job_id,
+      target: "deepseek",
+    }, launch.external_review));
+    assert.equal(progress.job_id, launch.job_id);
+    assert.equal(progress.target, "deepseek");
+    assert.equal(progress.status, "running");
+    assert.equal(progress.heartbeat, 1);
+    assert.equal(launch.external_review.provider, "DeepSeek");
+    assert.equal(launch.external_review.source_content_transmission, "may_be_sent");
+    assert.equal(record.status, "completed");
+    assert.equal(record.external_review.source_content_transmission, "sent");
+    assert.doesNotMatch(result.stdout, /secret-test-value/);
+  } finally {
+    server.close();
+    rmSync(pluginRoot, { recursive: true, force: true });
+  }
 });
 
 test("direct API reviewers reject invalid lifecycle event mode as bad args", async () => {

--- a/tests/smoke/api-reviewers.smoke.test.mjs
+++ b/tests/smoke/api-reviewers.smoke.test.mjs
@@ -3207,7 +3207,7 @@ test("direct API reviewers lifecycle jsonl emits launch before terminal record",
   const pluginRoot = makeInstalledApiReviewersRoot();
   const server = await startChatServer(async (req, res) => {
     req.resume();
-    await sleep(25);
+    await sleep(100);
     res.writeHead(200, { "content-type": "application/json" });
     res.end(mockResponse("deepseek-v4-pro"));
   });

--- a/tests/smoke/claude-companion.smoke.test.mjs
+++ b/tests/smoke/claude-companion.smoke.test.mjs
@@ -1085,8 +1085,9 @@ test("run --background: active job is visible as running and can be cancelled", 
       // cancel post-condition (process gone) holds.
       assert.equal(cancelRes.status, 2,
         `capture_error path must exit 2 (refused, unverifiable); stderr=${cancelRes.stderr}`);
-      assert.equal(cancel.status, "no_pid_info");
-      // No pid_info → no signal sent → job will run to natural completion
+      assert.equal(cancel.status, "unverifiable");
+      assert.match(cancel.suggested_action, /process inspection|ownership/i);
+      // Unverifiable pid_info → no signal sent → job will run to natural completion
       // (or remain running until timeout). We just need it to reach SOME
       // terminal state so the test doesn't leak background workers.
       const terminalDeadline = Date.now() + 7000;

--- a/tests/smoke/gemini-companion.smoke.test.mjs
+++ b/tests/smoke/gemini-companion.smoke.test.mjs
@@ -293,7 +293,7 @@ test("gemini cancel: signals a running background job (issue #22 sub-task 1)", a
       cwd, encoding: "utf8",
       env: { ...process.env, GEMINI_PLUGIN_DATA: dataDir },
     });
-    // Two acceptable outcomes: signaled (signal landed) or no_pid_info
+    // Two acceptable outcomes: signaled (signal landed) or unverifiable
     // (mock spawn raced and pid capture failed). What MUST NOT happen is
     // a "not_implemented" error from the dispatch.
     assert.notEqual(cancelRes.status, 1, `gemini cancel must be implemented; stderr=${cancelRes.stderr}`);
@@ -307,7 +307,8 @@ test("gemini cancel: signals a running background job (issue #22 sub-task 1)", a
       // lie that the cancel post-condition (process gone) holds.
       assert.equal(cancelRes.status, 2,
         `capture_error path must exit 2 (refused, unverifiable); stderr=${cancelRes.stderr}`);
-      assert.equal(cancel.status, "no_pid_info");
+      assert.equal(cancel.status, "unverifiable");
+      assert.match(cancel.suggested_action, /process inspection|ownership/i);
     } else {
       // Mock can exit between attachPidCapture's 'spawn' snapshot and
       // verifyPidInfo at cancel time. All four post-spawn outcomes are

--- a/tests/smoke/grok-web.smoke.test.mjs
+++ b/tests/smoke/grok-web.smoke.test.mjs
@@ -1500,7 +1500,7 @@ test("custom-review lifecycle jsonl emits launch before terminal record", async 
   writeFileSync(path.join(cwd, "review.js"), "export const value = 42;\n");
 
   await withServer(async (_req, res) => {
-    await sleep(25);
+    await sleep(100);
     res.setHeader("content-type", "application/json");
     res.end(JSON.stringify({
       id: "grok-web-session-lifecycle",

--- a/tests/smoke/grok-web.smoke.test.mjs
+++ b/tests/smoke/grok-web.smoke.test.mjs
@@ -111,6 +111,10 @@ function rmTree(dir) {
   rmSync(dir, { recursive: true, force: true });
 }
 
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 function makeEmptyBranchDiffWorkspace() {
   const cwd = realpathSync(mkdtempSync(path.join(tmpdir(), "grok-web-empty-branch-diff-")));
   writeFileSync(path.join(cwd, "review.js"), "export const value = 1;\n");
@@ -1496,6 +1500,7 @@ test("custom-review lifecycle jsonl emits launch before terminal record", async 
   writeFileSync(path.join(cwd, "review.js"), "export const value = 42;\n");
 
   await withServer(async (_req, res) => {
+    await sleep(25);
     res.setHeader("content-type", "application/json");
     res.end(JSON.stringify({
       id: "grok-web-session-lifecycle",
@@ -1515,18 +1520,25 @@ test("custom-review lifecycle jsonl emits launch before terminal record", async 
     ], {
       cwd,
       env: {
+        CODEX_PLUGIN_EXTERNAL_REVIEW_HEARTBEAT_MS: "5",
         GROK_WEB_BASE_URL: baseUrl,
         GROK_WEB_TUNNEL_API_KEY: "secret-cookie-like-token",
       },
     });
     assert.equal(result.status, 0, result.stderr || result.stdout);
     const lines = parseJsonLines(result);
-    assert.equal(lines.length, 2);
-    const [launch, record] = lines;
+    assert.ok(lines.length >= 3, result.stdout);
+    const [launch] = lines;
+    const progress = lines.find((line) => line.event === "external_review_progress");
+    const record = lines.at(-1);
     assert.deepEqual(launch, externalReviewLaunchedEvent({
       job_id: launch.job_id,
       target: "grok-web",
     }, launch.external_review));
+    assert.equal(progress.job_id, launch.job_id);
+    assert.equal(progress.target, "grok-web");
+    assert.equal(progress.status, "running");
+    assert.equal(progress.heartbeat, 1);
     assert.equal(launch.external_review.provider, "Grok Web");
     assert.equal(launch.external_review.source_content_transmission, "may_be_sent");
     assert.equal(record.status, "completed");

--- a/tests/unit/companion-common.test.mjs
+++ b/tests/unit/companion-common.test.mjs
@@ -6,11 +6,15 @@ import path from "node:path";
 
 import {
   PING_PROMPT,
+  cancelNoPidInfoSuggestedAction,
+  cancelUnverifiableSuggestedAction,
   comparePathStrings,
   consumePromptSidecar,
   credentialNameDiagnostics,
+  effectiveProfileForOptions,
   externalReviewBackgroundLaunchedEvent,
   externalReviewLaunchedEvent,
+  externalReviewHeartbeatIntervalMs,
   externalReviewProgressEvent,
   gitStatusLines,
   parseLifecycleEventsMode,
@@ -138,6 +142,20 @@ test("shared companion helpers cover small provider-agnostic behavior", () => {
   assert.deepEqual(gitStatusLines(" M a.js  \n\n?? b.js\n"), [" M a.js", "?? b.js"]);
   assert.equal(runKindFromRecord({ external_review: { run_kind: "foreground" } }), "foreground");
   assert.equal(runKindFromRecord({}), "unknown");
+  assert.equal(externalReviewHeartbeatIntervalMs({}), 30000);
+  assert.equal(externalReviewHeartbeatIntervalMs({ CODEX_PLUGIN_EXTERNAL_REVIEW_HEARTBEAT_MS: "7" }), 7);
+  assert.equal(externalReviewHeartbeatIntervalMs({ CODEX_PLUGIN_EXTERNAL_REVIEW_HEARTBEAT_MS: "0" }), 30000);
+  const reviewProfile = Object.freeze({ name: "review", scope: "working-tree" });
+  assert.deepEqual(effectiveProfileForOptions(reviewProfile, { "scope-base": "origin/main" }), {
+    name: "review",
+    scope: "branch-diff",
+  });
+  assert.equal(effectiveProfileForOptions(reviewProfile, { "scope-base": "" }), reviewProfile);
+  const customProfile = Object.freeze({ name: "custom-review", scope: "custom" });
+  assert.equal(effectiveProfileForOptions(customProfile, { "scope-base": "origin/main" }), customProfile);
+  assert.match(cancelUnverifiableSuggestedAction(1234), /pid 1234/);
+  assert.match(cancelUnverifiableSuggestedAction(1234), /ownership/);
+  assert.match(cancelNoPidInfoSuggestedAction(), /verify process ownership/);
 });
 
 test("startExternalReviewHeartbeat emits jsonl progress until stopped", async () => {
@@ -282,11 +300,11 @@ test("plugin packaging copies expose the canonical helper behavior", async () =>
     assert.deepEqual(mod.parseScopePathsOption("one,two"), ["one", "two"]);
     assert.deepEqual(mod.gitStatusLines(" M x\n"), [" M x"]);
     assert.equal(mod.runKindFromRecord({}), "unknown");
-    assertCopyHelperBranches(mod, plugin);
+    await assertCopyHelperBranches(mod, plugin);
   }
 });
 
-function assertCopyHelperBranches(mod, plugin) {
+async function assertCopyHelperBranches(mod, plugin) {
   let printed = "";
   mod.printJson({ plugin }, { write: (chunk) => { printed += chunk; } });
   assert.equal(printed, `{\n  "plugin": "${plugin}"\n}\n`);
@@ -366,6 +384,33 @@ function assertCopyHelperBranches(mod, plugin) {
   assert.deepEqual(mod.gitStatusLines(" M a.js  \n\n?? b.js\n"), [" M a.js", "?? b.js"]);
   assert.equal(mod.runKindFromRecord({ external_review: { run_kind: "background" } }), "background");
   assert.equal(mod.runKindFromRecord({}), "unknown");
+  assert.equal(mod.externalReviewHeartbeatIntervalMs({}), 30000);
+  assert.equal(mod.externalReviewHeartbeatIntervalMs({ CODEX_PLUGIN_EXTERNAL_REVIEW_HEARTBEAT_MS: "7" }), 7);
+  assert.equal(mod.externalReviewHeartbeatIntervalMs({ CODEX_PLUGIN_EXTERNAL_REVIEW_HEARTBEAT_MS: "0" }), 30000);
+  const reviewProfile = Object.freeze({ name: "review", scope: "working-tree" });
+  assert.deepEqual(mod.effectiveProfileForOptions(reviewProfile, { "scope-base": "origin/main" }), {
+    name: "review",
+    scope: "branch-diff",
+  });
+  assert.equal(mod.effectiveProfileForOptions(reviewProfile, { "scope-base": "" }), reviewProfile);
+  const customProfile = Object.freeze({ name: "custom-review", scope: "custom" });
+  assert.equal(mod.effectiveProfileForOptions(customProfile, { "scope-base": "origin/main" }), customProfile);
+  assert.match(mod.cancelUnverifiableSuggestedAction(1234), /pid 1234/);
+  assert.match(mod.cancelUnverifiableSuggestedAction(1234), /ownership/);
+  assert.match(mod.cancelNoPidInfoSuggestedAction(), /verify process ownership/);
+
+  const chunks = [];
+  const stop = mod.startExternalReviewHeartbeat(
+    { job_id: `copy-heartbeat-${plugin}`, target: plugin, mode: "review", run_kind: "foreground" },
+    "jsonl",
+    { intervalMs: 5, output: { write: (chunk) => chunks.push(chunk) } },
+  );
+  await new Promise((resolve) => setTimeout(resolve, 12));
+  stop();
+  assert.ok(chunks.length >= 1, `${plugin}: copied heartbeat helper must emit progress`);
+  const heartbeat = JSON.parse(chunks[0]);
+  assert.equal(heartbeat.event, "external_review_progress");
+  assert.equal(heartbeat.target, plugin);
 
   const jobsDir = mkdtempSync(path.join(tmpdir(), `companion-common-copy-jobs-${plugin}-`));
   assert.equal(mod.consumePromptSidecar(jobsDir, "job-1"), null);

--- a/tests/unit/companion-common.test.mjs
+++ b/tests/unit/companion-common.test.mjs
@@ -11,6 +11,7 @@ import {
   credentialNameDiagnostics,
   externalReviewBackgroundLaunchedEvent,
   externalReviewLaunchedEvent,
+  externalReviewProgressEvent,
   gitStatusLines,
   parseLifecycleEventsMode,
   parseScopePathsOption,
@@ -21,6 +22,7 @@ import {
   printLifecycleJson,
   promptSidecarPath,
   runKindFromRecord,
+  startExternalReviewHeartbeat,
   summarizeScopeDirectory,
   writePromptSidecar,
 } from "../../scripts/lib/companion-common.mjs";
@@ -114,12 +116,52 @@ test("shared companion helpers cover small provider-agnostic behavior", () => {
       external_review: { marker: "EXTERNAL REVIEW", run_kind: "background" },
     },
   );
+  assert.deepEqual(
+    externalReviewProgressEvent(
+      { job_id: "job-1", target: "claude", mode: "review", run_kind: "foreground" },
+      { sequence: 2, elapsedMs: 1234 },
+    ),
+    {
+      event: "external_review_progress",
+      job_id: "job-1",
+      target: "claude",
+      status: "running",
+      mode: "review",
+      run_kind: "foreground",
+      heartbeat: 2,
+      elapsed_ms: 1234,
+    },
+  );
   assert.deepEqual(parseScopePathsOption(" a.js, ,src/b.js "), ["a.js", "src/b.js"]);
   assert.equal(parseScopePathsOption(""), null);
   assert.deepEqual(["b", "a", "aa"].sort(comparePathStrings), ["a", "aa", "b"]);
   assert.deepEqual(gitStatusLines(" M a.js  \n\n?? b.js\n"), [" M a.js", "?? b.js"]);
   assert.equal(runKindFromRecord({ external_review: { run_kind: "foreground" } }), "foreground");
   assert.equal(runKindFromRecord({}), "unknown");
+});
+
+test("startExternalReviewHeartbeat emits jsonl progress until stopped", async () => {
+  const chunks = [];
+  const stop = startExternalReviewHeartbeat(
+    { job_id: "job-heartbeat", target: "gemini", mode: "review", run_kind: "foreground" },
+    "jsonl",
+    { intervalMs: 5, output: { write: (chunk) => chunks.push(chunk) } },
+  );
+
+  await new Promise((resolve) => setTimeout(resolve, 18));
+  stop();
+  const countAfterStop = chunks.length;
+  await new Promise((resolve) => setTimeout(resolve, 12));
+
+  assert.ok(countAfterStop >= 1, "heartbeat must emit at least one progress event");
+  assert.equal(chunks.length, countAfterStop, "stop must cancel future heartbeats");
+  const event = JSON.parse(chunks[0]);
+  assert.equal(event.event, "external_review_progress");
+  assert.equal(event.job_id, "job-heartbeat");
+  assert.equal(event.target, "gemini");
+  assert.equal(event.status, "running");
+  assert.equal(event.heartbeat, 1);
+  assert.equal(Number.isInteger(event.elapsed_ms), true);
 });
 
 test("summarizeScopeDirectory returns sorted files and byte totals", () => {

--- a/tests/unit/companion-common.test.mjs
+++ b/tests/unit/companion-common.test.mjs
@@ -26,6 +26,7 @@ import {
   printLifecycleJson,
   promptSidecarPath,
   runKindFromRecord,
+  scopeBaseForOptions,
   startExternalReviewHeartbeat,
   summarizeScopeDirectory,
   writePromptSidecar,
@@ -145,12 +146,17 @@ test("shared companion helpers cover small provider-agnostic behavior", () => {
   assert.equal(externalReviewHeartbeatIntervalMs({}), 30000);
   assert.equal(externalReviewHeartbeatIntervalMs({ CODEX_PLUGIN_EXTERNAL_REVIEW_HEARTBEAT_MS: "7" }), 7);
   assert.equal(externalReviewHeartbeatIntervalMs({ CODEX_PLUGIN_EXTERNAL_REVIEW_HEARTBEAT_MS: "0" }), 30000);
+  assert.equal(scopeBaseForOptions({}), null);
+  assert.equal(scopeBaseForOptions({ "scope-base": "" }), null);
+  assert.equal(scopeBaseForOptions({ "scope-base": "   " }), null);
+  assert.equal(scopeBaseForOptions({ "scope-base": "origin/main" }), "origin/main");
   const reviewProfile = Object.freeze({ name: "review", scope: "working-tree" });
   assert.deepEqual(effectiveProfileForOptions(reviewProfile, { "scope-base": "origin/main" }), {
     name: "review",
     scope: "branch-diff",
   });
   assert.equal(effectiveProfileForOptions(reviewProfile, { "scope-base": "" }), reviewProfile);
+  assert.equal(effectiveProfileForOptions(reviewProfile, { "scope-base": "   " }), reviewProfile);
   const customProfile = Object.freeze({ name: "custom-review", scope: "custom" });
   assert.equal(effectiveProfileForOptions(customProfile, { "scope-base": "origin/main" }), customProfile);
   assert.match(cancelUnverifiableSuggestedAction(1234), /pid 1234/);
@@ -387,12 +393,17 @@ async function assertCopyHelperBranches(mod, plugin) {
   assert.equal(mod.externalReviewHeartbeatIntervalMs({}), 30000);
   assert.equal(mod.externalReviewHeartbeatIntervalMs({ CODEX_PLUGIN_EXTERNAL_REVIEW_HEARTBEAT_MS: "7" }), 7);
   assert.equal(mod.externalReviewHeartbeatIntervalMs({ CODEX_PLUGIN_EXTERNAL_REVIEW_HEARTBEAT_MS: "0" }), 30000);
+  assert.equal(mod.scopeBaseForOptions({}), null);
+  assert.equal(mod.scopeBaseForOptions({ "scope-base": "" }), null);
+  assert.equal(mod.scopeBaseForOptions({ "scope-base": "   " }), null);
+  assert.equal(mod.scopeBaseForOptions({ "scope-base": "origin/main" }), "origin/main");
   const reviewProfile = Object.freeze({ name: "review", scope: "working-tree" });
   assert.deepEqual(mod.effectiveProfileForOptions(reviewProfile, { "scope-base": "origin/main" }), {
     name: "review",
     scope: "branch-diff",
   });
   assert.equal(mod.effectiveProfileForOptions(reviewProfile, { "scope-base": "" }), reviewProfile);
+  assert.equal(mod.effectiveProfileForOptions(reviewProfile, { "scope-base": "   " }), reviewProfile);
   const customProfile = Object.freeze({ name: "custom-review", scope: "custom" });
   assert.equal(mod.effectiveProfileForOptions(customProfile, { "scope-base": "origin/main" }), customProfile);
   assert.match(mod.cancelUnverifiableSuggestedAction(1234), /pid 1234/);

--- a/tests/unit/external-model-contracts.test.mjs
+++ b/tests/unit/external-model-contracts.test.mjs
@@ -89,6 +89,7 @@ test("shared review contracts keep upstream-parity review-only guarantees", () =
     "Return the runtime output verbatim; do not summarize or rewrite findings.",
     "If there is no substantive result or structured output, report review blocked / no findings produced.",
     "Render `external_review_launched` as soon as it appears.",
+    "`external_review_progress` is a heartbeat for long foreground runs; keep the existing launch card visible and do not render it as a terminal result.",
     "Render `external_review` before findings, status prose, or the review result.",
   ]) {
     assert.match(reviewDocs, new RegExp(escapeRegExp(required)));

--- a/tests/unit/external-review-default-ux.test.mjs
+++ b/tests/unit/external-review-default-ux.test.mjs
@@ -1,0 +1,252 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { fixtureGitEnv } from "../helpers/fixture-git.mjs";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+const COMPANIONS = Object.freeze([
+  {
+    target: "claude",
+    script: path.join(REPO_ROOT, "plugins/claude/scripts/claude-companion.mjs"),
+    dataEnv: "CLAUDE_PLUGIN_DATA",
+  },
+  {
+    target: "gemini",
+    script: path.join(REPO_ROOT, "plugins/gemini/scripts/gemini-companion.mjs"),
+    dataEnv: "GEMINI_PLUGIN_DATA",
+  },
+  {
+    target: "kimi",
+    script: path.join(REPO_ROOT, "plugins/kimi/scripts/kimi-companion.mjs"),
+    dataEnv: "KIMI_PLUGIN_DATA",
+  },
+]);
+
+function cleanup(...paths) {
+  for (const p of paths) rmSync(p, { recursive: true, force: true });
+}
+
+function git(cwd, ...args) {
+  const res = spawnSync("git", ["-C", cwd, "-c", "core.hooksPath=/dev/null", ...args], {
+    cwd,
+    encoding: "utf8",
+    env: fixtureGitEnv(),
+  });
+  if (res.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${res.stderr || res.stdout}`);
+  }
+  return res.stdout.trim();
+}
+
+function seedBranchDiffRepo() {
+  const cwd = mkdtempSync(path.join(tmpdir(), "external-review-default-ux-"));
+  git(cwd, "init", "-q", "-b", "main");
+  writeFileSync(path.join(cwd, ".gitignore"), ".claude/\n");
+  writeFileSync(path.join(cwd, "feature.md"), "base\n");
+  writeFileSync(path.join(cwd, "old.md"), "base old\n");
+  git(cwd, "add", ".gitignore", "feature.md", "old.md");
+  git(cwd, "commit", "-qm", "base");
+  const base = git(cwd, "rev-parse", "HEAD");
+  writeFileSync(path.join(cwd, "feature.md"), "head\n");
+  git(cwd, "add", "feature.md");
+  git(cwd, "commit", "-qm", "head");
+  return { cwd, base };
+}
+
+function addDirtyWorkingTreeAndIgnoredClaudeSymlink(cwd) {
+  writeFileSync(path.join(cwd, "old.md"), "dirty old\n");
+  const embeddedWorktree = path.join(cwd, ".claude/worktrees/agent-a");
+  mkdirSync(embeddedWorktree, { recursive: true });
+  git(embeddedWorktree, "init", "-q", "-b", "main");
+  writeFileSync(path.join(embeddedWorktree, "README.md"), "nested ignored repo\n");
+  git(embeddedWorktree, "add", "README.md");
+  git(embeddedWorktree, "commit", "-qm", "nested ignored repo");
+  const ignoredDir = path.join(embeddedWorktree, "node_modules/@codex-plugin-multi");
+  mkdirSync(ignoredDir, { recursive: true });
+  symlinkSync(cwd, path.join(ignoredDir, "api-reviewers-plugin"), "dir");
+}
+
+function runPreflight(companion, cwd, args) {
+  const dataDir = mkdtempSync(path.join(tmpdir(), `${companion.target}-preflight-data-`));
+  const res = spawnSync("node", [companion.script, "preflight", ...args], {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      ...fixtureGitEnv(),
+      [companion.dataEnv]: dataDir,
+    },
+  });
+  let json = null;
+  try {
+    json = JSON.parse(res.stdout);
+  } catch (error) {
+    throw new Error(`${companion.target} preflight did not emit JSON: ${error.message}\nstdout=${res.stdout}\nstderr=${res.stderr}`);
+  } finally {
+    cleanup(dataDir);
+  }
+  return { ...res, json };
+}
+
+function workspaceStateDir(dataDir, cwd) {
+  const workspaceRoot = realpathSync(cwd);
+  const slug = (path.basename(workspaceRoot) || "workspace")
+    .replace(/[^a-zA-Z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "") || "workspace";
+  const hash = createHash("sha256").update(workspaceRoot).digest("hex").slice(0, 16);
+  return path.join(dataDir, "state", `${slug}-${hash}`);
+}
+
+function writeRunningJobState(dataDir, cwd, job) {
+  const stateDir = workspaceStateDir(dataDir, cwd);
+  mkdirSync(path.join(stateDir, "jobs"), { recursive: true });
+  writeFileSync(path.join(stateDir, "state.json"), `${JSON.stringify({
+    version: 1,
+    config: { stopReviewGate: false },
+    jobs: [job],
+  }, null, 2)}\n`);
+}
+
+function runCancel(companion, cwd, dataDir, jobId) {
+  const res = spawnSync("node", [companion.script, "cancel", "--job", jobId, "--cwd", cwd], {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      [companion.dataEnv]: dataDir,
+    },
+  });
+  return { ...res, json: JSON.parse(res.stdout) };
+}
+
+test("Claude/Gemini/Kimi review --scope-base selects branch-diff, not dirty working-tree scope", () => {
+  for (const companion of COMPANIONS) {
+    const { cwd, base } = seedBranchDiffRepo();
+    try {
+      writeFileSync(path.join(cwd, "old.md"), "dirty old\n");
+
+      const res = runPreflight(companion, cwd, [
+        "--mode=review",
+        "--cwd", cwd,
+        "--scope-base", base,
+      ]);
+
+      assert.equal(res.status, 0, `${companion.target}: ${res.stderr}`);
+      assert.equal(res.json.ok, true, companion.target);
+      assert.equal(res.json.scope, "branch-diff", companion.target);
+      assert.deepEqual(res.json.files, ["feature.md"], companion.target);
+      assert.equal(res.json.selected_scope_sent_to_provider, false, companion.target);
+    } finally {
+      cleanup(cwd);
+    }
+  }
+});
+
+test("Claude/Gemini/Kimi plain review keeps working-tree scope and ignores .claude worktree debris", () => {
+  for (const companion of COMPANIONS) {
+    const { cwd } = seedBranchDiffRepo();
+    try {
+      addDirtyWorkingTreeAndIgnoredClaudeSymlink(cwd);
+
+      const res = runPreflight(companion, cwd, [
+        "--mode=review",
+        "--cwd", cwd,
+      ]);
+
+      assert.equal(res.status, 0, `${companion.target}: ${res.stderr}`);
+      assert.equal(res.json.ok, true, companion.target);
+      assert.equal(res.json.scope, "working-tree", companion.target);
+      assert.equal(res.json.selected_scope_sent_to_provider, false, companion.target);
+      assert.ok(res.json.files.includes("feature.md"), companion.target);
+      assert.ok(res.json.files.includes("old.md"), companion.target);
+      assert.equal(
+        res.json.files.some((file) => file.startsWith(".claude/")),
+        false,
+        `${companion.target}: ignored Claude worktree debris leaked into scope`,
+      );
+      assert.equal(existsSync(path.join(cwd, ".claude/worktrees/agent-a")), true);
+    } finally {
+      cleanup(cwd);
+    }
+  }
+});
+
+test("Claude/Gemini/Kimi preflight scope failure is explicit and source-free", () => {
+  for (const companion of COMPANIONS) {
+    const { cwd } = seedBranchDiffRepo();
+    try {
+      const res = runPreflight(companion, cwd, [
+        "--mode=custom-review",
+        "--cwd", cwd,
+        "--scope-paths", "missing.md",
+      ]);
+
+      assert.equal(res.status, 2, companion.target);
+      assert.equal(res.json.ok, false, companion.target);
+      assert.equal(res.json.error, "scope_failed", companion.target);
+      assert.equal(res.json.target_spawned, false, companion.target);
+      assert.equal(res.json.selected_scope_sent_to_provider, false, companion.target);
+      assert.match(res.json.disclosure_note, /was not spawned/i, companion.target);
+      assert.match(res.json.disclosure_note, /no selected scope content was sent/i, companion.target);
+    } finally {
+      cleanup(cwd);
+    }
+  }
+});
+
+test("all foreground external review providers wire lifecycle heartbeats after launch", () => {
+  for (const rel of [
+    "plugins/claude/scripts/claude-companion.mjs",
+    "plugins/gemini/scripts/gemini-companion.mjs",
+    "plugins/kimi/scripts/kimi-companion.mjs",
+    "plugins/api-reviewers/scripts/api-reviewer.mjs",
+    "plugins/grok/scripts/grok-web-reviewer.mjs",
+  ]) {
+    const source = readFileSync(path.join(REPO_ROOT, rel), "utf8");
+    assert.match(source, /externalReviewLaunchedEvent|external_review_launched/, rel);
+    assert.match(source, /startExternalReviewHeartbeat|startLifecycleHeartbeat/, rel);
+  }
+});
+
+test("Claude/Gemini/Kimi cancel surfaces process-inspection denial as unverifiable with next step", () => {
+  for (const companion of COMPANIONS) {
+    const cwd = mkdtempSync(path.join(tmpdir(), `${companion.target}-cancel-cwd-`));
+    const dataDir = mkdtempSync(path.join(tmpdir(), `${companion.target}-cancel-data-`));
+    const jobId = "11111111-2222-4333-8444-555555555555";
+    try {
+      writeRunningJobState(dataDir, cwd, {
+        id: jobId,
+        job_id: jobId,
+        status: "running",
+        updatedAt: new Date().toISOString(),
+        pid_info: {
+          pid: process.pid,
+          starttime: null,
+          argv0: null,
+          capture_error: "capture_error: spawnSync /bin/ps EPERM",
+        },
+      });
+
+      const res = runCancel(companion, cwd, dataDir, jobId);
+
+      assert.equal(res.status, 2, companion.target);
+      assert.equal(res.json.ok, false, companion.target);
+      assert.equal(res.json.status, "unverifiable", companion.target);
+      assert.equal(res.json.pid, process.pid, companion.target);
+      assert.match(res.json.capture_error, /EPERM/, companion.target);
+      assert.match(res.json.suggested_action, /less restricted shell|outside the sandbox/i, companion.target);
+      assert.match(res.json.suggested_action, /ownership/i, companion.target);
+    } finally {
+      cleanup(cwd, dataDir);
+    }
+  }
+});

--- a/tests/unit/external-review-default-ux.test.mjs
+++ b/tests/unit/external-review-default-ux.test.mjs
@@ -166,6 +166,31 @@ test("Claude/Gemini/Kimi review with empty --scope-base preserves plain working-
       assert.equal(res.status, 0, `${companion.target}: ${res.stderr}`);
       assert.equal(res.json.ok, true, companion.target);
       assert.equal(res.json.scope, "working-tree", companion.target);
+      assert.equal(res.json.scope_base, null, companion.target);
+      assert.ok(res.json.files.includes("old.md"), companion.target);
+      assert.equal(res.json.selected_scope_sent_to_provider, false, companion.target);
+    } finally {
+      cleanup(cwd);
+    }
+  }
+});
+
+test("Claude/Gemini/Kimi review with whitespace --scope-base also preserves working-tree scope", () => {
+  for (const companion of COMPANIONS) {
+    const { cwd } = seedBranchDiffRepo();
+    try {
+      writeFileSync(path.join(cwd, "old.md"), "dirty old\n");
+
+      const res = runPreflight(companion, cwd, [
+        "--mode=review",
+        "--cwd", cwd,
+        "--scope-base", "   ",
+      ]);
+
+      assert.equal(res.status, 0, `${companion.target}: ${res.stderr}`);
+      assert.equal(res.json.ok, true, companion.target);
+      assert.equal(res.json.scope, "working-tree", companion.target);
+      assert.equal(res.json.scope_base, null, companion.target);
       assert.ok(res.json.files.includes("old.md"), companion.target);
       assert.equal(res.json.selected_scope_sent_to_provider, false, companion.target);
     } finally {

--- a/tests/unit/external-review-default-ux.test.mjs
+++ b/tests/unit/external-review-default-ux.test.mjs
@@ -151,6 +151,29 @@ test("Claude/Gemini/Kimi review --scope-base selects branch-diff, not dirty work
   }
 });
 
+test("Claude/Gemini/Kimi review with empty --scope-base preserves plain working-tree scope", () => {
+  for (const companion of COMPANIONS) {
+    const { cwd } = seedBranchDiffRepo();
+    try {
+      writeFileSync(path.join(cwd, "old.md"), "dirty old\n");
+
+      const res = runPreflight(companion, cwd, [
+        "--mode=review",
+        "--cwd", cwd,
+        "--scope-base", "",
+      ]);
+
+      assert.equal(res.status, 0, `${companion.target}: ${res.stderr}`);
+      assert.equal(res.json.ok, true, companion.target);
+      assert.equal(res.json.scope, "working-tree", companion.target);
+      assert.ok(res.json.files.includes("old.md"), companion.target);
+      assert.equal(res.json.selected_scope_sent_to_provider, false, companion.target);
+    } finally {
+      cleanup(cwd);
+    }
+  }
+});
+
 test("Claude/Gemini/Kimi plain review keeps working-tree scope and ignores .claude worktree debris", () => {
   for (const companion of COMPANIONS) {
     const { cwd } = seedBranchDiffRepo();

--- a/tests/unit/review-prompt.test.mjs
+++ b/tests/unit/review-prompt.test.mjs
@@ -191,6 +191,10 @@ function assertReviewPromptContract(targetBuildReviewPrompt = buildReviewPrompt,
   assert.match(prompt, /Do not report missing external tool access as a blocking code finding by itself/);
   assert.match(prompt, /runtime\/tool limitations/);
   assert.match(prompt, /Blocking findings first/);
+  assert.match(prompt, /Start the first line with exactly one verdict marker/);
+  assert.match(prompt, /Verdict: APPROVE/);
+  assert.match(prompt, /Verdict: REQUEST_CHANGES/);
+  assert.match(prompt, /Verdict: NOT_REVIEWED/);
   assert.match(prompt, /overlapping predicates, early returns, and branch ordering/);
   assert.match(prompt, /Do not upgrade speculative input-validation hardening into a blocking finding/);
   assert.match(prompt, /APPROVE with non-blocking concerns or test gaps when code is acceptable/);


### PR DESCRIPTION
Closes #149.

## Summary
- Make Claude/Gemini/Kimi `review --scope-base <ref>` use branch-diff scope while preserving plain `review` working-tree behavior.
- Treat ignored directory markers such as `.claude/` as excluding descendants during live working-tree scope population.
- Require first-line verdict markers in shared review prompts and sync the prompt across Claude/Gemini/Kimi/API/Grok while keeping the audit parser tolerant of known provider markdown variants.
- Emit foreground lifecycle progress heartbeats after launch across companion, API, and Grok reviewers, and document `external_review_progress` as a heartbeat event rather than a terminal result.
- Return explicit `unverifiable` cancel status with `suggested_action` when process inspection is blocked, without weakening PID ownership checks.
- Address Gemini Code Assist, Greptile, and external reviewer feedback by moving shared companion helpers into `companion-common`, normalizing empty/whitespace `--scope-base`, aligning API/Grok heartbeat timer validation/output injection, and stopping heartbeats before terminal error exits.

## Verification
- `npm run lint`
- `npm test` (1,637 pass, 0 fail, 6 skipped)
- `npm run test:coverage` (1,751 pass, 0 fail, 18 skipped; coverage target met)
- Targeted lifecycle smokes: API reviewers and Grok `external_review_progress` cases
- `git diff --check`
- GitHub PR checks at head `1741ff6b91383af1c320c0312b47892e1f73d853`: Greptile Review, SonarCloud Code Analysis, lint, smoke (api-reviewers), smoke (claude), smoke (gemini), smoke (grok), smoke (kimi), and test all pass