### PR TITLE
Fix review scope transport for live external reviews

### DIFF
--- a/plugins/claude/scripts/claude-companion.mjs
+++ b/plugins/claude/scripts/claude-companion.mjs
@@ -816,7 +816,9 @@ async function executeRun(invocation, prompt, { foreground, lifecycleEvents = nu
   let authSelection = resolveAuthSelection(invocation.auth_mode);
   invocation = invocationWithAuthSelection(invocation, authSelection);
   const { job_id: jobId, workspace_root: workspaceRoot } = invocation;
-  const profile = resolveProfile(invocation.mode_profile_name);
+  const profile = effectiveProfileForOptions(resolveProfile(invocation.mode_profile_name), {
+    "scope-base": invocation.scope_base,
+  });
 
   const executionScope = setupExecutionScopeOrExit(invocation, profile, { foreground, lifecycleEvents });
   const mutationContext = prepareMutationContext(invocation, profile);
@@ -1419,7 +1421,9 @@ async function cmdContinue(rest) {
   const newJobId_ = newJobId();
   const model = options.model ?? prior.model;
   const priorModeName = prior.mode_profile_name ?? prior.mode;
-  const priorProfile = resolveProfile(priorModeName);
+  const priorProfile = effectiveProfileForOptions(resolveProfile(priorModeName), {
+    "scope-base": prior.scope_base,
+  });
   const priorResumeChain = Array.isArray(prior.resume_chain) ? prior.resume_chain : [];
   const priorRuntimeOptions = readRuntimeOptionsSidecar(workspaceRoot, options.job);
   const priorTimeoutMs =

--- a/plugins/claude/scripts/lib/claude.mjs
+++ b/plugins/claude/scripts/lib/claude.mjs
@@ -1,4 +1,4 @@
-// Claude-specific dispatcher. Spawns `claude -p ...` per spec §7.2 / §10
+// Claude-specific dispatcher. Spawns `claude -p` and sends the prompt via stdin
 // with the layered-defense flag stack for read-only review, the review
 // permission-mode ladder, and acceptEdits permission mode for rescue. Pure
 // Claude concerns live here;
@@ -42,8 +42,39 @@ function assertPermissionMode(permissionMode) {
   }
 }
 
+function makeSettler(resolve, reject, cleanup) {
+  let settled = false;
+  const finish = (fn, value) => {
+    if (settled) return;
+    settled = true;
+    cleanup();
+    fn(value);
+  };
+  return {
+    resolve: (value) => finish(resolve, value),
+    reject: (error) => finish(reject, error),
+  };
+}
+
+function collectChildOutput(child) {
+  const output = { stdout: "", stderr: "" };
+  child.stdout.on("data", (chunk) => { output.stdout += chunk.toString("utf8"); });
+  child.stderr.on("data", (chunk) => { output.stderr += chunk.toString("utf8"); });
+  return output;
+}
+
+function armChildTimeout(child, timeoutMs, onTimeout) {
+  if (timeoutMs <= 0) return () => {};
+  const timer = setTimeout(() => {
+    onTimeout();
+    try { child.kill("SIGTERM"); } catch { /* already gone */ }
+    setTimeout(() => { try { child.kill("SIGKILL"); } catch { /* already gone */ } }, 2000).unref();
+  }, timeoutMs);
+  return () => clearTimeout(timer);
+}
+
 /**
- * Build the argv array for `claude -p ...` from a mode profile and the
+ * Build the argv array for `claude -p` from a mode profile and the
  * per-invocation runtime inputs. Extracted for unit testing; the actual
  * spawn lives in spawnClaude() below.
  *
@@ -89,7 +120,8 @@ export function buildClaudeArgs(profile, runtimeInputs = {}) {
   assertPermissionMode(effectivePermissionMode);
 
   const args = [
-    "-p", promptText,
+    "-p",
+    "--input-format", "text",
     "--output-format", "json",
     "--no-session-persistence",
   ];
@@ -202,38 +234,25 @@ export async function spawnClaude(profile, runtimeInputs = {}) {
   const targetEnv = sanitizeTargetEnv(env, { allowedApiKeyEnv });
 
   return new Promise((resolve, reject) => {
-    // Claude receives the prompt via argv and ignores stdin, so there is no
-    // stdin EPIPE race to coordinate here. Gemini has a write/close harness.
-    const child = spawn(binary, args, { cwd, env: targetEnv, stdio: ["ignore", "pipe", "pipe"] });
+    const child = spawn(binary, args, { cwd, env: targetEnv, stdio: ["pipe", "pipe", "pipe"] });
     const getPidInfo = attachPidCapture(child, onSpawn);
-    let stdout = "";
-    let stderr = "";
     let timedOut = false;
-    let timer = null;
-    if (timeoutMs > 0) {
-      timer = setTimeout(() => {
-        timedOut = true;
-        try { child.kill("SIGTERM"); } catch { /* already gone */ }
-        setTimeout(() => { try { child.kill("SIGKILL"); } catch { /* already gone */ } }, 2000).unref();
-      }, timeoutMs);
-    }
-    child.stdout.on("data", (chunk) => { stdout += chunk.toString("utf8"); });
-    child.stderr.on("data", (chunk) => { stderr += chunk.toString("utf8"); });
+    const output = collectChildOutput(child);
+    const disarmTimeout = armChildTimeout(child, timeoutMs, () => { timedOut = true; });
+    const finish = makeSettler(resolve, reject, disarmTimeout);
     child.on("error", (e) => {
-      if (timer) clearTimeout(timer);
-      reject(Object.assign(new Error(`spawn ${binary} failed: ${e.message}`), { code: e.code }));
+      finish.reject(Object.assign(new Error(`spawn ${binary} failed: ${e.message}`), { code: e.code }));
     });
     child.on("close", (exitCode, signal) => {
-      if (timer) clearTimeout(timer);
       const endedAt = new Date().toISOString();
-      const parsed = parseClaudeResult(stdout);
-      resolve({
+      const parsed = parseClaudeResult(output.stdout);
+      finish.resolve({
         exitCode,
         signal,
         timedOut,
         endedAt,
-        stdout,
-        stderr,
+        stdout: output.stdout,
+        stderr: output.stderr,
         // What the companion SENT as --session-id (or null on resume). Not a
         // durable identity — persisted records store claudeSessionId instead.
         sessionIdSent: resumeId ? null : sessionId,
@@ -250,6 +269,11 @@ export async function spawnClaude(profile, runtimeInputs = {}) {
         parsed,
       });
     });
+    child.stdin.on("error", (e) => {
+      if (e?.code === "EPIPE") return;
+      finish.reject(Object.assign(new Error(`write to ${binary} stdin failed: ${e.message}`), { code: e.code }));
+    });
+    child.stdin.end(promptText);
   });
 }
 

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -668,7 +668,9 @@ async function executeRun(invocation, prompt, { foreground, lifecycleEvents = nu
   let authSelection = resolveAuthSelection(invocation.auth_mode);
   invocation = invocationWithAuthSelection(invocation, authSelection);
   const { job_id: jobId, workspace_root: workspaceRoot } = invocation;
-  const profile = resolveProfile(invocation.mode_profile_name);
+  const profile = effectiveProfileForOptions(resolveProfile(invocation.mode_profile_name), {
+    "scope-base": invocation.scope_base,
+  });
   const executionScope = setupExecutionScopeOrExit(invocation, profile, { foreground, lifecycleEvents });
   const mutationContext = prepareMutationContext(invocation, profile);
   const resumeId = latestResumeId(invocation);
@@ -1174,7 +1176,9 @@ async function cmdContinue(rest) {
   const newJobId_ = newJobId();
   const model = options.model ?? prior.model;
   const priorModeName = prior.mode_profile_name ?? prior.mode;
-  const priorProfile = resolveProfile(priorModeName);
+  const priorProfile = effectiveProfileForOptions(resolveProfile(priorModeName), {
+    "scope-base": prior.scope_base,
+  });
   const priorResumeChain = Array.isArray(prior.resume_chain) ? prior.resume_chain : [];
   const priorRuntimeOptions = readRuntimeOptionsSidecar(workspaceRoot, options.job);
   const priorTimeoutMs =

--- a/plugins/kimi/scripts/kimi-companion.mjs
+++ b/plugins/kimi/scripts/kimi-companion.mjs
@@ -727,7 +727,9 @@ async function cmdRun(rest) {
 
 async function executeRun(invocation, prompt, { foreground, lifecycleEvents = null }) {
   const { job_id: jobId, cwd, workspace_root: workspaceRoot, dispose_effective: disposeEffective } = invocation;
-  const profile = resolveProfile(invocation.mode_profile_name);
+  const profile = effectiveProfileForOptions(resolveProfile(invocation.mode_profile_name), {
+    "scope-base": invocation.scope_base,
+  });
   let containment = null;
   try {
     containment = setupContainment(profile, cwd);
@@ -1142,7 +1144,9 @@ async function cmdContinue(rest) {
   const newJobId_ = newJobId();
   const model = options.model ?? prior.model;
   const priorModeName = prior.mode_profile_name ?? prior.mode;
-  const priorProfile = resolveProfile(priorModeName);
+  const priorProfile = effectiveProfileForOptions(resolveProfile(priorModeName), {
+    "scope-base": prior.scope_base,
+  });
   const priorResumeChain = Array.isArray(prior.resume_chain) ? prior.resume_chain : [];
   const priorRuntimeOptions = readRuntimeOptionsSidecar(workspaceRoot, options.job);
   const priorTimeoutMs =

--- a/tests/helpers/fixture-git.mjs
+++ b/tests/helpers/fixture-git.mjs
@@ -90,3 +90,34 @@ export function fixtureSeedRepo(cwd, {
     throw new Error(`fixtureSeedRepo: git commit failed: ${commit.stderr ?? ""}`);
   }
 }
+
+export function fixtureBranchDiffRepo(cwd, {
+  baseFileName = "old.md",
+  baseFileContents = "old\n",
+  changedFileName = "foo.md",
+  changedFileContents = "foo\n",
+} = {}) {
+  fixtureSeedRepo(cwd, {
+    fileName: baseFileName,
+    fileContents: baseFileContents,
+    message: "main",
+  });
+  const base = fixtureGit(cwd, ["rev-parse", "HEAD"]).stdout.trim();
+
+  const checkout = fixtureGit(cwd, ["checkout", "-qb", "feature"]);
+  if (checkout.status !== 0) {
+    throw new Error(`fixtureBranchDiffRepo: git checkout failed: ${checkout.stderr ?? ""}`);
+  }
+
+  writeFileSync(joinPath(cwd, changedFileName), changedFileContents);
+  const add = fixtureGit(cwd, ["add", changedFileName]);
+  if (add.status !== 0) {
+    throw new Error(`fixtureBranchDiffRepo: git add failed: ${add.stderr ?? ""}`);
+  }
+  const commit = fixtureGit(cwd, ["commit", "-q", "-m", "feature"]);
+  if (commit.status !== 0) {
+    throw new Error(`fixtureBranchDiffRepo: git commit failed: ${commit.stderr ?? ""}`);
+  }
+
+  return { base, changedFileName, baseFileName };
+}

--- a/tests/smoke/claude
+++ b/tests/smoke/claude
@@ -1,1 +1,1 @@
-/Users/spson/Projects/Claude/codex-plugin-multi/tests/smoke/claude-mock.mjs
+claude-mock.mjs

--- a/tests/smoke/claude-companion.smoke.test.mjs
+++ b/tests/smoke/claude-companion.smoke.test.mjs
@@ -12,7 +12,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { fixtureGitEnv, fixtureSeedRepo } from "../helpers/fixture-git.mjs";
+import { fixtureBranchDiffRepo, fixtureGitEnv, fixtureSeedRepo } from "../helpers/fixture-git.mjs";
 import { assertJobRecordShape } from "../helpers/job-record-shape.mjs";
 import { CLAUDE_PROVIDER_API_KEY_ENV } from "../../plugins/claude/scripts/lib/claude-provider-keys.mjs";
 
@@ -1660,6 +1660,64 @@ test("adversarial-review scope=branch-diff: only changed files appear in --add-d
   }
 });
 
+test("review --scope-base preserves branch-diff scope through target execution", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "smoke-review-scope-base-"));
+  const { base } = fixtureBranchDiffRepo(cwd);
+  const { stdout, status, stderr, dataDir } = runCompanion(
+    ["run", "--mode=review", "--foreground",
+     "--model", "claude-haiku-4-5-20251001",
+     "--cwd", cwd, "--scope-base", base, "--", "focus"],
+    { cwd, env: { CLAUDE_MOCK_LIST_ADDDIR: "1" } }
+  );
+  try {
+    assert.equal(status, 0, `exit ${status}: ${stderr}`);
+    const result = JSON.parse(stdout);
+    const fx = readStdoutLog(dataDir, result.job_id);
+    const files = fx.t7_add_dir_files ?? [];
+    assert.deepEqual(files, ["foo.md"]);
+    assert.deepEqual(
+      result.review_metadata.audit_manifest.selected_source.files.map((file) => file.path),
+      ["foo.md"]
+    );
+  } finally {
+    cleanup(dataDir);
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("continue preserves prior review branch-diff scope through target execution", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "smoke-continue-scope-base-"));
+  const { base } = fixtureBranchDiffRepo(cwd);
+  const dataDir = mkdtempSync(path.join(tmpdir(), "continue-scope-base-data-"));
+  try {
+    const runRes = runCompanion(
+      ["run", "--mode=review", "--foreground",
+       "--model", "claude-haiku-4-5-20251001",
+       "--cwd", cwd, "--scope-base", base, "--", "focus"],
+      { cwd, dataDir, env: { CLAUDE_MOCK_LIST_ADDDIR: "1" } }
+    );
+    assert.equal(runRes.status, 0, runRes.stderr);
+    const prior = JSON.parse(runRes.stdout);
+    const contRes = runCompanion(
+      ["continue", "--job", prior.job_id, "--foreground",
+       "--cwd", cwd, "--", "follow-up"],
+      { cwd, dataDir, env: { CLAUDE_MOCK_LIST_ADDDIR: "1" } }
+    );
+    assert.equal(contRes.status, 0, contRes.stderr);
+    const continued = JSON.parse(contRes.stdout);
+    const fx = readStdoutLog(dataDir, continued.job_id);
+    assert.equal(continued.scope, "branch-diff");
+    assert.deepEqual(fx.t7_add_dir_files ?? [], ["foo.md"]);
+    assert.deepEqual(
+      continued.review_metadata.audit_manifest.selected_source.files.map((file) => file.path),
+      ["foo.md"]
+    );
+  } finally {
+    cleanup(dataDir);
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test("adversarial-review scope=branch-diff: scope paths narrow copied and audited files", () => {
   const cwd = mkdtempSync(path.join(tmpdir(), "smoke-adv-paths-"));
   spawnSync("git", ["init", "-q", "-b", "main"], { cwd, env: fixtureGitEnv() });
@@ -3279,7 +3337,7 @@ test("run: auto auth re-preflights API-key fallback before review launch", () =>
   const tmp = mkdtempSync(path.join(tmpdir(), "claude-run-auto-api-fallback-preflight-bin-"));
   const leakMarker = path.join(tmp, "source-leaked");
   const binary = writeExecutable(tmp, "claude-auto-api-fallback-preflight", `#!/usr/bin/env node
-import { writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 
 const argv = process.argv.slice(2);
 if (argv.join(" ") === "auth status --json") {
@@ -3292,7 +3350,7 @@ if (argv.join(" ") === "auth status --json") {
   process.exit(0);
 }
 
-const prompt = argv[argv.indexOf("-p") + 1] ?? "";
+const prompt = argv.includes("--input-format") ? readFileSync(0, "utf8") : (argv[argv.indexOf("-p") + 1] ?? "");
 if (process.env.ANTHROPIC_API_KEY !== "secret-test-value") {
   process.stdout.write(JSON.stringify({
     type: "result",

--- a/tests/smoke/claude-mock.mjs
+++ b/tests/smoke/claude-mock.mjs
@@ -83,11 +83,11 @@ function parseCli(argv) {
 
 const parsed = parseCli(process.argv.slice(2));
 
-// Prompt source: argv positional (`claude -p "..."`) OR stdin (if --input-format stream-json).
+// Prompt source: argv positional (`claude -p "..."`) OR stdin (if --input-format text/stream-json).
 let prompt;
 if (parsed.positional.length > 0) {
   prompt = parsed.positional.join(" ");
-} else if (parsed.flags["--input-format"] === "stream-json") {
+} else if (["text", "stream-json"].includes(parsed.flags["--input-format"])) {
   prompt = readFileSync(0, "utf8");
 } else {
   // Claude real behavior: errors if -p lacks both positional and stdin.

--- a/tests/smoke/gemini-companion.smoke.test.mjs
+++ b/tests/smoke/gemini-companion.smoke.test.mjs
@@ -9,7 +9,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { fixtureSeedRepo } from "../helpers/fixture-git.mjs";
+import { fixtureBranchDiffRepo, fixtureSeedRepo } from "../helpers/fixture-git.mjs";
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
 const COMPANION = path.join(REPO_ROOT, "plugins/gemini/scripts/gemini-companion.mjs");
@@ -1192,6 +1192,55 @@ test("gemini review foreground: policy-first, stdin transport, /tmp cwd, scoped 
     assert.equal(fx.t7_sandbox, true, "Gemini review must pass the sandbox flag");
     assert.equal(fx.t7_skip_trust, true, "Gemini review must pass --skip-trust so plan approval is not downgraded");
     assert.equal(fx.t7_prompt_from_stdin, true, "Gemini prompt must arrive on stdin, not argv");
+  } finally {
+    rmTree(dataDir);
+    rmTree(cwd);
+  }
+});
+
+test("gemini review --scope-base preserves branch-diff scope through target execution", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "gemini-review-scope-base-"));
+  const { base } = fixtureBranchDiffRepo(cwd);
+  const { stdout, stderr, status, dataDir } = runCompanion(
+    ["run", "--mode=review", "--foreground", "--cwd", cwd, "--scope-base", base, "--", "review: x=1"],
+    { cwd },
+  );
+  try {
+    assert.equal(status, 0, `exit ${status}: ${stderr}`);
+    const record = JSON.parse(stdout);
+    assert.equal(record.scope, "branch-diff");
+    assert.deepEqual(
+      record.review_metadata.audit_manifest.selected_source.files.map((file) => file.path),
+      ["foo.md"]
+    );
+  } finally {
+    rmTree(dataDir);
+    rmTree(cwd);
+  }
+});
+
+test("gemini continue preserves prior review branch-diff scope through target execution", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "gemini-continue-scope-base-"));
+  const { base } = fixtureBranchDiffRepo(cwd);
+  const dataDir = mkdtempSync(path.join(tmpdir(), "gemini-continue-scope-base-data-"));
+  try {
+    const runRes = runCompanion(
+      ["run", "--mode=review", "--foreground", "--cwd", cwd, "--scope-base", base, "--", "review: x=1"],
+      { cwd, dataDir },
+    );
+    assert.equal(runRes.status, 0, runRes.stderr);
+    const prior = JSON.parse(runRes.stdout);
+    const contRes = runCompanion(
+      ["continue", "--job", prior.job_id, "--foreground", "--cwd", cwd, "--", "follow-up"],
+      { cwd, dataDir },
+    );
+    assert.equal(contRes.status, 0, contRes.stderr);
+    const continued = JSON.parse(contRes.stdout);
+    assert.equal(continued.scope, "branch-diff");
+    assert.deepEqual(
+      continued.review_metadata.audit_manifest.selected_source.files.map((file) => file.path),
+      ["foo.md"]
+    );
   } finally {
     rmTree(dataDir);
     rmTree(cwd);

--- a/tests/smoke/kimi-companion.smoke.test.mjs
+++ b/tests/smoke/kimi-companion.smoke.test.mjs
@@ -6,7 +6,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { fixtureGit, fixtureSeedRepo } from "../helpers/fixture-git.mjs";
+import { fixtureBranchDiffRepo, fixtureGit, fixtureSeedRepo } from "../helpers/fixture-git.mjs";
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
 const COMPANION = path.join(REPO_ROOT, "plugins/kimi/scripts/kimi-companion.mjs");
@@ -1557,6 +1557,73 @@ test("kimi review foreground lifecycle jsonl emits launch event before terminal 
   assert.equal(record.status, "completed");
   assert.equal(record.external_review.source_content_transmission, "sent");
 }));
+
+test("kimi review --scope-base preserves branch-diff scope through target execution", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "kimi-review-scope-base-"));
+  try {
+    const { base } = fixtureBranchDiffRepo(cwd);
+    const result = runCompanion([
+      "run",
+      "--mode",
+      "review",
+      "--cwd",
+      cwd,
+      "--scope-base",
+      base,
+      "--foreground",
+      "--",
+      "Review this scope.",
+    ], {
+      cwd,
+      env: {
+        KIMI_MOCK_ASSERT_FILE: "foo.md",
+        KIMI_MOCK_ASSERT_CWD_NOT: realpathSync(tmpdir()),
+        KIMI_MOCK_ASSERT_CWD_PREFIX: realpathSync(tmpdir()),
+      },
+    });
+    assert.equal(result.status, 0, result.stderr);
+    const record = parseJson(result.stdout);
+    assert.equal(record.scope, "branch-diff");
+    const { record: persisted } = readOnlyJobRecord(result.dataDir);
+    assert.deepEqual(
+      persisted.review_metadata.audit_manifest.selected_source.files.map((file) => file.path),
+      ["foo.md"]
+    );
+    rmSync(result.dataDir, { recursive: true, force: true });
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("kimi continue preserves prior review branch-diff scope through target execution", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "kimi-continue-scope-base-"));
+  try {
+    const { base } = fixtureBranchDiffRepo(cwd);
+    const dataDir = mkdtempSync(path.join(tmpdir(), "kimi-continue-scope-base-data-"));
+    try {
+      const runRes = runCompanion([
+        "run", "--mode", "review", "--cwd", cwd, "--scope-base", base,
+        "--foreground", "--", "Review this scope.",
+      ], { cwd, dataDir });
+      assert.equal(runRes.status, 0, runRes.stderr);
+      const prior = parseJson(runRes.stdout);
+      const contRes = runCompanion([
+        "continue", "--job", prior.job_id, "--foreground", "--cwd", cwd, "--", "follow-up",
+      ], { cwd, dataDir });
+      assert.equal(contRes.status, 0, contRes.stderr);
+      const continued = parseJson(contRes.stdout);
+      assert.equal(continued.scope, "branch-diff");
+      assert.deepEqual(
+        continued.review_metadata.audit_manifest.selected_source.files.map((file) => file.path),
+        ["foo.md"]
+      );
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
 
 test("kimi review foreground lifecycle jsonl suppresses launch event on scope failure", () => withRepo((cwd) => {
   writeFileSync(path.join(cwd, ".git", "index"), "corrupt index");

--- a/tests/unit/claude-dispatcher.test.mjs
+++ b/tests/unit/claude-dispatcher.test.mjs
@@ -332,6 +332,33 @@ test("spawnClaude: returns claudeSessionId from stdout and pidInfo tuple", async
   );
 });
 
+test("spawnClaude: sends prompt on stdin so large prompts do not hit argv limits", async () => {
+  const result = await spawnClaude(resolveProfile("rescue"), {
+    model: "claude-haiku-4-5-20251001",
+    promptText: "x".repeat(1_100_000),
+    sessionId: UUID,
+    binary: MOCK,
+  });
+  assert.equal(result.exitCode, 0, `mock exited ${result.exitCode}: ${result.stderr}`);
+  assert.equal(result.claudeSessionId, UUID);
+});
+
+test("spawnClaude: spawn failures reject with structured code", async () => {
+  await assert.rejects(
+    spawnClaude(resolveProfile("rescue"), {
+      model: "claude-haiku-4-5-20251001",
+      promptText: "hello",
+      sessionId: UUID,
+      binary: "/definitely/not/a/claude/binary",
+    }),
+    (error) => {
+      assert.match(error.message, /spawn .* failed/);
+      assert.equal(error.code, "ENOENT");
+      return true;
+    }
+  );
+});
+
 test("spawnClaude: onSpawn fires asynchronously via 'spawn' event, not synchronously (issue #25)", async () => {
   // Regression for the argv0_mismatch flake: capturePidInfo must run
   // AFTER the child's execve completes, otherwise /proc/<pid>/cmdline
@@ -355,6 +382,19 @@ test("spawnClaude: onSpawn fires asynchronously via 'spawn' event, not synchrono
   // Once the spawn settles, onSpawn must have fired.
   assert.equal(onSpawnFired, true, "onSpawn must fire by the time spawnClaude resolves");
   assert.ok(result.pidInfo, "pidInfo must be present after a successful spawn");
+});
+
+test("spawnClaude: onSpawn callback failures do not strand terminal results", async () => {
+  const result = await spawnClaude(resolveProfile("rescue"), {
+    model: "claude-haiku-4-5-20251001",
+    promptText: "hello",
+    sessionId: UUID,
+    binary: MOCK,
+    onSpawn: () => { throw new Error("boom"); },
+  });
+
+  assert.equal(result.exitCode, 0, `mock exited ${result.exitCode}: ${result.stderr}`);
+  assert.equal(result.claudeSessionId, UUID);
 });
 
 test("spawnClaude: strips provider creds and routing env before launching target CLI", async () => {

--- a/tests/unit/external-review-default-ux.test.mjs
+++ b/tests/unit/external-review-default-ux.test.mjs
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
-  existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync,
+  existsSync, mkdirSync, mkdtempSync, readFileSync, readlinkSync, realpathSync, rmSync, symlinkSync, writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -127,6 +127,12 @@ function runCancel(companion, cwd, dataDir, jobId) {
   });
   return { ...res, json: JSON.parse(res.stdout) };
 }
+
+test("Claude smoke command shim is a relative symlink for portable worktrees", () => {
+  const linkTarget = readlinkSync(path.join(REPO_ROOT, "tests/smoke/claude"));
+  assert.equal(path.isAbsolute(linkTarget), false);
+  assert.equal(linkTarget, "claude-mock.mjs");
+});
 
 test("Claude/Gemini/Kimi review --scope-base selects branch-diff, not dirty working-tree scope", () => {
   for (const companion of COMPANIONS) {

--- a/tests/unit/mode-profiles.test.mjs
+++ b/tests/unit/mode-profiles.test.mjs
@@ -217,15 +217,17 @@ test("buildClaudeArgs: review produces the exact §4.5/§9 argv", () => {
     sessionId: UUID,
   });
   // Core prefix.
-  assert.deepEqual(args.slice(0, 10), [
-    "-p", "review this",
+  assert.deepEqual(args.slice(0, 11), [
+    "-p",
+    "--input-format", "text",
     "--output-format", "json",
     "--no-session-persistence",
     "--model", "claude-haiku-4-5-20251001",
     "--effort", "max",
     "--session-id",
   ]);
-  assert.equal(args[10], UUID);
+  assert.equal(args[11], UUID);
+  assert.equal(args.includes("review this"), false);
   // Layer 1 — strip_context.
   assert.ok(args.includes("--setting-sources"));
   assert.equal(args[args.indexOf("--setting-sources") + 1], "");


### PR DESCRIPTION
## Summary
- Preserve effective `--scope-base` branch-diff profiles through companion run and continue execution for Claude, Gemini, and Kimi.
- Move Claude prompt transport from argv to stdin to avoid macOS `E2BIG` on large rendered review prompts.
- Make the Claude smoke shim symlink relative so clean worktrees do not fail scope validation on repo-local smoke fixtures.
- Add shared branch-diff fixture setup and dispatcher regressions for spawn failure/onSpawn handoff so coverage and review-comment invariants stay guarded.

## Verification
- `npm run lint`
- `node --test --test-name-pattern 'scope-base|continue preserves prior review branch-diff' tests/smoke/claude-companion.smoke.test.mjs tests/smoke/gemini-companion.smoke.test.mjs tests/smoke/kimi-companion.smoke.test.mjs` — 6 pass
- `node --test tests/unit/claude-dispatcher.test.mjs` — 33 pass
- `node --test tests/unit/claude-dispatcher.test.mjs tests/unit/mode-profiles.test.mjs tests/unit/external-review-default-ux.test.mjs`
- `npm test` — 1684 tests, 1678 pass, 6 skipped
- `npm run test:coverage` — 1810 tests, 1792 pass, 18 skipped; coverage target met
- `npm run test:full` — 1845 tests, 1833 pass, 12 skipped