### PR TITLE
Fix Claude continuation session context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,17 @@
 # codex-plugin-multi — Claude Code project notes
 
+<!-- SPECKIT START -->
+Active spec-kit feature: **no-mistakes provider readiness** (spec 140).
+
+For technical context, structure, gates, and the readiness manifest schema, read:
+- `specs/140-no-mistakes-provider-readiness/spec.md` — problem specification
+- `specs/140-no-mistakes-provider-readiness/plan.md` — current implementation plan
+- `specs/140-no-mistakes-provider-readiness/research.md` — Phase 0 research decisions
+- `specs/140-no-mistakes-provider-readiness/data-model.md` — entities and invariants
+- `specs/140-no-mistakes-provider-readiness/contracts/` — JSON schemas
+- `specs/140-no-mistakes-provider-readiness/quickstart.md` — operator runbook
+<!-- SPECKIT END -->
+
 ## Test
 
 `npm test`

--- a/plugins/claude/scripts/claude-companion.mjs
+++ b/plugins/claude/scripts/claude-companion.mjs
@@ -447,6 +447,9 @@ function writeRuntimeOptionsSidecar(workspaceRoot, jobId, options) {
     if (Number.isSafeInteger(options.timeout_ms) && options.timeout_ms > 0) payload.timeout_ms = options.timeout_ms;
     if (Array.isArray(options.permission_mode_ladder)) payload.permission_mode_ladder = [...options.permission_mode_ladder];
     if (typeof options.allow_bypass_permissions === "boolean") payload.allow_bypass_permissions = options.allow_bypass_permissions;
+    if (typeof options.claude_project_cwd === "string" && options.claude_project_cwd.length > 0) {
+      payload.claude_project_cwd = options.claude_project_cwd;
+    }
     writeFileSync(tmpFile, `${JSON.stringify(payload, null, 2)}\n`, { mode: 0o600, encoding: "utf8" });
     try { chmodSync(tmpFile, 0o600); } catch { /* best-effort on non-POSIX */ }
     renameSync(tmpFile, file);
@@ -472,10 +475,29 @@ function readRuntimeOptionsSidecar(workspaceRoot, jobId) {
     if (typeof parsed.allow_bypass_permissions === "boolean") {
       out.allow_bypass_permissions = parsed.allow_bypass_permissions;
     }
+    if (typeof parsed.claude_project_cwd === "string" && parsed.claude_project_cwd.length > 0) {
+      out.claude_project_cwd = parsed.claude_project_cwd;
+    }
     return out;
   } catch {
     return {};
   }
+}
+
+function claudeProjectCwdForJob(workspaceRoot, jobId) {
+  return joinPath(resolveJobsDir(workspaceRoot), jobId, "claude-project-cwd");
+}
+
+function claudeProjectCwdFromRecord(record) {
+  const value = record?.runtime_diagnostics?.child_cwd;
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function ensureClaudeProjectCwd(dir) {
+  if (!dir) return null;
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  try { chmodSync(dir, 0o700); } catch { /* best-effort on non-POSIX */ }
+  return dir;
 }
 
 function invocationFromRecord(record, fallbackAuthMode = "subscription", runtimeOptions = {}) {
@@ -505,6 +527,10 @@ function invocationFromRecord(record, fallbackAuthMode = "subscription", runtime
       runtimeOptions.timeout_ms ??
       record.review_metadata?.audit_manifest?.request?.timeout_ms ??
       DEFAULT_CLAUDE_REVIEW_TIMEOUT_MS,
+    claude_project_cwd:
+      runtimeOptions.claude_project_cwd ??
+      claudeProjectCwdFromRecord(record) ??
+      null,
     permission_mode_ladder: Array.isArray(runtimeOptions.permission_mode_ladder)
       ? Object.freeze([...runtimeOptions.permission_mode_ladder])
       : null,
@@ -769,6 +795,7 @@ async function cmdRun(rest) {
     auth_mode: authSelection.auth_mode,
     permission_mode_ladder: permissionModeLadder,
     allow_bypass_permissions: allowBypassPermissions,
+    claude_project_cwd: claudeProjectCwdForJob(workspaceRoot, jobId),
     started_at: startedAt,
   });
 
@@ -788,6 +815,7 @@ async function cmdRun(rest) {
         timeout_ms: timeoutMs,
         permission_mode_ladder: permissionModeLadder,
         allow_bypass_permissions: allowBypassPermissions,
+        claude_project_cwd: invocation.claude_project_cwd,
       });
     } catch (error) {
       failBackgroundPromptSidecarWrite(workspaceRoot, invocation, error);
@@ -964,10 +992,12 @@ function setupExecutionScopeOrExit(invocation, profile, { foreground, lifecycleE
 
 function prepareMutationContext(invocation, profile) {
   const checkMutations = profile.permission_mode === "plan" || REVIEW_MODE_SET.has(profile.name);
-  const context = { checkMutations, gitStatusBefore: null, neutralCwd: null, mutations: [] };
+  const context = { checkMutations, gitStatusBefore: null, neutralCwd: null, cleanupNeutralCwd: false, mutations: [] };
   if (!checkMutations) return context;
   try {
-    context.neutralCwd = mkdtempSync(joinPath(tmpdir(), "claude-neutral-cwd-"));
+    context.neutralCwd = ensureClaudeProjectCwd(invocation.claude_project_cwd)
+      ?? mkdtempSync(joinPath(tmpdir(), "claude-neutral-cwd-"));
+    context.cleanupNeutralCwd = true;
   } catch (e) {
     context.mutations.push(mutationDetectionFailure(e));
   }
@@ -1278,7 +1308,7 @@ function persistFinalizationFallback(invocation, execution, finalRecord, mutatio
 }
 
 function cleanupExecutionResources(executionScope, mutationContext) {
-  cleanupNeutralCwd(mutationContext.neutralCwd);
+  cleanupNeutralCwd(mutationContext);
   if (executionScope.disposeEffective) {
     try { executionScope.containment.cleanup(); } catch { /* best-effort */ }
   }
@@ -1288,9 +1318,9 @@ function cleanupScopedPromptExecutionScope(executionScope) {
   try { executionScope.containment.cleanup(); } catch { /* best-effort */ }
 }
 
-function cleanupNeutralCwd(neutralCwd) {
-  if (!neutralCwd) return;
-  try { rmSync(neutralCwd, { recursive: true, force: true }); } catch { /* best-effort */ }
+function cleanupNeutralCwd(mutationContext) {
+  if (!mutationContext?.cleanupNeutralCwd || !mutationContext.neutralCwd) return;
+  try { rmSync(mutationContext.neutralCwd, { recursive: true, force: true }); } catch { /* best-effort */ }
 }
 
 // ——— subcommand: _run-worker (hidden; detached worker for --background) ———
@@ -1477,6 +1507,10 @@ async function cmdContinue(rest) {
     auth_mode: authSelection.auth_mode,
     permission_mode_ladder: permissionModeLadder,
     allow_bypass_permissions: allowBypassPermissions,
+    claude_project_cwd:
+      priorRuntimeOptions.claude_project_cwd ??
+      claudeProjectCwdFromRecord(prior) ??
+      null,
     started_at: new Date().toISOString(),
   });
 
@@ -1492,6 +1526,7 @@ async function cmdContinue(rest) {
         timeout_ms: timeoutMs,
         permission_mode_ladder: permissionModeLadder,
         allow_bypass_permissions: allowBypassPermissions,
+        claude_project_cwd: invocation.claude_project_cwd,
       });
     } catch (error) {
       failBackgroundPromptSidecarWrite(workspaceRoot, invocation, error);

--- a/plugins/claude/scripts/claude-companion.mjs
+++ b/plugins/claude/scripts/claude-companion.mjs
@@ -995,9 +995,15 @@ function prepareMutationContext(invocation, profile) {
   const context = { checkMutations, gitStatusBefore: null, neutralCwd: null, cleanupNeutralCwd: false, mutations: [] };
   if (!checkMutations) return context;
   try {
-    context.neutralCwd = ensureClaudeProjectCwd(invocation.claude_project_cwd)
-      ?? mkdtempSync(joinPath(tmpdir(), "claude-neutral-cwd-"));
-    context.cleanupNeutralCwd = true;
+    const projectCwd = ensureClaudeProjectCwd(invocation.claude_project_cwd);
+    if (projectCwd) {
+      // Retain this per-job project cwd: Claude resolves persisted sessions by
+      // project path, and the directory lives under the job sidecar state.
+      context.neutralCwd = projectCwd;
+    } else {
+      context.neutralCwd = mkdtempSync(joinPath(tmpdir(), "claude-neutral-cwd-"));
+      context.cleanupNeutralCwd = true;
+    }
   } catch (e) {
     context.mutations.push(mutationDetectionFailure(e));
   }

--- a/plugins/claude/scripts/claude-companion.mjs
+++ b/plugins/claude/scripts/claude-companion.mjs
@@ -495,6 +495,9 @@ function claudeProjectCwdFromRecord(record) {
 
 function ensureClaudeProjectCwd(dir) {
   if (!dir) return null;
+  // This path may be recreated after state pruning removes the job sidecar
+  // directory. Claude stores session data under ~/.claude/projects keyed by
+  // project path, not inside this directory.
   mkdirSync(dir, { recursive: true, mode: 0o700 });
   try { chmodSync(dir, 0o700); } catch { /* best-effort on non-POSIX */ }
   return dir;
@@ -995,10 +998,16 @@ function prepareMutationContext(invocation, profile) {
   const context = { checkMutations, gitStatusBefore: null, neutralCwd: null, cleanupNeutralCwd: false, mutations: [] };
   if (!checkMutations) return context;
   try {
-    const projectCwd = ensureClaudeProjectCwd(invocation.claude_project_cwd);
+    let projectCwd = null;
+    try {
+      projectCwd = ensureClaudeProjectCwd(invocation.claude_project_cwd);
+    } catch (e) {
+      context.mutations.push(mutationDetectionFailure(e));
+    }
     if (projectCwd) {
       // Retain this per-job project cwd: Claude resolves persisted sessions by
-      // project path, and the directory lives under the job sidecar state.
+      // project path for continue --job, and the directory lives under the
+      // job sidecar state.
       context.neutralCwd = projectCwd;
     } else {
       context.neutralCwd = mkdtempSync(joinPath(tmpdir(), "claude-neutral-cwd-"));

--- a/specs/140-no-mistakes-provider-readiness/checklists/requirements.md
+++ b/specs/140-no-mistakes-provider-readiness/checklists/requirements.md
@@ -1,0 +1,32 @@
+# Specification Quality Checklist: No-Mistakes Provider Readiness
+
+**Purpose**: Validate specification completeness and quality before continuing implementation.
+**Created**: 2026-05-14
+**Feature**: `specs/140-no-mistakes-provider-readiness/spec.md`
+
+## Content Quality
+
+- [x] No unresolved placeholders or template markers remain.
+- [x] Requirements focus on operator-visible behavior and evidence, not hidden implementation preference.
+- [x] Mandatory sections are complete.
+- [x] Internal runtime evidence fields are included only where they are required for operator diagnosis.
+
+## Requirement Completeness
+
+- [x] No `[NEEDS CLARIFICATION]` markers remain.
+- [x] Requirements are testable and unambiguous.
+- [x] Success criteria are measurable.
+- [x] Acceptance scenarios cover readiness, source-bearing review, continuation, semantic replay, and workflow mutation gates.
+- [x] Edge cases include sandbox skill visibility failure, provider session lookup context, semantic replay shape, and approval ambiguity.
+- [x] Dependencies and assumptions are documented.
+
+## Feature Readiness
+
+- [x] Functional requirements have corresponding acceptance criteria or success criteria.
+- [x] User scenarios cover primary, follow-up, exception, and recovery flows.
+- [x] Feature meets measurable outcomes defined in Success Criteria.
+- [x] Spec is ready for plan/test work without new clarification questions.
+
+## Notes
+
+- Current `/speckit.checklist` prerequisite script rejects `main` because it expects a numbered feature branch. `.specify/feature.json` still points at `specs/140-no-mistakes-provider-readiness`, so this checklist was generated against that active feature directory.

--- a/specs/140-no-mistakes-provider-readiness/checklists/review-quality-continuation.md
+++ b/specs/140-no-mistakes-provider-readiness/checklists/review-quality-continuation.md
@@ -8,39 +8,52 @@
 
 ## Requirement Completeness
 
-- [ ] CHK001 Are continuable reviewer session requirements defined for providers that support follow-up or resume flows? [Gap, Spec §User Story 1]
-- [ ] CHK002 Are requirements documented for how session identifiers differ from plugin job identifiers? [Gap, Spec §FR-002]
-- [ ] CHK003 Are stdout, stderr, and lifecycle diagnostic requirements defined for failed reviewer invocations? [Gap, Spec §FR-002]
-- [ ] CHK004 Are semantic-audit requirements complete for reviewer prose that uses non-numeric checklist labels? [Gap, Spec §FR-008]
-- [ ] CHK005 Are requirements present for negated failure language such as "without permission blocks" versus actual permission denials? [Gap, Spec §FR-008]
+- [x] CHK001 Are continuable reviewer session requirements defined for providers that support follow-up or resume flows? [Gap, Spec §User Story 4]
+- [x] CHK002 Are requirements documented for how session identifiers differ from plugin job identifiers? [Gap, Spec §FR-010]
+- [x] CHK003 Are stdout, stderr, and lifecycle diagnostic requirements defined for failed reviewer invocations? [Gap, Spec §FR-013]
+- [x] CHK004 Are semantic-audit requirements complete for reviewer prose that uses non-numeric checklist labels? [Gap, Spec §FR-017]
+- [x] CHK005 Are requirements present for negated failure language such as "without permission blocks" versus actual permission denials? [Gap, Spec §FR-018]
 
 ## Requirement Clarity
 
-- [ ] CHK006 Is "prompt-persistence status" clarified with provider-specific fields and allowed values? [Clarity, Spec §FR-002]
-- [ ] CHK007 Is "review-quality result" defined with objective audit fields rather than inferred prose confidence? [Clarity, Spec §FR-008]
-- [ ] CHK008 Is "missing_evidence" differentiated from parser, transport, provider, and semantic-audit failures? [Clarity, Spec §SC-005]
-- [ ] CHK009 Are source-transmission states specified distinctly for source-free setup, approval-gated no-send, and approved fixture-source send? [Clarity, Spec §FR-002, Spec §FR-006]
+- [x] CHK006 Is "prompt-persistence status" clarified with provider-specific fields and allowed values? [Clarity, Spec §FR-002, Data Model §Provider Row]
+- [x] CHK007 Is "review-quality result" defined with objective audit fields rather than inferred prose confidence? [Clarity, Spec §FR-008]
+- [x] CHK008 Is "missing_evidence" differentiated from parser, transport, provider, and semantic-audit failures? [Clarity, Spec §SC-005]
+- [x] CHK009 Are source-transmission states specified distinctly for source-free setup, approval-gated no-send, and approved fixture-source send? [Clarity, Spec §FR-002, Spec §FR-006]
 
 ## Requirement Consistency
 
-- [ ] CHK010 Do continuation requirements align with the no-full-prompt-persistence requirement? [Consistency, Spec §FR-009]
-- [ ] CHK011 Do failure classes in measurable outcomes align with the provider row fields required by the manifest? [Consistency, Spec §FR-002, Spec §SC-005]
-- [ ] CHK012 Are direct API approval-gate requirements consistent with synthetic-fixture assumptions? [Consistency, Spec §FR-006, Spec §Assumptions]
+- [x] CHK010 Do continuation requirements align with the no-full-prompt-persistence requirement? [Consistency, Spec §FR-009, Spec §FR-011]
+- [x] CHK011 Do failure classes in measurable outcomes align with the provider row fields required by the manifest? [Consistency, Spec §FR-002, Spec §SC-005]
+- [x] CHK012 Are direct API approval-gate requirements consistent with synthetic-fixture assumptions? [Consistency, Spec §FR-006, Spec §Assumptions]
 
 ## Acceptance Criteria Quality
 
-- [ ] CHK013 Can a continuation failure be objectively classified from required JobRecord fields without consulting provider prose alone? [Acceptance Criteria, Spec §FR-002]
-- [ ] CHK014 Can semantic-audit false positives be objectively identified from required audit metadata? [Acceptance Criteria, Spec §FR-008]
-- [ ] CHK015 Are criteria measurable for proving no full prompt is persisted while prompt identity remains auditable? [Measurability, Spec §FR-009]
+- [x] CHK013 Can a continuation failure be objectively classified from required JobRecord fields without consulting provider prose alone? [Acceptance Criteria, Spec §User Story 4]
+- [x] CHK014 Can semantic-audit false positives be objectively identified from required audit metadata? [Acceptance Criteria, Spec §FR-014, Spec §FR-018]
+- [x] CHK015 Are criteria measurable for proving no full prompt is persisted while prompt identity remains auditable? [Measurability, Spec §FR-009]
 
 ## Scenario Coverage
 
-- [ ] CHK016 Are primary and follow-up reviewer flows both covered in user scenarios? [Coverage, Spec §User Story 1]
-- [ ] CHK017 Are exception-flow requirements defined for empty stdout with actionable stderr? [Gap, Spec §Edge Cases]
-- [ ] CHK018 Are exception-flow requirements defined for provider prose that mentions a failure term in a passing or negated sentence? [Gap, Spec §Edge Cases]
-- [ ] CHK019 Are recovery or next-action requirements defined for non-resumable provider sessions? [Coverage, Spec §FR-002]
+- [x] CHK016 Are primary and follow-up reviewer flows both covered in user scenarios? [Coverage, Spec §User Story 1, Spec §User Story 4]
+- [x] CHK017 Are exception-flow requirements defined for empty stdout with actionable stderr? [Gap, Spec §FR-013]
+- [x] CHK018 Are exception-flow requirements defined for provider prose that mentions a failure term in a passing or negated sentence? [Gap, Spec §FR-018]
+- [x] CHK019 Are recovery or next-action requirements defined for non-resumable provider sessions? [Coverage, Spec §User Story 4]
 
 ## Dependencies & Assumptions
 
-- [ ] CHK020 Are provider-specific CLI/session persistence assumptions documented where continuation depends on external runtime behavior? [Assumption, Spec §Technical Context]
-- [ ] CHK021 Are live-provider nondeterminism assumptions documented for semantic-audit replay versus fresh provider output? [Assumption, Spec §User Story 3]
+- [x] CHK020 Are provider-specific CLI/session persistence assumptions documented where continuation depends on external runtime behavior? [Assumption, Spec §Assumptions]
+- [x] CHK021 Are live-provider nondeterminism assumptions documented for semantic-audit replay versus fresh provider output? [Assumption, Spec §Assumptions]
+
+## Post-Smoke Root Cause Coverage
+
+- [x] CHK022 Does the spec require provider session lookup context, not only provider session id, for continuation-capable providers? [Gap, Spec §FR-011]
+- [x] CHK023 Does the spec distinguish plugin job ids, parent job ids, and provider conversation/session ids with testable fields? [Clarity, Spec §FR-010]
+- [x] CHK024 Are continuation acceptance criteria measurable from parent/continue JobRecords without relying on provider prose? [Acceptance Criteria, Spec §User Story 4]
+- [x] CHK025 Does the spec define how to classify `No conversation found with session ID` when stdout is empty but stderr is actionable? [Edge Case, Spec §FR-013]
+- [x] CHK026 Are requirements clear that source-safety neutral cwd/worktree behavior must not break provider session lookup? [Consistency, Spec §FR-011, Spec §FR-012]
+- [x] CHK027 Does the spec separate classifier-only semantic probes from full review-audit probes? [Clarity, Spec §FR-014]
+- [x] CHK028 Are success criteria explicit that tiny passing prose snippets are not required to satisfy verdict/substance audit gates? [Acceptance Criteria, Spec §SC-007]
+- [x] CHK029 Are workflow mutation approval requirements stated as a hard requirement, not a retrospective hygiene note? [Gap, Spec §FR-016]
+- [x] CHK030 Does the plan require a regression seam that fails when a provider session id is resumed from the wrong provider project/cwd? [Coverage, Plan §Phase 1]
+- [x] CHK031 Does the plan require installed-cache/live validation after cache sync, rather than trusting source-only tests? [Coverage, Plan §Phase 3]

--- a/specs/140-no-mistakes-provider-readiness/data-model.md
+++ b/specs/140-no-mistakes-provider-readiness/data-model.md
@@ -7,7 +7,7 @@
 - `review_status`: `completed`, `failed`, provider-specific status string, `not_run`
 - `approval_status`: `not_required`, `not_sent`, `missing`, `invalid`
 - `error_code`: normalized top-level or nested diagnostic error code, or null
-- `failure_class`: `none`, `sandbox`, `auth`, `provider`, `tunnel`, `session_tokens`, `review_quality`, `approval_gate`, `cache_install`, `missing_evidence`
+- `failure_class`: `none`, `sandbox`, `auth`, `provider`, `tunnel`, `session_tokens`, `review_quality`, `approval_gate`, `cache_install`, `parser`, `transport`, `continuation`, `workflow_gate`, `missing_evidence`
 - `next_action`: operator guidance derived from the failure class and evidence
 - `source_content_transmission`: `not_sent`, `may_be_sent`, `sent`
 - `failed_review_slot`: boolean or null
@@ -46,3 +46,46 @@ is classified as `full_prompt_found` if evidence contains a full prompt carrier
 such as `prompt`, `rendered_prompt`, `prompt_text`, `renderedPrompt`,
 `promptText`, `system_prompt`, `developer_prompt`, `user_prompt`, or
 `messages[].content`.
+
+## Continuation Record
+
+Parent and follow-up JobRecords used to prove reviewer continuation.
+
+- `parent_job_id`: plugin job id from the initial review
+- `continue_job_id`: plugin job id from the follow-up run
+- `provider_session_id`: provider conversation/session id used with `--resume` or equivalent
+- `session_lookup_context`: bounded provider runtime context required to resolve the session, including provider project/cwd when applicable
+- `child_cwd`: runtime cwd recorded in JobRecord diagnostics
+- `source_scope`: source selection mode used by parent and continue
+- `stdout_bytes` / `stderr_bytes`: bounded output sizes
+- `error_code` / `error_message`: top-level failure diagnostics
+- `failed_review_slot`: authoritative audit flag
+
+Validation rules:
+
+- `provider_session_id` must not be inferred from `parent_job_id` unless the provider record proves that value is the actual provider session id.
+- For Claude, `session_lookup_context` must remain stable across parent and continue.
+- A continue failure with empty stdout and actionable stderr must preserve the stderr cause without storing full prompts or source bodies.
+
+## Semantic Replay Probe
+
+Synthetic text replayed through parser/audit logic.
+
+- `mode`: `classifier_only` or `full_review_audit`
+- `input_text`: synthetic text, never real project source
+- `expected_reasons`: exact semantic failure reasons expected
+- `expected_failed_review_slot`: boolean for full-audit probes; null for classifier-only probes when verdict/substance gates are intentionally out of scope
+
+Validation rules:
+
+- `classifier_only` probes must assert only the targeted classifier result.
+- `full_review_audit` probes must include review-shaped output with verdict and sufficient substance.
+
+## Operator Approval Gate
+
+Evidence that a workflow mutation was explicitly approved.
+
+- `operation`: `merge`, `push`, `issue_close`, `comment`, `destructive_cleanup`, or `source_send`
+- `approval_source`: current operator instruction or generated approval token
+- `approved_at`: timestamp or null
+- `status`: `approved`, `blocked`, or `not_required`

--- a/specs/140-no-mistakes-provider-readiness/plan.md
+++ b/specs/140-no-mistakes-provider-readiness/plan.md
@@ -1,40 +1,127 @@
 # Implementation Plan: No-Mistakes Provider Readiness
 
-**Branch**: `140-no-mistakes-provider-readiness` | **Date**: 2026-05-11 | **Spec**: `specs/140-no-mistakes-provider-readiness/spec.md`
+**Branch**: `main` | **Date**: 2026-05-14 | **Spec**: `specs/140-no-mistakes-provider-readiness/spec.md`
+**Input**: Post-merge complex installed smoke failed on Claude continuation while initial six-provider review passed; semantic replay probes also had ambiguous pass criteria.
 
 ## Summary
 
-Make delegated reviewer usage auditable across all providers. First TDD slice fixes Grok default startup so `uv` gets a sandbox-writable cache dir. Later slices add a six-provider live-smoke manifest and harden failure classification.
+Address all confirmed failure classes end to end:
+
+1. Claude continuation must reuse the provider session lookup context from the parent JobRecord. The confirmed failure is not stale cache, source leakage, `--no-session-persistence`, E2BIG, or stderr masking; it is a changed Claude project/cwd between parent and continue jobs.
+2. Regression tests must model the real session-resolution invariant, not only argv shape.
+3. Semantic replay smoke must split classifier-only checks from full review-quality audit checks.
+4. Spec-kit and agent context must point at the real active feature directory.
+5. Merge/remote mutation workflow must preserve explicit approval gates.
 
 ## Technical Context
 
 **Language/Version**: Node.js 20+
-**Primary Dependencies**: Node built-ins, plugin companion scripts, `uv` for grok2api
-**Storage**: Local JobRecord JSON, plugin data dirs, synthetic `/private/tmp` fixture repos
-**Testing**: `node:test`, smoke tests, `npm run lint`, `npm run test:full`, GitHub CI
+**Primary Dependencies**: Node built-ins, provider CLIs, plugin companion scripts, `uv` for Grok tunnel runtime
+**Storage**: Local JobRecord JSON, runtime option sidecars, plugin data dirs, synthetic `/private/tmp` fixture repos
+**Testing**: `node:test`, smoke tests, targeted installed-cache smoke, `npm run lint`, GitHub CI
 **Target Platform**: macOS/Linux Codex local sessions
 **Project Type**: CLI/plugin bundle
-**Performance Goals**: Keep unit/smoke tests deterministic; live smoke records elapsed time instead of enforcing brittle provider latency budgets
-**Constraints**: No secret printing; no real project source in live smoke; approval before direct API source send; no Docker requirement for Grok
-**Scale/Scope**: Six reviewer providers: Claude, Gemini, Kimi, Grok, DeepSeek, GLM
+**Performance Goals**: Deterministic local tests; live smoke records elapsed time but does not enforce provider latency budgets
+**Constraints**: No secret printing; no real project source in live smoke; approval before direct API source send; no full prompt persistence; no merge/remote mutation without explicit approval
+**Scale/Scope**: Six reviewer providers plus continuation for providers that support follow-up: Claude, Gemini, Kimi; direct API result retrieval for DeepSeek/GLM
 
 ## Constitution Check
 
-- Evidence first: use real command output and audit fields.
-- TDD: public CLI seam tests before fixes.
-- No full prompt persistence.
-- no-mistakes: keep `.no-mistakes.yaml` full gate intact, but do not use it as authoritative merge evidence until `seungpyoson/claude-config#780` is fixed.
+- Evidence first: every root cause needs artifact or code/test proof.
+- TDD: failing test before fix when a correct seam exists.
+- Audit fields over prose: `failed_review_slot`, `semantic_failure_reasons`, selected-source metadata, and source-send fields are authoritative.
+- Privacy: synthetic `/private/tmp` fixture source only for live provider source-bearing smoke.
+- No full prompt persistence: keep rendered prompt hash and content hashes, not full prompt bodies.
+- Workflow safety: no merge, issue closure, destructive cleanup, push, or GitHub mutation without explicit current-turn approval.
 
 ## Project Structure
 
+### Documentation (this feature)
+
 ```text
-plugins/grok/scripts/grok-web-reviewer.mjs
-tests/smoke/grok-web.smoke.test.mjs
-tests/smoke/*companion*.smoke.test.mjs
+specs/140-no-mistakes-provider-readiness/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+plugins/claude/scripts/claude-companion.mjs
+plugins/claude/scripts/lib/claude.mjs
+plugins/*/scripts/lib/review-prompt.mjs
+plugins/api-reviewers/scripts/api-reviewer.mjs
+tests/smoke/claude-companion.smoke.test.mjs
 tests/smoke/api-reviewers.smoke.test.mjs
-scripts/
-docs/
+tests/unit/claude-dispatcher.test.mjs
+tests/unit/review-prompt.test.mjs
+scripts/sync-review-prompt.mjs
 specs/140-no-mistakes-provider-readiness/
 ```
 
-**Structure Decision**: Existing CLI scripts and smoke tests are the correct public seams. Add shared manifest tooling only after Grok default startup slice is green.
+**Structure Decision**: Use existing public CLI seams and smoke tests. Do not add new runtime abstractions until a failing test proves the seam is insufficient.
+
+## Phase 0: Confirmed Diagnosis
+
+### Claude continuation
+
+- Symptom: installed Claude initial review passed; `continue --job` failed with `parse_error`, empty stdout, and stderr `No conversation found with session ID: 749b07ee-4ac3-4618-b2c6-d088fc6e74a8`.
+- Artifact proof: parent record stored `claude_session_id` equal to plugin job id and `runtime_diagnostics.child_cwd` under one `claude-neutral-cwd-*`; continue record used same session id but a different `claude-neutral-cwd-*`.
+- External runtime proof: Claude persisted the parent session JSONL under `~/.claude/projects/<initial-neutral-cwd>/749b07ee-...jsonl`; lookup from another project/cwd failed.
+- Falsified: cache drift, source-selection leak, `--no-session-persistence`, E2BIG, stderr diagnostic masking, direct API result parity.
+- Root cause: plugin changed Claude project/session lookup cwd between parent and continue jobs.
+
+### Semantic replay
+
+- Symptom: exact passing permission prose did not trigger `permission_blocked`, but full audit still failed as `shallow_output` / `missing_verdict`.
+- Root cause: smoke expected tiny classifier probes to satisfy full review-quality gates. That is an invalid acceptance criterion, not a permission-block classifier regression.
+
+### Workflow gate
+
+- Symptom: prior merge happened without explicit approval.
+- Root cause: process invariant was not encoded as a hard workflow requirement in this feature spec/plan.
+
+## Phase 1: Test-First Work
+
+1. Add/keep regression proving Claude continue reuses parent provider session lookup cwd, not only `--resume`.
+2. Strengthen mock seam if needed so a changed cwd reproduces `No conversation found with session ID`.
+3. Keep stderr promotion regression for empty stdout with actionable stderr.
+4. Add semantic replay tests that assert classifier outputs only for short snippets.
+5. Keep full review-quality tests limited to review-shaped output with verdict and adequate substance.
+6. Add/update workflow checklist so merge/remote mutation requires explicit current-turn approval.
+
+## Phase 2: Implementation Work
+
+1. Persist Claude provider project/cwd in runtime sidecars and/or JobRecord diagnostics.
+2. On `continue --job`, reuse parent provider project/cwd for Claude session lookup.
+3. Keep throwaway worktree/source-safety behavior separate from provider session lookup cwd.
+4. Preserve cleanup of temporary neutral cwds when safe.
+5. Update smoke harness semantics so classifier-only probes do not report overall audit failure unless the classifier reason is wrong.
+
+## Phase 3: Verification
+
+Required before any merge request:
+
+1. `git diff --check`
+2. Targeted Claude continue smoke test red/green evidence.
+3. Full Claude smoke tests.
+4. Review-prompt semantic tests.
+5. `npm run lint`
+6. `npm run doctor:cache` before installed-runtime validation; after local source changes this may be `ok:false` until reinstall/cache refresh.
+7. Installed synthetic fixture live smoke after reinstall/cache sync:
+   - source-free readiness for all providers
+   - initial source-bearing review for all approved providers
+   - continuation for Claude/Gemini/Kimi
+   - direct API `result --job` for DeepSeek/GLM
+   - classifier-only semantic probes reported separately from full audit probes
+8. Explicit approval captured before merge/push/issue closure/remote mutation.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+No constitution violations currently identified.

--- a/specs/140-no-mistakes-provider-readiness/quickstart.md
+++ b/specs/140-no-mistakes-provider-readiness/quickstart.md
@@ -41,10 +41,57 @@ npm run readiness:manifest -- \
 
 The manifest is a normalizer, not a provider runner. It classifies missing
 direct-API approval as `approval_gate`, Grok runtime-token issues as
-`session_tokens`, audit failures as `review_quality`, and persisted full prompt
+`session_tokens`, audit failures as `review_quality`, parse failures as
+`parser`, continuation failures as `continuation`, and persisted full prompt
 keys as `full_prompt_found`. Each row includes `next_action` so sandbox,
-approval, cache-install, tunnel, session-token, provider, and review-quality
-failures remain operator-actionable.
+approval, cache-install, tunnel, session-token, provider, parser, continuation,
+and review-quality failures remain operator-actionable.
+
+## Continuation smoke
+
+After initial source-bearing reviews pass, run continuation for providers that
+support follow-up:
+
+```sh
+# Provider-specific installed commands; use the plugin runtime paths, not ad hoc
+# direct provider calls.
+claude continue --job <claude-parent-job-id>
+gemini continue --job <gemini-parent-job-id>
+kimi continue --job <kimi-parent-job-id>
+```
+
+For each continue JobRecord, inspect:
+
+- `parent_job_id`
+- provider session id field, such as `claude_session_id`
+- `runtime_diagnostics.child_cwd`
+- `raw_output.stdout_bytes` / `raw_output.stderr_bytes`
+- `error_code` / `error_message`
+- `review_quality.failed_review_slot`
+
+Claude continuation is not proven by `--resume <id>` alone. The parent and
+continue records must show that the provider session lookup context is reused.
+`No conversation found with session ID` is a continuation failure even when the
+initial review passed.
+
+## Semantic replay probes
+
+Run two different probe classes:
+
+1. Classifier-only snippets: assert targeted semantic reasons, for example that
+   passing prose containing `without permission blocks` does not emit
+   `permission_blocked`.
+2. Full review-audit samples: include review-shaped output with verdict and
+   enough substance to satisfy `missing_verdict` and `shallow_output` gates.
+
+Do not mark a classifier-only snippet as failed because it lacks a full review
+verdict. Do mark it failed when the targeted classifier reason is wrong.
+
+## Workflow mutation gate
+
+Before merge, push, issue closure, GitHub comment, or destructive cleanup, record
+explicit current operator approval. If approval is absent or ambiguous, stop and
+ask. Do not normalize an unapproved mutation after it happens.
 
 ## no-mistakes status
 

--- a/specs/140-no-mistakes-provider-readiness/research.md
+++ b/specs/140-no-mistakes-provider-readiness/research.md
@@ -15,3 +15,19 @@ With writable `UV_CACHE_DIR`, default grok2api starts but has zero runtime token
 ## Decision: Live smoke uses synthetic source only
 
 Real project source is not needed to prove wiring. Use git-backed `/private/tmp` fixture and record hashes, source-send state, quality gate, mutations, prompt-persistence checks.
+
+## Decision: Claude continuation must preserve provider project/cwd context
+
+The installed post-merge smoke proved that Claude initial review can pass while `continue --job` fails with `No conversation found with session ID: <parent-job-id>`. The parent JobRecord and continue JobRecord used the same stored session id, and the initial run did not include `--no-session-persistence`; however, the parent session JSONL was stored under the initial Claude project/cwd in `~/.claude/projects/...`, while the continue run used a different neutral cwd. Claude session lookup is therefore not session-id-only in practice. The plugin must persist and reuse provider session lookup context across continuation jobs.
+
+## Decision: Semantic replay must separate classifier-only probes from full audit gates
+
+Short replay prose such as "PASS ... without permission blocks" is useful to prove that `permission_blocked` is not falsely emitted. It is not a full reviewer answer and should not be expected to pass verdict/substance gates. Smoke reports must classify that as a classifier probe result, not as a failed full review.
+
+## Decision: Workflow mutations require explicit current approval
+
+The readiness workflow includes non-code process gates. Merge, issue closure, destructive cleanup, push, or remote mutation must not run from inferred approval or stale context. The approval state must be explicit in the current operator workflow.
+
+## Decision: Spec-kit agent context must point at the real active spec
+
+`.specify/feature.json` points at `specs/140-no-mistakes-provider-readiness`, but AGENTS.md referenced nonexistent `specs/001-no-mistakes-wiring-readiness`. Agent context must be aligned with the active feature directory before planning or checklist work is trusted.

--- a/specs/140-no-mistakes-provider-readiness/spec.md
+++ b/specs/140-no-mistakes-provider-readiness/spec.md
@@ -52,6 +52,23 @@ Maintainers can distinguish model/provider defects from operator prompt-shape mi
 1. **Given** Kimi output is shallow or lacks verdict, **When** JobRecord is built, **Then** result fails with `review_not_completed`.
 2. **Given** current prompt shape is used, **When** Kimi reviews the synthetic fixture, **Then** review quality gate can pass and the manifest does not treat old malformed output as current readiness failure.
 
+---
+
+### User Story 4 - Reviewer Continuation Uses The Right External Session Context (Priority: P1)
+
+An operator runs a source-bearing review and then asks the same provider to continue from that result. The plugin resumes the real provider conversation in the same external session/project context, or fails with a precise, evidence-backed classification.
+
+**Why this priority**: A source-bearing review can pass while follow-up review fails if the plugin stores the right-looking session id but resumes it from a different runtime project context. That makes continuation untrustworthy even when the initial review, cache doctor, and source selection are clean.
+
+**Independent Test**: Run the installed Claude review and `continue --job` path against a synthetic git fixture, then inspect both persisted JobRecords for provider session id, parent job id, runtime child cwd, stdout/stderr diagnostics, and review-quality fields.
+
+**Acceptance Scenarios**:
+
+1. **Given** an initial Claude review completes with a persisted provider session id, **When** `continue --job <parent>` runs, **Then** the continue invocation resumes in the same Claude project/session lookup context and does not fail with `No conversation found with session ID`.
+2. **Given** a provider stores conversations by runtime project/cwd, **When** the plugin creates neutral working directories for source safety, **Then** the provider session lookup cwd remains stable across parent and continue jobs while throwaway worktrees may differ.
+3. **Given** a continue run emits empty stdout and actionable stderr, **When** the JobRecord is built, **Then** the top-level error message exposes the bounded stderr cause and preserves `failed_review_slot: true`.
+4. **Given** a provider cannot support continuation with the available evidence, **When** `continue --job` is requested, **Then** the failure class and next action state the missing provider/session evidence instead of treating plausible prose as success.
+
 ## Edge Cases
 
 - Fresh Codex session cannot run `codex debug prompt-input` inside sandbox.
@@ -59,6 +76,10 @@ Maintainers can distinguish model/provider defects from operator prompt-shape mi
 - Grok has reachable `/models` but no runtime session tokens.
 - Provider prose says approve but audit fields fail.
 - Review record contains no full rendered prompt even when source was sent.
+- Provider conversation ids equal plugin job ids but are only resolvable inside the original provider project/cwd.
+- Continuation uses a new neutral cwd and the external CLI cannot find a persisted conversation.
+- Tiny semantic replay prose proves a classifier branch but is too short to satisfy full review-quality gates.
+- A merge, cleanup, issue closure, or remote mutation is requested without explicit current-turn approval.
 
 ## Requirements
 
@@ -73,12 +94,24 @@ Maintainers can distinguish model/provider defects from operator prompt-shape mi
 - **FR-007**: Skill visibility failure inside sandbox MUST be classifiable as sandbox failure when outside-sandbox probe succeeds.
 - **FR-008**: Review-quality audit fields MUST be source of truth over provider prose.
 - **FR-009**: Full rendered prompts MUST NOT be persisted in records or manifests.
+- **FR-010**: Continuation-capable providers MUST persist the provider conversation/session id separately from plugin job linkage fields whenever the provider exposes a distinct id.
+- **FR-011**: Continuation-capable providers MUST persist enough runtime context to resolve the provider session on follow-up, including provider project/cwd when the external runtime scopes session lookup by cwd.
+- **FR-012**: `continue --job` MUST reuse provider session lookup context from the parent record while preserving fixture/source safety and avoiding real project source send.
+- **FR-013**: Empty-stdout failures with actionable stderr MUST promote a bounded stderr message into operator-visible JobRecord diagnostics without masking parser or audit fields.
+- **FR-014**: Semantic replay checks MUST distinguish narrow classifier probes from full review-quality audits; non-review-shaped snippets MUST NOT be expected to satisfy verdict or shallow-output gates.
+- **FR-015**: Live smoke criteria MUST include initial review and continuation for every supported continuation provider, not only initial source-bearing review.
+- **FR-016**: Merge, issue closure, destructive cleanup, and remote mutation steps MUST require explicit operator approval in the current workflow before execution.
+- **FR-017**: Review-quality audit MUST recognize provider checklist formats used by live reviewers, including bold `Checklist item N` labels, without counting ordinary item-prefixed prose as checklist evidence.
+- **FR-018**: Review-quality audit MUST distinguish negated passing language such as `without permission blocks` from concrete permission denial or source-inspection failure language on the same line.
 
 ### Key Entities
 
 - **Provider Row**: One provider result with status, failure class, source-send state, quality gate, mutation and persistence checks.
 - **Readiness Manifest**: Complete evidence object for one synthetic-fixture run.
 - **Synthetic Fixture**: Git-backed `/private/tmp` repository used for live smoke without real project source.
+- **Continuation Record**: Pair of parent and follow-up JobRecords with provider session id, parent job id, runtime project/cwd evidence, stdout/stderr diagnostics, and review-quality result.
+- **Semantic Replay Probe**: Synthetic provider prose replayed through the audit/parser layer with an explicit mode: classifier-only or full-review-audit.
+- **Operator Approval Gate**: Evidence that merge, remote mutation, destructive cleanup, or source-send was explicitly approved before execution.
 
 ## Success Criteria
 
@@ -88,11 +121,18 @@ Maintainers can distinguish model/provider defects from operator prompt-shape mi
 - **SC-002**: Grok default auto-start smoke proves no inherited sandbox-blocked uv cache path is required.
 - **SC-003**: Direct API approval-request rows show `source_content_transmission: "not_sent"` before approved runs.
 - **SC-004**: Every completed source-bearing row has `failed_review_slot=false`, no tracked fixture mutation, and no persisted full prompt key.
-- **SC-005**: Failure classes are explicit: `sandbox`, `auth`, `provider`, `tunnel`, `session_tokens`, `review_quality`, `approval_gate`, `cache_install`, or `missing_evidence`.
+- **SC-005**: Failure classes are explicit: `sandbox`, `auth`, `provider`, `tunnel`, `session_tokens`, `review_quality`, `approval_gate`, `cache_install`, `parser`, `transport`, `continuation`, `workflow_gate`, or `missing_evidence`.
+- **SC-006**: Claude initial review plus `continue --job` passes on a git-backed synthetic fixture without `No conversation found with session ID`, with stable provider session lookup cwd across parent and continue records.
+- **SC-007**: Semantic permission-block probes prove no `permission_blocked` false positive for passing or negated prose, while full-audit pass expectations are limited to review-shaped outputs with verdict and sufficient substance.
+- **SC-008**: Regression tests fail if continuation only asserts `--resume` argv but does not model provider session lookup context.
+- **SC-009**: Workflow evidence distinguishes approved merges/remote mutations from unapproved operations; unapproved operations are blocked, not normalized after the fact.
 
 ## Assumptions
 
 - Synthetic fixture source can be sent to live providers after explicit approval for direct APIs.
 - Real secrets remain in existing runtime stores and are never printed.
+- External reviewer CLIs may scope conversation persistence by provider project/cwd, not only by session id.
+- Plugin job ids may look identical to provider session ids in some providers; correctness still depends on where and how that id is resolved.
+- Semantic replay of short snippets is valid for classifier branch testing, not for proving full reviewer output quality.
 - `.no-mistakes.yaml` remains configured with `npm ci && npm run lint && npm run test:full`, but no-mistakes is not authoritative merge evidence until `seungpyoson/claude-config#780` is fixed.
 - Direct local verification and GitHub CI are authoritative for this slice while no-mistakes has the review/fix-loop defect.

--- a/tests/smoke/claude-companion.smoke.test.mjs
+++ b/tests/smoke/claude-companion.smoke.test.mjs
@@ -1498,6 +1498,46 @@ test("continue --job --background reuses the parent Claude project cwd", async (
   }
 });
 
+test("continue --job: project-cwd setup failure falls back to neutral cwd, not source add-dir", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "smoke-continue-cwd-conflict-"));
+  writeFileSync(path.join(cwd, "seed.txt"), "continue cwd conflict seed\n");
+  const dataDir = mkdtempSync(path.join(tmpdir(), "continue-cwd-conflict-data-"));
+  try {
+    const runRes = runCompanion(
+      ["run", "--mode=custom-review", "--foreground",
+       "--model", "claude-haiku-4-5-20251001",
+       "--scope-paths", "seed.txt",
+       "--cwd", cwd, "--", "seed"],
+      { cwd, dataDir },
+    );
+    assert.equal(runRes.status, 0, runRes.stderr);
+    const parent = JSON.parse(runRes.stdout);
+    const parentProjectCwd = parent.runtime_diagnostics.child_cwd;
+    rmSync(parentProjectCwd, { recursive: true, force: true });
+    writeFileSync(parentProjectCwd, "blocks project cwd recreation\n", "utf8");
+
+    const contRes = runCompanion(
+      ["continue", "--job", parent.job_id, "--foreground",
+       "--cwd", cwd, "--", "follow-up"],
+      { cwd, dataDir, env: { CLAUDE_MOCK_LIST_ADDDIR: "1" } },
+    );
+    assert.equal(contRes.status, 0, contRes.stderr);
+    const continued = JSON.parse(contRes.stdout);
+    assert.ok(
+      continued.mutations.some((mutation) => mutation.startsWith("mutation_detection_failed:")),
+      `project cwd setup failure must be surfaced in mutations; got ${JSON.stringify(continued.mutations)}`
+    );
+    assert.notEqual(
+      continued.runtime_diagnostics.child_cwd,
+      continued.runtime_diagnostics.add_dir,
+      "project-cwd setup failure must not make Claude run from the selected-source add-dir"
+    );
+  } finally {
+    rmSync(dataDir, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test("continue --job: --timeout-ms overrides prior timeout and env", () => {
   const cwd = mkdtempSync(path.join(tmpdir(), "smoke-continue-timeout-override-"));
   writeFileSync(path.join(cwd, "seed.txt"), "continue timeout override seed\n");

--- a/tests/smoke/claude-companion.smoke.test.mjs
+++ b/tests/smoke/claude-companion.smoke.test.mjs
@@ -105,7 +105,7 @@ function readJobRecord(dataDir, jobId) {
       return JSON.parse(readFileSync(metaPath, "utf8"));
     }
   }
-  assert.fail(`meta.json for job ${jobId} not found under ${stateRoot}`);
+  assert.fail(`${jobId}.json not found under ${stateRoot}`);
 }
 
 function jobSidecarDir(dataDir, jobId) {

--- a/tests/smoke/claude-companion.smoke.test.mjs
+++ b/tests/smoke/claude-companion.smoke.test.mjs
@@ -108,6 +108,31 @@ function readJobRecord(dataDir, jobId) {
   assert.fail(`meta.json for job ${jobId} not found under ${stateRoot}`);
 }
 
+function jobSidecarDir(dataDir, jobId) {
+  const stateRoot = path.join(dataDir, "state");
+  for (const workspaceDir of readdirSync(stateRoot)) {
+    const sidecarDir = path.join(stateRoot, workspaceDir, "jobs", jobId);
+    if (existsSync(sidecarDir)) return sidecarDir;
+  }
+  assert.fail(`sidecar dir for job ${jobId} not found under ${stateRoot}`);
+}
+
+async function waitForJobRecord(dataDir, jobId, predicate, label, timeoutMs = CLAUDE_SMOKE_POLL_TIMEOUT_MS) {
+  const deadline = Date.now() + timeoutMs;
+  let lastRecord = null;
+  while (Date.now() < deadline) {
+    try {
+      const record = readJobRecord(dataDir, jobId);
+      lastRecord = record;
+      if (predicate(record)) return record;
+    } catch {
+      // The worker may not have written the first record yet.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  assert.fail(`${label}; last record=${JSON.stringify(lastRecord)}`);
+}
+
 async function waitForOnlyJobRecord(dataDir, predicate, label, timeoutMs = CLAUDE_SMOKE_POLL_TIMEOUT_MS) {
   const deadline = Date.now() + timeoutMs;
   let lastRecord = null;
@@ -1345,7 +1370,19 @@ test("continue --job: resumes a prior session via --resume", () => {
       "--cwd", cwd, "--", "seed",
     ], { cwd, encoding: "utf8",
         env });
+    assert.equal(runRes.status, 0, runRes.stderr);
     const { job_id } = JSON.parse(runRes.stdout);
+    const prior = readJobRecord(dataDir, job_id);
+    assert.equal(
+      existsSync(prior.runtime_diagnostics.child_cwd),
+      true,
+      "Claude project cwd must remain on disk so provider project-scoped continuation has a stable home"
+    );
+    assert.equal(
+      existsSync(path.join(jobSidecarDir(dataDir, job_id), "runtime-options.json")),
+      false,
+      "foreground parent has no runtime-options sidecar; continue must fall back to JobRecord child_cwd"
+    );
     const contRes = spawnSync("node", [
       path.join(REPO_ROOT, "plugins/claude/scripts/claude-companion.mjs"),
       "continue", "--job", job_id, "--foreground", "--lifecycle-events", "jsonl",
@@ -1363,12 +1400,98 @@ test("continue --job: resumes a prior session via --resume", () => {
     assert.equal(out.status, "completed");
     assert.equal(out.parent_job_id, job_id, "resume carries parent_job_id");
     assert.equal(out.review_metadata.audit_manifest.request.timeout_ms, priorTimeoutMs);
-    const prior = readJobRecord(dataDir, job_id);
     assert.equal(
       out.runtime_diagnostics.child_cwd,
       prior.runtime_diagnostics.child_cwd,
       "continue must run Claude from the same project cwd so --resume can find the persisted session"
     );
+  } finally {
+    rmSync(dataDir, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("continue --job: continues a continued Claude session in the same project cwd", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "smoke-continue-chain-"));
+  writeFileSync(path.join(cwd, "seed.txt"), "continue chain seed\n");
+  const dataDir = mkdtempSync(path.join(tmpdir(), "continue-chain-data-"));
+  const sessionStore = path.join(dataDir, "mock-project-sessions");
+  const env = {
+    CLAUDE_MOCK_ENFORCE_PROJECT_SESSIONS: "1",
+    CLAUDE_MOCK_PROJECT_SESSION_STORE: sessionStore,
+  };
+  try {
+    const runRes = runCompanion(
+      ["run", "--mode=custom-review", "--foreground",
+       "--model", "claude-haiku-4-5-20251001",
+       "--scope-paths", "seed.txt",
+       "--cwd", cwd, "--", "seed"],
+      { cwd, dataDir, env },
+    );
+    assert.equal(runRes.status, 0, runRes.stderr);
+    const parent = JSON.parse(runRes.stdout);
+    const firstRes = runCompanion(
+      ["continue", "--job", parent.job_id, "--foreground",
+       "--cwd", cwd, "--", "first follow-up"],
+      { cwd, dataDir, env },
+    );
+    assert.equal(firstRes.status, 0, firstRes.stderr);
+    const first = JSON.parse(firstRes.stdout);
+    const secondRes = runCompanion(
+      ["continue", "--job", first.job_id, "--foreground",
+       "--cwd", cwd, "--", "second follow-up"],
+      { cwd, dataDir, env },
+    );
+    assert.equal(secondRes.status, 0, secondRes.stderr);
+    const second = JSON.parse(secondRes.stdout);
+    const parentRecord = readJobRecord(dataDir, parent.job_id);
+    assert.equal(first.parent_job_id, parent.job_id);
+    assert.equal(second.parent_job_id, first.job_id);
+    assert.equal(first.runtime_diagnostics.child_cwd, parentRecord.runtime_diagnostics.child_cwd);
+    assert.equal(second.runtime_diagnostics.child_cwd, parentRecord.runtime_diagnostics.child_cwd);
+  } finally {
+    rmSync(dataDir, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("continue --job --background reuses the parent Claude project cwd", async () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "smoke-continue-bg-"));
+  writeFileSync(path.join(cwd, "seed.txt"), "continue background seed\n");
+  const dataDir = mkdtempSync(path.join(tmpdir(), "continue-bg-data-"));
+  const sessionStore = path.join(dataDir, "mock-project-sessions");
+  const env = {
+    CLAUDE_MOCK_ENFORCE_PROJECT_SESSIONS: "1",
+    CLAUDE_MOCK_PROJECT_SESSION_STORE: sessionStore,
+  };
+  try {
+    const runRes = runCompanion(
+      ["run", "--mode=custom-review", "--foreground",
+       "--model", "claude-haiku-4-5-20251001",
+       "--scope-paths", "seed.txt",
+       "--cwd", cwd, "--", "seed"],
+      { cwd, dataDir, env },
+    );
+    assert.equal(runRes.status, 0, runRes.stderr);
+    const parent = JSON.parse(runRes.stdout);
+    const parentRecord = readJobRecord(dataDir, parent.job_id);
+    const contRes = runCompanion(
+      ["continue", "--job", parent.job_id, "--background",
+       "--cwd", cwd, "--", "follow-up"],
+      { cwd, dataDir, env },
+    );
+    assert.equal(contRes.status, 0, contRes.stderr);
+    const launched = JSON.parse(contRes.stdout);
+    const continued = await waitForJobRecord(
+      dataDir,
+      launched.job_id,
+      (record) => record.status === "completed" || record.status === "failed",
+      "background continue did not reach terminal status",
+    );
+    assert.equal(continued.status, "completed");
+    assert.equal(continued.parent_job_id, parent.job_id);
+    assert.equal(continued.runtime_diagnostics.child_cwd, parentRecord.runtime_diagnostics.child_cwd);
+    await new Promise((resolve) => setTimeout(resolve, 250));
   } finally {
     rmSync(dataDir, { recursive: true, force: true });
     rmSync(cwd, { recursive: true, force: true });
@@ -1823,8 +1946,8 @@ test("custom-review scope=custom: reviews explicit bundle files from a non-git d
       assert.equal(fx.t7_saw_file, true, "custom-review should include PR23.diff in --add-dir");
       assert.deepEqual(fx.t7_add_dir_files.sort(), ["PR23.diff", "notes.md"]);
       assert.equal(fx.t7_add_dir, result.runtime_diagnostics.add_dir);
-      assert.equal(existsSync(result.runtime_diagnostics.child_cwd), false,
-        `neutral Claude cwd should be disposed after custom review: ${result.runtime_diagnostics.child_cwd}`);
+      assert.equal(existsSync(result.runtime_diagnostics.child_cwd), true,
+        `Claude project cwd should remain under job state for continuation: ${result.runtime_diagnostics.child_cwd}`);
     } finally {
       cleanup(dataDir);
     }
@@ -1983,8 +2106,8 @@ test("review worktree disposed by profile default (dispose_default=true)", () =>
     assert.ok(fx.t7_cwd, "mock didn't record cwd");
     assert.notEqual(fx.t7_cwd, fx.t7_add_dir, "Claude review must run from a neutral cwd, not the scoped add-dir");
     assert.notEqual(fx.t7_cwd_real, fx.t7_add_dir_real, "Claude review cwd must resolve outside the scoped add-dir");
-    assert.equal(existsSync(fx.t7_cwd), false,
-      `neutral Claude cwd should be disposed after review: ${fx.t7_cwd}`);
+    assert.equal(existsSync(fx.t7_cwd), true,
+      `Claude project cwd should remain under job state for continuation: ${fx.t7_cwd}`);
     assert.equal(existsSync(fx.t7_add_dir), false,
       `review worktree ${fx.t7_add_dir} should be disposed (dispose_default=true)`);
   } finally {

--- a/tests/smoke/claude-companion.smoke.test.mjs
+++ b/tests/smoke/claude-companion.smoke.test.mjs
@@ -97,6 +97,17 @@ function readOnlyJobRecord(dataDir) {
   return records[0];
 }
 
+function readJobRecord(dataDir, jobId) {
+  const stateRoot = path.join(dataDir, "state");
+  for (const workspaceDir of readdirSync(stateRoot)) {
+    const metaPath = path.join(stateRoot, workspaceDir, "jobs", `${jobId}.json`);
+    if (existsSync(metaPath)) {
+      return JSON.parse(readFileSync(metaPath, "utf8"));
+    }
+  }
+  assert.fail(`meta.json for job ${jobId} not found under ${stateRoot}`);
+}
+
 async function waitForOnlyJobRecord(dataDir, predicate, label, timeoutMs = CLAUDE_SMOKE_POLL_TIMEOUT_MS) {
   const deadline = Date.now() + timeoutMs;
   let lastRecord = null;
@@ -1314,7 +1325,16 @@ test("continue --job: resumes a prior session via --resume", () => {
   const cwd = mkdtempSync(path.join(tmpdir(), "smoke-continue-"));
   writeFileSync(path.join(cwd, "seed.txt"), "continue timeout seed\n");
   const dataDir = mkdtempSync(path.join(tmpdir(), "continue-data-"));
+  const sessionStore = path.join(dataDir, "mock-project-sessions");
   const priorTimeoutMs = 777777;
+  const env = {
+    ...process.env,
+    CLAUDE_BINARY: MOCK,
+    CLAUDE_PLUGIN_DATA: dataDir,
+    CLAUDE_REVIEW_TIMEOUT_MS: "",
+    CLAUDE_MOCK_ENFORCE_PROJECT_SESSIONS: "1",
+    CLAUDE_MOCK_PROJECT_SESSION_STORE: sessionStore,
+  };
   try {
     const runRes = spawnSync("node", [
       path.join(REPO_ROOT, "plugins/claude/scripts/claude-companion.mjs"),
@@ -1324,14 +1344,14 @@ test("continue --job: resumes a prior session via --resume", () => {
       "--timeout-ms", String(priorTimeoutMs),
       "--cwd", cwd, "--", "seed",
     ], { cwd, encoding: "utf8",
-        env: { ...process.env, CLAUDE_BINARY: MOCK, CLAUDE_PLUGIN_DATA: dataDir, CLAUDE_REVIEW_TIMEOUT_MS: "" } });
+        env });
     const { job_id } = JSON.parse(runRes.stdout);
     const contRes = spawnSync("node", [
       path.join(REPO_ROOT, "plugins/claude/scripts/claude-companion.mjs"),
       "continue", "--job", job_id, "--foreground", "--lifecycle-events", "jsonl",
       "--cwd", cwd, "--", "follow-up",
     ], { cwd, encoding: "utf8",
-        env: { ...process.env, CLAUDE_BINARY: MOCK, CLAUDE_PLUGIN_DATA: dataDir, CLAUDE_REVIEW_TIMEOUT_MS: "" } });
+        env });
     assert.equal(contRes.status, 0, contRes.stderr);
     const lines = contRes.stdout.trim().split("\n").map((line) => JSON.parse(line));
     assert.equal(lines.length, 2);
@@ -1343,6 +1363,12 @@ test("continue --job: resumes a prior session via --resume", () => {
     assert.equal(out.status, "completed");
     assert.equal(out.parent_job_id, job_id, "resume carries parent_job_id");
     assert.equal(out.review_metadata.audit_manifest.request.timeout_ms, priorTimeoutMs);
+    const prior = readJobRecord(dataDir, job_id);
+    assert.equal(
+      out.runtime_diagnostics.child_cwd,
+      prior.runtime_diagnostics.child_cwd,
+      "continue must run Claude from the same project cwd so --resume can find the persisted session"
+    );
   } finally {
     rmSync(dataDir, { recursive: true, force: true });
     rmSync(cwd, { recursive: true, force: true });

--- a/tests/smoke/claude-mock.mjs
+++ b/tests/smoke/claude-mock.mjs
@@ -22,7 +22,7 @@
 //   CLAUDE_MOCK_OMIT_SESSION_ID, CLAUDE_MOCK_RECORD_RESUME, CLAUDE_MOCK_*
 //                              other test-oracle knobs (see below).
 
-import { readFileSync, existsSync, realpathSync } from "node:fs";
+import { mkdirSync, readFileSync, existsSync, realpathSync, writeFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createHash } from "node:crypto";
@@ -107,6 +107,29 @@ const readinessPrompt = prompt.includes("reply with exactly: pong.") && prompt.i
 if (expectedPromptText && !readinessPrompt && !prompt.includes(expectedPromptText)) {
   process.stderr.write(`claude-mock: prompt missing expected text: ${expectedPromptText}\n`);
   process.exit(1);
+}
+
+if (process.env.CLAUDE_MOCK_ENFORCE_PROJECT_SESSIONS === "1" && !readinessPrompt) {
+  const store = process.env.CLAUDE_MOCK_PROJECT_SESSION_STORE;
+  if (!store) {
+    process.stderr.write("claude-mock: CLAUDE_MOCK_PROJECT_SESSION_STORE is required\n");
+    process.exit(1);
+  }
+  mkdirSync(store, { recursive: true, mode: 0o700 });
+  const sessionFile = resolve(store, `${resumeId ?? sessionId}.json`);
+  if (resumeId) {
+    if (!existsSync(sessionFile)) {
+      process.stderr.write(`No conversation found with session ID: ${resumeId}\n`);
+      process.exit(1);
+    }
+    const stored = JSON.parse(readFileSync(sessionFile, "utf8"));
+    if (stored.cwd !== process.cwd()) {
+      process.stderr.write(`No conversation found with session ID: ${resumeId}\n`);
+      process.exit(1);
+    }
+  } else {
+    writeFileSync(sessionFile, `${JSON.stringify({ cwd: process.cwd() })}\n`, { mode: 0o600 });
+  }
 }
 
 if (process.env.CLAUDE_MOCK_SIDECAR_CONFLICT === "1") {


### PR DESCRIPTION
## Summary

Fixes the post-merge installed-smoke Claude `continue --job` failure where initial review passed but continue failed with:

`No conversation found with session ID: <parent-job-id>`

Root cause: Claude CLI session lookup is scoped by provider project/cwd, not session id alone. The plugin created a new neutral cwd for continue, so `--resume` searched the wrong Claude project namespace.

This PR:
- persists a deterministic Claude project cwd per parent job
- reuses that cwd for continue runs while keeping throwaway source worktrees separate
- strengthens the smoke mock so it reproduces cwd-scoped session lookup failure
- adds a continue regression asserting parent/continue `runtime_diagnostics.child_cwd` stability
- updates spec-kit docs/checklists for continuation, semantic replay probe semantics, and workflow approval gates
- tracks the active spec in `CLAUDE.md`

## Verification

Local verification run before opening PR:

- `git diff --check` — pass
- targeted Claude continue regression — pass
- full Claude smoke — `102/102` pass
- `npm run lint` — pass
- `npm test` — `1714` pass, `6` skipped

## External Reviews

Exact range reviewed: `9b74e3771cbcc2b1bad0fe97bf2d93cd50edb245..f8ce0b3cee6a3b0906e3a2a9d5dcc65ba5d8ef3e`

All six reviewers completed with no blocking findings:

- Claude: `1e2e060e-2d72-4141-8eee-c9d668ff52af` — approve
- Gemini: `8d196b4f-6fb6-490e-b655-29faee1f11f6` — approve
- Kimi: `a55b962a-00c6-45f5-8dbf-69b209f1e866` — approve
- Grok: `job_bc8528d6-67ef-4f04-b85b-924c864277bf` — approve
- DeepSeek: `job_da9a534a-55c8-42ea-bcd3-6cfbd306d57a` — approve
- GLM: `job_b40d5287-b619-432b-ab67-fb40a88d35ad` — approve

Direct API reviewer source-send was approval-gated before DeepSeek/GLM ran.

## Follow-up Needed After Merge/Reinstall

- `npm run doctor:cache` must return `ok:true`
- run installed synthetic fixture live smoke
- specifically verify Claude initial review plus `continue --job` no longer fails with `No conversation found...`
- then run full complex provider matrix

No merge until explicit approval after CI/review/liveness checks.