### PR TITLE
[codex] Add shared source-packet budget gates

### DIFF
--- a/plugins/api-reviewers/scripts/api-reviewer.mjs
+++ b/plugins/api-reviewers/scripts/api-reviewer.mjs
@@ -2371,6 +2371,16 @@ function approvalRouteFields(routeState) {
   });
 }
 
+const LARGE_SOURCE_PACKET_FLAG = "--allow-large-source-packet";
+
+function sourcePacketOverrideRouteFields(options = {}) {
+  const approved = options["allow-large-source-packet"] === true;
+  return {
+    sourcePacketOverrideApproved: approved,
+    sourcePacketOverrideSource: approved ? LARGE_SOURCE_PACKET_FLAG : null,
+  };
+}
+
 function approvalScopeForOptions(options = {}) {
   return normalizeApprovalScope(options["approval-scope"] ?? "session");
 }
@@ -2397,7 +2407,7 @@ function approvalTokenFor({ provider, mode, auditManifest, authPath = null, bill
   });
 }
 
-function buildApprovalAuditManifest({ cfg, renderedPrompt, request, scopeInfo, routeFields = null, approvalScope = "session" }) {
+function buildApprovalAuditManifest({ cfg, renderedPrompt, request, scopeInfo, routeFields = null, approvalScope = "session", options = {} }) {
   return buildReviewAuditManifest({
     prompt: renderedPrompt,
     sourceFiles: scopeInfo.files,
@@ -2445,6 +2455,7 @@ function buildApprovalAuditManifest({ cfg, renderedPrompt, request, scopeInfo, r
       sourceSendApprovalRequired: routeFields?.source_send_approval_required ?? null,
       sourceSendApprovalState: routeFields?.source_send_approval_state ?? null,
       providerCapabilities: providerCapabilitiesForConfig(cfg),
+      ...sourcePacketOverrideRouteFields(options),
     },
     status: "approval_request",
     errorCode: null,
@@ -2545,7 +2556,7 @@ function buildApprovalRequest({ provider, cfg, mode, options, scopeInfo }) {
   const billingPath = approvalBillingPathFor(cfg);
   const routeFields = approvalRouteFields(routeStateForApproval(cfg, process.env));
   const approvalScope = approvalScopeForOptions(options);
-  const auditManifest = buildApprovalAuditManifest({ cfg, renderedPrompt, request, scopeInfo, routeFields, approvalScope });
+  const auditManifest = buildApprovalAuditManifest({ cfg, renderedPrompt, request, scopeInfo, routeFields, approvalScope, options });
   const sourcePacketFailure = sourcePacketPolicyFailureFromManifest(auditManifest);
   if (sourcePacketFailure) {
     throw runProviderFailure(
@@ -2648,7 +2659,7 @@ function diagnosticErrorSummary(errorCode, errorMessage, scopeInfo, execution, s
   ].join(" ");
 }
 
-function buildReviewMetadata(cfg, scopeInfo, execution = null, startedAt = null, endedAt = null) {
+function buildReviewMetadata(cfg, scopeInfo, execution = null, startedAt = null, endedAt = null, options = {}) {
   let routeFields;
   try {
     routeFields = approvalRouteFields(routeStateForApproval(cfg, process.env, { sourceSendApproved: !!execution?.approval_scope }));
@@ -2705,6 +2716,7 @@ function buildReviewMetadata(cfg, scopeInfo, execution = null, startedAt = null,
       sourceSendApprovalRequired: routeFields.source_send_approval_required,
       sourceSendApprovalState: routeFields.source_send_approval_state,
       providerCapabilities: providerCapabilitiesForConfig(cfg),
+      ...sourcePacketOverrideRouteFields(options),
     },
     result: execution.parsed?.result ?? "",
     status: execution.exitCode === 0 && execution.parsed?.ok === true ? "completed" : "failed",
@@ -2761,7 +2773,7 @@ function buildRuntimeDiagnostics(diagnostics) {
 }
 
 function buildRecord({ provider, cfg, mode, options, scopeInfo, execution, startedAt, endedAt }) {
-  const reviewMetadata = buildReviewMetadata(cfg, scopeInfo, execution, startedAt, endedAt);
+  const reviewMetadata = buildReviewMetadata(cfg, scopeInfo, execution, startedAt, endedAt, options);
   const processCompleted = execution.exitCode === 0 && execution.parsed?.ok === true;
   const reviewQualityState = processCompleted
     ? reviewQualityFailureState(reviewMetadata?.audit_manifest?.review_quality, {
@@ -3071,7 +3083,7 @@ async function cmdRun(options) {
         authPath = approvalAuthPathFor(cfg, process.env);
         billingPath = approvalBillingPathFor(cfg);
         routeFields = approvalRouteFields(routeStateForApproval(cfg, process.env));
-        auditManifest = buildApprovalAuditManifest({ cfg, renderedPrompt, request, scopeInfo, routeFields, approvalScope });
+        auditManifest = buildApprovalAuditManifest({ cfg, renderedPrompt, request, scopeInfo, routeFields, approvalScope, options });
         execution = sourcePacketPolicyFailureFromManifest(auditManifest);
         if (execution) execution.prompt = renderedPrompt;
       }

--- a/plugins/api-reviewers/scripts/lib/provider-route-policy.mjs
+++ b/plugins/api-reviewers/scripts/lib/provider-route-policy.mjs
@@ -38,6 +38,8 @@ export const PROVIDER_POLICY_DOMAINS = Object.freeze([
       "selected_source_bytes",
       "source_packet_within_budget",
       "source_packet_action",
+      "source_packet_override_approved",
+      "source_packet_override_source",
       "source_send_approval_required",
       "source_send_approval_state",
       "source_content_transmission",
@@ -337,7 +339,7 @@ function previousReviewQualityReasons(previousAttempt = null) {
 function sourcePacketSuggestedAction(action, provider = null) {
   const target = provider ? `${provider} ` : "";
   if (action === "narrow_source_packet") {
-    return `Do not send selected source. Narrow or shard the ${target}source packet before retrying.`;
+    return `Do not send selected source. Narrow or shard the ${target}source packet before retrying, or use --allow-large-source-packet only after explicitly confirming the larger packet is intentional.`;
   }
   if (action === "resend_confirmation_required") {
     return `Treat the previous ${target}slot as failed. Do not automatically resend selected source without explicit resend confirmation or a narrowed source packet.`;
@@ -350,6 +352,9 @@ function sourcePacketSuggestedAction(action, provider = null) {
   }
   if (action === "send_after_resend_confirmation") {
     return "Proceed after explicit resend confirmation and record the approval tuple.";
+  }
+  if (action === "send_after_source_packet_override") {
+    return "Proceed with the explicitly approved large source packet and record the override tuple.";
   }
   return null;
 }
@@ -364,12 +369,15 @@ export function evaluateSourcePacketPolicy({
   previousAttempt = null,
   resendConfirmationApproved = false,
   resumeWithoutSourceResend = false,
+  sourcePacketOverrideApproved = false,
+  sourcePacketOverrideSource = null,
 } = {}) {
   const totals = selectedSourceTotals(selectedSource);
   const packetBudgetBytes = sourcePacketBudgetBytes(providerCapabilities, routeStep);
   const resumeWithoutResendSupported = sourcePacketResumeWithoutResendSupported(providerCapabilities, routeStep);
   const effectiveSourceBearing = sourceBearing === true || totals.bytes > 0 || totals.files > 0;
   const sourcePacketWithinBudget = totals.bytes <= packetBudgetBytes;
+  const sourcePacketOverride = sourcePacketOverrideApproved === true;
   const previousSource = previousSelectedSource(previousAttempt);
   const previousTotals = selectedSourceTotals(previousSource);
   const previousHash = sourcePacketHash(previousSource);
@@ -387,6 +395,10 @@ export function evaluateSourcePacketPolicy({
     source_packet_budget_bytes: packetBudgetBytes,
     selected_source_bytes: totals.bytes,
     source_packet_within_budget: sourcePacketWithinBudget,
+    source_packet_override_approved: sourcePacketOverride,
+    source_packet_override_source: sourcePacketOverride
+      ? (sourcePacketOverrideSource ?? "unknown")
+      : null,
     resend_confirmation_required: false,
     resume_without_source_resend: resumeWithoutSourceResend === true,
     review_surface_changed: reviewSurfaceChanged,
@@ -403,7 +415,7 @@ export function evaluateSourcePacketPolicy({
     });
   }
 
-  if (!sourcePacketWithinBudget) {
+  if (!sourcePacketWithinBudget && !sourcePacketOverride) {
     const action = "narrow_source_packet";
     return Object.freeze({
       ...base,
@@ -474,11 +486,13 @@ export function evaluateSourcePacketPolicy({
     });
   }
 
+  const action = sourcePacketWithinBudget ? "send" : "send_after_source_packet_override";
   return Object.freeze({
     ...base,
     source_send_allowed: true,
-    source_packet_action: "send",
+    source_packet_action: action,
     source_content_transmission: "may_be_sent",
+    suggested_action: sourcePacketSuggestedAction(action, provider),
   });
 }
 

--- a/plugins/api-reviewers/scripts/lib/review-prompt.mjs
+++ b/plugins/api-reviewers/scripts/lib/review-prompt.mjs
@@ -1081,6 +1081,8 @@ export function buildReviewAuditManifest({
     previousAttempt: route.previousAttempt ?? null,
     resendConfirmationApproved: route.resendConfirmationApproved === true,
     resumeWithoutSourceResend: route.resumeWithoutSourceResend === true,
+    sourcePacketOverrideApproved: route.sourcePacketOverrideApproved === true,
+    sourcePacketOverrideSource: route.sourcePacketOverrideSource ?? null,
   });
   return Object.freeze({
     schema_version: REVIEW_AUDIT_MANIFEST_VERSION,

--- a/plugins/claude/scripts/claude-companion.mjs
+++ b/plugins/claude/scripts/claude-companion.mjs
@@ -2247,7 +2247,7 @@ function providerCapabilitiesForReviewAudit() {
 }
 
 function modeSendsSelectedSource(mode) {
-  return mode === "review" || mode === "adversarial-review" || mode === "custom-review";
+  return mode === "review" || mode === "adversarial-review" || mode === "custom-review" || mode === "rescue";
 }
 
 function sourceSendApprovalPreflight(authSelection, invocation, prompt, containmentPath) {

--- a/plugins/claude/scripts/claude-companion.mjs
+++ b/plugins/claude/scripts/claude-companion.mjs
@@ -455,6 +455,7 @@ function reviewAuditManifest(invocation, prompt, containmentPath, execution) {
       previousAttempt: invocation.previous_source_attempt ?? null,
       resendConfirmationApproved: invocation.resend_confirmation_approved === true,
       resumeWithoutSourceResend: invocation.resume_without_source_resend === true,
+      ...sourcePacketOverrideRouteFields(invocation),
     },
     result: execution?.parsed?.result ?? "",
     status: reviewAuditStatus(auditExecution, invocation),
@@ -464,6 +465,23 @@ function reviewAuditManifest(invocation, prompt, containmentPath, execution) {
 
 function approvalScopeForOptions(options = {}) {
   return normalizeApprovalScope(options["approval-scope"] ?? "session", fail);
+}
+
+const LARGE_SOURCE_PACKET_FLAG = "--allow-large-source-packet";
+
+function sourcePacketOverrideInvocationFields(options = {}) {
+  const approved = options["allow-large-source-packet"] === true;
+  return Object.freeze({
+    source_packet_override_approved: approved,
+    source_packet_override_source: approved ? LARGE_SOURCE_PACKET_FLAG : null,
+  });
+}
+
+function sourcePacketOverrideRouteFields(invocation = {}) {
+  return {
+    sourcePacketOverrideApproved: invocation.source_packet_override_approved === true,
+    sourcePacketOverrideSource: invocation.source_packet_override_source ?? null,
+  };
 }
 
 function approvalAuditManifest(invocation, prompt, containmentPath) {
@@ -513,6 +531,7 @@ function approvalAuditManifest(invocation, prompt, containmentPath) {
       sourceSendApprovalRequired: invocation.source_send_approval_required ?? null,
       sourceSendApprovalState: invocation.source_send_approval_state ?? null,
       providerCapabilities: providerCapabilitiesForReviewAudit(),
+      ...sourcePacketOverrideRouteFields(invocation),
     },
     result: "",
     status: "approval_request",
@@ -685,6 +704,12 @@ function writeRuntimeOptionsSidecar(workspaceRoot, jobId, options) {
     if (typeof options.resume_without_source_resend === "boolean") {
       payload.resume_without_source_resend = options.resume_without_source_resend;
     }
+    if (typeof options.source_packet_override_approved === "boolean") {
+      payload.source_packet_override_approved = options.source_packet_override_approved;
+    }
+    if (typeof options.source_packet_override_source === "string" && options.source_packet_override_source.length > 0) {
+      payload.source_packet_override_source = options.source_packet_override_source;
+    }
     writeFileSync(tmpFile, `${JSON.stringify(payload, null, 2)}\n`, { mode: 0o600, encoding: "utf8" });
     try { chmodSync(tmpFile, 0o600); } catch { /* best-effort on non-POSIX */ }
     renameSync(tmpFile, file);
@@ -726,6 +751,12 @@ function readRuntimeOptionsSidecar(workspaceRoot, jobId) {
   }
   if (typeof parsed.resume_without_source_resend === "boolean") {
     out.resume_without_source_resend = parsed.resume_without_source_resend;
+  }
+  if (typeof parsed.source_packet_override_approved === "boolean") {
+    out.source_packet_override_approved = parsed.source_packet_override_approved;
+  }
+  if (typeof parsed.source_packet_override_source === "string" && parsed.source_packet_override_source.length > 0) {
+    out.source_packet_override_source = parsed.source_packet_override_source;
   }
   if (consumed.cleanup_warning) {
     out.cleanup_warning = consumed.cleanup_warning;
@@ -800,6 +831,8 @@ function invocationFromRecord(record, fallbackAuthMode = defaultAuthMode(), runt
     previous_source_attempt: runtimeOptions.previous_source_attempt ?? null,
     resend_confirmation_approved: runtimeOptions.resend_confirmation_approved === true,
     resume_without_source_resend: runtimeOptions.resume_without_source_resend === true,
+    source_packet_override_approved: runtimeOptions.source_packet_override_approved === true,
+    source_packet_override_source: runtimeOptions.source_packet_override_source ?? null,
   });
 }
 
@@ -971,7 +1004,7 @@ function commonRunOptions(rest, { includeApproval = false } = {}) {
   if (includeApproval) valueOptions.push("approval-token", "approval-scope");
   return parseArgs(rest, {
     valueOptions,
-    booleanOptions: ["background", "foreground", "allow-bypass-permissions"],
+    booleanOptions: ["background", "foreground", "allow-bypass-permissions", "allow-large-source-packet"],
     aliasMap: {},
   });
 }
@@ -1044,6 +1077,7 @@ async function cmdApprovalRequest(rest) {
     started_at: new Date().toISOString(),
     approval_scope: approvalScope,
     approval_token: null,
+    ...sourcePacketOverrideInvocationFields(options),
   });
   invocation = invocationWithAuthSelection(invocation, authSelection);
   let containment = null;
@@ -1196,6 +1230,7 @@ async function cmdRun(rest) {
     started_at: startedAt,
     approval_scope: approvalScope,
     approval_token: options["approval-token"] ?? null,
+    ...sourcePacketOverrideInvocationFields(options),
   });
 
   // Pre-run record: status=queued. Goes to disk + state before any child
@@ -1270,6 +1305,8 @@ async function cmdRun(rest) {
         claude_project_cwd: invocation.claude_project_cwd,
         approval_scope: invocation.approval_scope,
         approval_token: invocation.approval_token,
+        source_packet_override_approved: invocation.source_packet_override_approved,
+        source_packet_override_source: invocation.source_packet_override_source,
       });
     } catch (error) {
       failBackgroundPromptSidecarWrite(workspaceRoot, invocation, error);
@@ -1952,7 +1989,7 @@ async function cmdRunWorker(rest) {
 async function cmdContinue(rest) {
   const { options, positionals } = parseArgs(rest, {
     valueOptions: ["job", "cwd", "model", "binary", "auth-mode", "timeout-ms", "lifecycle-events", "approval-token", "approval-scope"],
-    booleanOptions: ["background", "foreground", "allow-bypass-permissions", "resend-confirmation-approved"],
+    booleanOptions: ["background", "foreground", "allow-bypass-permissions", "resend-confirmation-approved", "allow-large-source-packet"],
   });
   if (!options.job) fail("bad_args", "--job <id> is required");
   if (options.background && options.foreground) {
@@ -2075,6 +2112,7 @@ async function cmdContinue(rest) {
     previous_source_attempt: previousSourceAttempt,
     resend_confirmation_approved: options["resend-confirmation-approved"] === true,
     resume_without_source_resend: resumeWithoutSourceResend,
+    ...sourcePacketOverrideInvocationFields(options),
     started_at: new Date().toISOString(),
   });
 
@@ -2149,6 +2187,8 @@ async function cmdContinue(rest) {
         previous_source_attempt: previousSourceAttempt,
         resend_confirmation_approved: options["resend-confirmation-approved"] === true,
         resume_without_source_resend: resumeWithoutSourceResend,
+        source_packet_override_approved: invocation.source_packet_override_approved,
+        source_packet_override_source: invocation.source_packet_override_source,
       });
     } catch (error) {
       failBackgroundPromptSidecarWrite(workspaceRoot, invocation, error);

--- a/plugins/claude/scripts/lib/provider-route-policy.mjs
+++ b/plugins/claude/scripts/lib/provider-route-policy.mjs
@@ -38,6 +38,8 @@ export const PROVIDER_POLICY_DOMAINS = Object.freeze([
       "selected_source_bytes",
       "source_packet_within_budget",
       "source_packet_action",
+      "source_packet_override_approved",
+      "source_packet_override_source",
       "source_send_approval_required",
       "source_send_approval_state",
       "source_content_transmission",
@@ -337,7 +339,7 @@ function previousReviewQualityReasons(previousAttempt = null) {
 function sourcePacketSuggestedAction(action, provider = null) {
   const target = provider ? `${provider} ` : "";
   if (action === "narrow_source_packet") {
-    return `Do not send selected source. Narrow or shard the ${target}source packet before retrying.`;
+    return `Do not send selected source. Narrow or shard the ${target}source packet before retrying, or use --allow-large-source-packet only after explicitly confirming the larger packet is intentional.`;
   }
   if (action === "resend_confirmation_required") {
     return `Treat the previous ${target}slot as failed. Do not automatically resend selected source without explicit resend confirmation or a narrowed source packet.`;
@@ -350,6 +352,9 @@ function sourcePacketSuggestedAction(action, provider = null) {
   }
   if (action === "send_after_resend_confirmation") {
     return "Proceed after explicit resend confirmation and record the approval tuple.";
+  }
+  if (action === "send_after_source_packet_override") {
+    return "Proceed with the explicitly approved large source packet and record the override tuple.";
   }
   return null;
 }
@@ -364,12 +369,15 @@ export function evaluateSourcePacketPolicy({
   previousAttempt = null,
   resendConfirmationApproved = false,
   resumeWithoutSourceResend = false,
+  sourcePacketOverrideApproved = false,
+  sourcePacketOverrideSource = null,
 } = {}) {
   const totals = selectedSourceTotals(selectedSource);
   const packetBudgetBytes = sourcePacketBudgetBytes(providerCapabilities, routeStep);
   const resumeWithoutResendSupported = sourcePacketResumeWithoutResendSupported(providerCapabilities, routeStep);
   const effectiveSourceBearing = sourceBearing === true || totals.bytes > 0 || totals.files > 0;
   const sourcePacketWithinBudget = totals.bytes <= packetBudgetBytes;
+  const sourcePacketOverride = sourcePacketOverrideApproved === true;
   const previousSource = previousSelectedSource(previousAttempt);
   const previousTotals = selectedSourceTotals(previousSource);
   const previousHash = sourcePacketHash(previousSource);
@@ -387,6 +395,10 @@ export function evaluateSourcePacketPolicy({
     source_packet_budget_bytes: packetBudgetBytes,
     selected_source_bytes: totals.bytes,
     source_packet_within_budget: sourcePacketWithinBudget,
+    source_packet_override_approved: sourcePacketOverride,
+    source_packet_override_source: sourcePacketOverride
+      ? (sourcePacketOverrideSource ?? "unknown")
+      : null,
     resend_confirmation_required: false,
     resume_without_source_resend: resumeWithoutSourceResend === true,
     review_surface_changed: reviewSurfaceChanged,
@@ -403,7 +415,7 @@ export function evaluateSourcePacketPolicy({
     });
   }
 
-  if (!sourcePacketWithinBudget) {
+  if (!sourcePacketWithinBudget && !sourcePacketOverride) {
     const action = "narrow_source_packet";
     return Object.freeze({
       ...base,
@@ -474,11 +486,13 @@ export function evaluateSourcePacketPolicy({
     });
   }
 
+  const action = sourcePacketWithinBudget ? "send" : "send_after_source_packet_override";
   return Object.freeze({
     ...base,
     source_send_allowed: true,
-    source_packet_action: "send",
+    source_packet_action: action,
     source_content_transmission: "may_be_sent",
+    suggested_action: sourcePacketSuggestedAction(action, provider),
   });
 }
 

--- a/plugins/claude/scripts/lib/review-prompt.mjs
+++ b/plugins/claude/scripts/lib/review-prompt.mjs
@@ -1081,6 +1081,8 @@ export function buildReviewAuditManifest({
     previousAttempt: route.previousAttempt ?? null,
     resendConfirmationApproved: route.resendConfirmationApproved === true,
     resumeWithoutSourceResend: route.resumeWithoutSourceResend === true,
+    sourcePacketOverrideApproved: route.sourcePacketOverrideApproved === true,
+    sourcePacketOverrideSource: route.sourcePacketOverrideSource ?? null,
   });
   return Object.freeze({
     schema_version: REVIEW_AUDIT_MANIFEST_VERSION,

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -1949,7 +1949,7 @@ function providerCapabilitiesForReviewAudit() {
 }
 
 function modeSendsSelectedSource(mode) {
-  return mode === "review" || mode === "adversarial-review" || mode === "custom-review";
+  return mode === "review" || mode === "adversarial-review" || mode === "custom-review" || mode === "rescue";
 }
 
 function sourceSendApprovalPreflight(authSelection, invocation, prompt, containmentPath) {

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -373,6 +373,7 @@ function reviewAuditManifest(invocation, prompt, containmentPath, execution) {
       previousAttempt: invocation.previous_source_attempt ?? null,
       resendConfirmationApproved: invocation.resend_confirmation_approved === true,
       resumeWithoutSourceResend: invocation.resume_without_source_resend === true,
+      ...sourcePacketOverrideRouteFields(invocation),
     },
     result: execution?.parsed?.result ?? "",
     status: execution?.preflight === true ? "preflight_failed" : executionStatus,
@@ -382,6 +383,23 @@ function reviewAuditManifest(invocation, prompt, containmentPath, execution) {
 
 function approvalScopeForOptions(options = {}) {
   return normalizeApprovalScope(options["approval-scope"] ?? "session", fail);
+}
+
+const LARGE_SOURCE_PACKET_FLAG = "--allow-large-source-packet";
+
+function sourcePacketOverrideInvocationFields(options = {}) {
+  const approved = options["allow-large-source-packet"] === true;
+  return Object.freeze({
+    source_packet_override_approved: approved,
+    source_packet_override_source: approved ? LARGE_SOURCE_PACKET_FLAG : null,
+  });
+}
+
+function sourcePacketOverrideRouteFields(invocation = {}) {
+  return {
+    sourcePacketOverrideApproved: invocation.source_packet_override_approved === true,
+    sourcePacketOverrideSource: invocation.source_packet_override_source ?? null,
+  };
 }
 
 function approvalAuditManifest(invocation, prompt, containmentPath) {
@@ -431,6 +449,7 @@ function approvalAuditManifest(invocation, prompt, containmentPath) {
       sourceSendApprovalRequired: invocation.source_send_approval_required ?? null,
       sourceSendApprovalState: invocation.source_send_approval_state ?? null,
       providerCapabilities: providerCapabilitiesForReviewAudit(),
+      ...sourcePacketOverrideRouteFields(invocation),
     },
     result: "",
     status: "approval_request",
@@ -633,6 +652,12 @@ function writeRuntimeOptionsSidecar(workspaceRoot, jobId, options) {
     if (typeof options.resume_without_source_resend === "boolean") {
       payload.resume_without_source_resend = options.resume_without_source_resend;
     }
+    if (typeof options.source_packet_override_approved === "boolean") {
+      payload.source_packet_override_approved = options.source_packet_override_approved;
+    }
+    if (typeof options.source_packet_override_source === "string" && options.source_packet_override_source.length > 0) {
+      payload.source_packet_override_source = options.source_packet_override_source;
+    }
     writeFileSync(tmpFile, `${JSON.stringify(payload, null, 2)}\n`, { mode: 0o600, encoding: "utf8" });
     try { chmodSync(tmpFile, 0o600); } catch { /* best-effort on non-POSIX */ }
     renameSync(tmpFile, file);
@@ -663,6 +688,12 @@ function readRuntimeOptionsSidecar(workspaceRoot, jobId) {
   }
   if (typeof parsed.resume_without_source_resend === "boolean") {
     options.resume_without_source_resend = parsed.resume_without_source_resend;
+  }
+  if (typeof parsed.source_packet_override_approved === "boolean") {
+    options.source_packet_override_approved = parsed.source_packet_override_approved;
+  }
+  if (typeof parsed.source_packet_override_source === "string" && parsed.source_packet_override_source.length > 0) {
+    options.source_packet_override_source = parsed.source_packet_override_source;
   }
   if (consumed.cleanup_warning) {
     options.cleanup_warning = consumed.cleanup_warning;
@@ -722,6 +753,8 @@ function invocationFromRecord(record, fallbackAuthMode = defaultAuthMode(), runt
     previous_source_attempt: runtimeOptions.previous_source_attempt ?? null,
     resend_confirmation_approved: runtimeOptions.resend_confirmation_approved === true,
     resume_without_source_resend: runtimeOptions.resume_without_source_resend === true,
+    source_packet_override_approved: runtimeOptions.source_packet_override_approved === true,
+    source_packet_override_source: runtimeOptions.source_packet_override_source ?? null,
   });
 }
 
@@ -870,7 +903,7 @@ function cmdPreflight(rest) {
 async function cmdApprovalRequest(rest) {
   const { options, positionals } = parseArgs(rest, {
     valueOptions: ["mode", "model", "cwd", "binary", "scope-base", "scope-paths", "override-dispose", "auth-mode", "timeout-ms", "approval-scope"],
-    booleanOptions: [],
+    booleanOptions: ["allow-large-source-packet"],
   });
   const mode = options.mode;
   if (!mode || !PREFLIGHT_MODES.includes(mode)) {
@@ -926,6 +959,7 @@ async function cmdApprovalRequest(rest) {
     started_at: new Date().toISOString(),
     approval_scope: approvalScope,
     approval_token: null,
+    ...sourcePacketOverrideInvocationFields(options),
   });
   invocation = invocationWithAuthSelection(invocation, authSelection);
 
@@ -981,7 +1015,7 @@ async function cmdApprovalRequest(rest) {
 async function cmdRun(rest) {
   const { options, positionals } = parseArgs(rest, {
     valueOptions: ["mode", "model", "cwd", "binary", "scope-base", "scope-paths", "override-dispose", "auth-mode", "timeout-ms", "lifecycle-events", "approval-token", "approval-scope"],
-    booleanOptions: ["background", "foreground"],
+    booleanOptions: ["background", "foreground", "allow-large-source-packet"],
   });
   const mode = options.mode;
   if (!mode || !RUN_MODES.includes(mode)) {
@@ -1052,6 +1086,7 @@ async function cmdRun(rest) {
     approval_scope: approvalScope,
     approval_token: options["approval-token"] ?? null,
     started_at: new Date().toISOString(),
+    ...sourcePacketOverrideInvocationFields(options),
   });
   invocation = invocationWithAuthSelection(invocation, authSelection);
 
@@ -1105,6 +1140,8 @@ async function cmdRun(rest) {
         timeout_ms: timeoutMs,
         approval_scope: invocation.approval_scope,
         approval_token: invocation.approval_token,
+        source_packet_override_approved: invocation.source_packet_override_approved,
+        source_packet_override_source: invocation.source_packet_override_source,
       });
     } catch (error) {
       failBackgroundPromptSidecarWrite(workspaceRoot, invocation, error);
@@ -1663,7 +1700,7 @@ async function cmdRunWorker(rest) {
 async function cmdContinue(rest) {
   const { options, positionals } = parseArgs(rest, {
     valueOptions: ["job", "cwd", "model", "binary", "auth-mode", "timeout-ms", "lifecycle-events", "approval-token", "approval-scope"],
-    booleanOptions: ["background", "foreground", "resend-confirmation-approved"],
+    booleanOptions: ["background", "foreground", "resend-confirmation-approved", "allow-large-source-packet"],
   });
   if (!options.job) fail("bad_args", "--job <id> is required");
   if (options.background && options.foreground) {
@@ -1768,6 +1805,7 @@ async function cmdContinue(rest) {
     previous_source_attempt: previousSourceAttempt,
     resend_confirmation_approved: options["resend-confirmation-approved"] === true,
     resume_without_source_resend: resumeWithoutSourceResend,
+    ...sourcePacketOverrideInvocationFields(options),
     started_at: new Date().toISOString(),
   });
   invocation = invocationWithAuthSelection(invocation, authSelection);
@@ -1825,6 +1863,8 @@ async function cmdContinue(rest) {
         previous_source_attempt: previousSourceAttempt,
         resend_confirmation_approved: options["resend-confirmation-approved"] === true,
         resume_without_source_resend: resumeWithoutSourceResend,
+        source_packet_override_approved: invocation.source_packet_override_approved,
+        source_packet_override_source: invocation.source_packet_override_source,
       });
     } catch (error) {
       failBackgroundPromptSidecarWrite(workspaceRoot, invocation, error);

--- a/plugins/gemini/scripts/lib/provider-route-policy.mjs
+++ b/plugins/gemini/scripts/lib/provider-route-policy.mjs
@@ -38,6 +38,8 @@ export const PROVIDER_POLICY_DOMAINS = Object.freeze([
       "selected_source_bytes",
       "source_packet_within_budget",
       "source_packet_action",
+      "source_packet_override_approved",
+      "source_packet_override_source",
       "source_send_approval_required",
       "source_send_approval_state",
       "source_content_transmission",
@@ -337,7 +339,7 @@ function previousReviewQualityReasons(previousAttempt = null) {
 function sourcePacketSuggestedAction(action, provider = null) {
   const target = provider ? `${provider} ` : "";
   if (action === "narrow_source_packet") {
-    return `Do not send selected source. Narrow or shard the ${target}source packet before retrying.`;
+    return `Do not send selected source. Narrow or shard the ${target}source packet before retrying, or use --allow-large-source-packet only after explicitly confirming the larger packet is intentional.`;
   }
   if (action === "resend_confirmation_required") {
     return `Treat the previous ${target}slot as failed. Do not automatically resend selected source without explicit resend confirmation or a narrowed source packet.`;
@@ -350,6 +352,9 @@ function sourcePacketSuggestedAction(action, provider = null) {
   }
   if (action === "send_after_resend_confirmation") {
     return "Proceed after explicit resend confirmation and record the approval tuple.";
+  }
+  if (action === "send_after_source_packet_override") {
+    return "Proceed with the explicitly approved large source packet and record the override tuple.";
   }
   return null;
 }
@@ -364,12 +369,15 @@ export function evaluateSourcePacketPolicy({
   previousAttempt = null,
   resendConfirmationApproved = false,
   resumeWithoutSourceResend = false,
+  sourcePacketOverrideApproved = false,
+  sourcePacketOverrideSource = null,
 } = {}) {
   const totals = selectedSourceTotals(selectedSource);
   const packetBudgetBytes = sourcePacketBudgetBytes(providerCapabilities, routeStep);
   const resumeWithoutResendSupported = sourcePacketResumeWithoutResendSupported(providerCapabilities, routeStep);
   const effectiveSourceBearing = sourceBearing === true || totals.bytes > 0 || totals.files > 0;
   const sourcePacketWithinBudget = totals.bytes <= packetBudgetBytes;
+  const sourcePacketOverride = sourcePacketOverrideApproved === true;
   const previousSource = previousSelectedSource(previousAttempt);
   const previousTotals = selectedSourceTotals(previousSource);
   const previousHash = sourcePacketHash(previousSource);
@@ -387,6 +395,10 @@ export function evaluateSourcePacketPolicy({
     source_packet_budget_bytes: packetBudgetBytes,
     selected_source_bytes: totals.bytes,
     source_packet_within_budget: sourcePacketWithinBudget,
+    source_packet_override_approved: sourcePacketOverride,
+    source_packet_override_source: sourcePacketOverride
+      ? (sourcePacketOverrideSource ?? "unknown")
+      : null,
     resend_confirmation_required: false,
     resume_without_source_resend: resumeWithoutSourceResend === true,
     review_surface_changed: reviewSurfaceChanged,
@@ -403,7 +415,7 @@ export function evaluateSourcePacketPolicy({
     });
   }
 
-  if (!sourcePacketWithinBudget) {
+  if (!sourcePacketWithinBudget && !sourcePacketOverride) {
     const action = "narrow_source_packet";
     return Object.freeze({
       ...base,
@@ -474,11 +486,13 @@ export function evaluateSourcePacketPolicy({
     });
   }
 
+  const action = sourcePacketWithinBudget ? "send" : "send_after_source_packet_override";
   return Object.freeze({
     ...base,
     source_send_allowed: true,
-    source_packet_action: "send",
+    source_packet_action: action,
     source_content_transmission: "may_be_sent",
+    suggested_action: sourcePacketSuggestedAction(action, provider),
   });
 }
 

--- a/plugins/gemini/scripts/lib/review-prompt.mjs
+++ b/plugins/gemini/scripts/lib/review-prompt.mjs
@@ -1081,6 +1081,8 @@ export function buildReviewAuditManifest({
     previousAttempt: route.previousAttempt ?? null,
     resendConfirmationApproved: route.resendConfirmationApproved === true,
     resumeWithoutSourceResend: route.resumeWithoutSourceResend === true,
+    sourcePacketOverrideApproved: route.sourcePacketOverrideApproved === true,
+    sourcePacketOverrideSource: route.sourcePacketOverrideSource ?? null,
   });
   return Object.freeze({
     schema_version: REVIEW_AUDIT_MANIFEST_VERSION,

--- a/plugins/grok/scripts/grok-web-reviewer.mjs
+++ b/plugins/grok/scripts/grok-web-reviewer.mjs
@@ -1560,7 +1560,17 @@ function modeSendsSelectedSource(mode) {
   return VALID_MODES.has(mode);
 }
 
-function sourcePacketPolicyPreflight({ cfg, mode, prompt, scopeInfo }) {
+const LARGE_SOURCE_PACKET_FLAG = "--allow-large-source-packet";
+
+function sourcePacketOverrideRouteFields(options = {}) {
+  const approved = options["allow-large-source-packet"] === true;
+  return {
+    sourcePacketOverrideApproved: approved,
+    sourcePacketOverrideSource: approved ? LARGE_SOURCE_PACKET_FLAG : null,
+  };
+}
+
+function sourcePacketPolicyPreflight({ cfg, mode, prompt, scopeInfo, options = {} }) {
   const providerCapabilities = providerCapabilitiesForConfig(cfg);
   const sourceBearing = modeSendsSelectedSource(mode);
   const route = selectProviderRoute({
@@ -1616,6 +1626,7 @@ function sourcePacketPolicyPreflight({ cfg, mode, prompt, scopeInfo }) {
       sourceSendApprovalRequired: route.source_send_approval_required,
       sourceSendApprovalState: route.source_send_approval_state,
       providerCapabilities,
+      ...sourcePacketOverrideRouteFields(options),
     },
     status: "preflight_failed",
     errorCode: "source_packet_policy_preflight",
@@ -3154,7 +3165,7 @@ function buildTerminalExternalReview({ cfg, mode, options, scopeInfo, execution,
   });
 }
 
-function buildReviewMetadata(cfg, scopeInfo, execution = null, startedAt = null, endedAt = null) {
+function buildReviewMetadata(cfg, scopeInfo, execution = null, startedAt = null, endedAt = null, options = {}) {
   const sourceBearing = execution?.payload_sent ?? (execution?.exitCode === 0 && execution?.parsed?.ok === true);
   const processCompleted = execution?.exitCode === 0 && execution?.parsed?.ok === true;
   const sourceContentTransmission = sourceContentTransmissionForPayload({
@@ -3219,6 +3230,7 @@ function buildReviewMetadata(cfg, scopeInfo, execution = null, startedAt = null,
       sourceSendApprovalRequired: route.source_send_approval_required,
       sourceSendApprovalState: route.source_send_approval_state,
       providerCapabilities: providerCapabilitiesForConfig(cfg),
+      ...sourcePacketOverrideRouteFields(options),
     },
     result: execution.parsed?.result ?? "",
     status: execution.exitCode === 0 && execution.parsed?.ok === true ? "completed" : "failed",
@@ -3242,7 +3254,7 @@ function buildReviewMetadata(cfg, scopeInfo, execution = null, startedAt = null,
 }
 
 function buildRecord({ cfg, mode, options, scopeInfo, execution, startedAt, endedAt }) {
-  const reviewMetadata = buildReviewMetadata(cfg, scopeInfo, execution, startedAt, endedAt);
+  const reviewMetadata = buildReviewMetadata(cfg, scopeInfo, execution, startedAt, endedAt, options);
   const processCompleted = execution.exitCode === 0 && execution.parsed?.ok === true;
   const redactSensitiveText = buildPrivacyRedactor({
     env: process.env,
@@ -4383,7 +4395,7 @@ async function cmdRun(options) {
     let webReadiness = null;
     try {
       prompt = promptFor(cfg, mode, options.prompt ?? "", scopeInfo);
-      execution = sourcePacketPolicyPreflight({ cfg, mode, prompt, scopeInfo });
+      execution = sourcePacketPolicyPreflight({ cfg, mode, prompt, scopeInfo, options });
       if (!execution && prompt.length > cfg.max_prompt_chars) {
         const capName = cfg.transport === "cli" ? "GROK_CLI_MAX_PROMPT_CHARS" : "GROK_WEB_MAX_PROMPT_CHARS";
         execution = providerFailure("prompt_too_large", redactor()(`prompt_too_large:${prompt.length} chars exceeds ${capName}=${cfg.max_prompt_chars}`), null, null, false);
@@ -4441,7 +4453,7 @@ async function cmdRun(options) {
           const cliFailure = execution;
           cfg = webAutoFallbackConfig(process.env, cliFailure.parsed?.reason ?? "grok_cli_unavailable");
           prompt = promptFor(cfg, mode, options.prompt ?? "", scopeInfo);
-          const fallbackSourcePacketPreflight = sourcePacketPolicyPreflight({ cfg, mode, prompt, scopeInfo });
+          const fallbackSourcePacketPreflight = sourcePacketPolicyPreflight({ cfg, mode, prompt, scopeInfo, options });
           if (fallbackSourcePacketPreflight) {
             execution = fallbackSourcePacketPreflight;
             execution.diagnostics = {

--- a/plugins/grok/scripts/lib/provider-route-policy.mjs
+++ b/plugins/grok/scripts/lib/provider-route-policy.mjs
@@ -38,6 +38,8 @@ export const PROVIDER_POLICY_DOMAINS = Object.freeze([
       "selected_source_bytes",
       "source_packet_within_budget",
       "source_packet_action",
+      "source_packet_override_approved",
+      "source_packet_override_source",
       "source_send_approval_required",
       "source_send_approval_state",
       "source_content_transmission",
@@ -337,7 +339,7 @@ function previousReviewQualityReasons(previousAttempt = null) {
 function sourcePacketSuggestedAction(action, provider = null) {
   const target = provider ? `${provider} ` : "";
   if (action === "narrow_source_packet") {
-    return `Do not send selected source. Narrow or shard the ${target}source packet before retrying.`;
+    return `Do not send selected source. Narrow or shard the ${target}source packet before retrying, or use --allow-large-source-packet only after explicitly confirming the larger packet is intentional.`;
   }
   if (action === "resend_confirmation_required") {
     return `Treat the previous ${target}slot as failed. Do not automatically resend selected source without explicit resend confirmation or a narrowed source packet.`;
@@ -350,6 +352,9 @@ function sourcePacketSuggestedAction(action, provider = null) {
   }
   if (action === "send_after_resend_confirmation") {
     return "Proceed after explicit resend confirmation and record the approval tuple.";
+  }
+  if (action === "send_after_source_packet_override") {
+    return "Proceed with the explicitly approved large source packet and record the override tuple.";
   }
   return null;
 }
@@ -364,12 +369,15 @@ export function evaluateSourcePacketPolicy({
   previousAttempt = null,
   resendConfirmationApproved = false,
   resumeWithoutSourceResend = false,
+  sourcePacketOverrideApproved = false,
+  sourcePacketOverrideSource = null,
 } = {}) {
   const totals = selectedSourceTotals(selectedSource);
   const packetBudgetBytes = sourcePacketBudgetBytes(providerCapabilities, routeStep);
   const resumeWithoutResendSupported = sourcePacketResumeWithoutResendSupported(providerCapabilities, routeStep);
   const effectiveSourceBearing = sourceBearing === true || totals.bytes > 0 || totals.files > 0;
   const sourcePacketWithinBudget = totals.bytes <= packetBudgetBytes;
+  const sourcePacketOverride = sourcePacketOverrideApproved === true;
   const previousSource = previousSelectedSource(previousAttempt);
   const previousTotals = selectedSourceTotals(previousSource);
   const previousHash = sourcePacketHash(previousSource);
@@ -387,6 +395,10 @@ export function evaluateSourcePacketPolicy({
     source_packet_budget_bytes: packetBudgetBytes,
     selected_source_bytes: totals.bytes,
     source_packet_within_budget: sourcePacketWithinBudget,
+    source_packet_override_approved: sourcePacketOverride,
+    source_packet_override_source: sourcePacketOverride
+      ? (sourcePacketOverrideSource ?? "unknown")
+      : null,
     resend_confirmation_required: false,
     resume_without_source_resend: resumeWithoutSourceResend === true,
     review_surface_changed: reviewSurfaceChanged,
@@ -403,7 +415,7 @@ export function evaluateSourcePacketPolicy({
     });
   }
 
-  if (!sourcePacketWithinBudget) {
+  if (!sourcePacketWithinBudget && !sourcePacketOverride) {
     const action = "narrow_source_packet";
     return Object.freeze({
       ...base,
@@ -474,11 +486,13 @@ export function evaluateSourcePacketPolicy({
     });
   }
 
+  const action = sourcePacketWithinBudget ? "send" : "send_after_source_packet_override";
   return Object.freeze({
     ...base,
     source_send_allowed: true,
-    source_packet_action: "send",
+    source_packet_action: action,
     source_content_transmission: "may_be_sent",
+    suggested_action: sourcePacketSuggestedAction(action, provider),
   });
 }
 

--- a/plugins/grok/scripts/lib/review-prompt.mjs
+++ b/plugins/grok/scripts/lib/review-prompt.mjs
@@ -1081,6 +1081,8 @@ export function buildReviewAuditManifest({
     previousAttempt: route.previousAttempt ?? null,
     resendConfirmationApproved: route.resendConfirmationApproved === true,
     resumeWithoutSourceResend: route.resumeWithoutSourceResend === true,
+    sourcePacketOverrideApproved: route.sourcePacketOverrideApproved === true,
+    sourcePacketOverrideSource: route.sourcePacketOverrideSource ?? null,
   });
   return Object.freeze({
     schema_version: REVIEW_AUDIT_MANIFEST_VERSION,

--- a/plugins/kimi/scripts/kimi-companion.mjs
+++ b/plugins/kimi/scripts/kimi-companion.mjs
@@ -443,7 +443,7 @@ function withMutationReviewFailure(manifest, mutations) {
 }
 
 function modeSendsSelectedSource(mode) {
-  return mode === "review" || mode === "adversarial-review" || mode === "custom-review";
+  return mode === "review" || mode === "adversarial-review" || mode === "custom-review" || mode === "rescue";
 }
 
 function scopedTargetPromptForOrExit(invocation, profile, userPrompt, lifecycleEvents) {

--- a/plugins/kimi/scripts/kimi-companion.mjs
+++ b/plugins/kimi/scripts/kimi-companion.mjs
@@ -361,6 +361,8 @@ function reviewAuditManifest(invocation, prompt, containmentPath, execution) {
       previousAttempt: invocation.previous_source_attempt ?? null,
       resendConfirmationApproved: invocation.resend_confirmation_approved === true,
       resumeWithoutSourceResend: invocation.resume_without_source_resend === true,
+      sourcePacketOverrideApproved: invocation.source_packet_override_approved === true,
+      sourcePacketOverrideSource: invocation.source_packet_override_source ?? null,
     },
     result: execution?.parsed?.result ?? "",
     status: execution?.preflight === true ? "preflight_failed" : executionStatus,
@@ -407,6 +409,16 @@ function subscriptionRouteFacts({ sourceBearing = false } = {}) {
     source_send_approval_required: route.source_send_approval_required,
     source_send_approval_state: route.source_send_approval_state,
   };
+}
+
+const LARGE_SOURCE_PACKET_FLAG = "--allow-large-source-packet";
+
+function sourcePacketOverrideInvocationFields(options = {}) {
+  const approved = options["allow-large-source-packet"] === true;
+  return Object.freeze({
+    source_packet_override_approved: approved,
+    source_packet_override_source: approved ? LARGE_SOURCE_PACKET_FLAG : null,
+  });
 }
 
 function withMutationReviewFailure(manifest, mutations) {
@@ -672,6 +684,12 @@ function writeRuntimeOptionsSidecar(workspaceRoot, jobId, options) {
   if (typeof options.resume_without_source_resend === "boolean") {
     payload.resume_without_source_resend = options.resume_without_source_resend;
   }
+  if (typeof options.source_packet_override_approved === "boolean") {
+    payload.source_packet_override_approved = options.source_packet_override_approved;
+  }
+  if (typeof options.source_packet_override_source === "string" && options.source_packet_override_source.length > 0) {
+    payload.source_packet_override_source = options.source_packet_override_source;
+  }
   try {
     writeFileSync(tmpFile, `${JSON.stringify(payload, null, 2)}\n`, { mode: 0o600, encoding: "utf8" });
     try { chmodSync(tmpFile, 0o600); } catch { /* best-effort on non-POSIX */ }
@@ -700,6 +718,12 @@ function readRuntimeOptionsSidecar(workspaceRoot, jobId) {
   }
   if (typeof parsed.resume_without_source_resend === "boolean") {
     options.resume_without_source_resend = parsed.resume_without_source_resend;
+  }
+  if (typeof parsed.source_packet_override_approved === "boolean") {
+    options.source_packet_override_approved = parsed.source_packet_override_approved;
+  }
+  if (typeof parsed.source_packet_override_source === "string" && parsed.source_packet_override_source.length > 0) {
+    options.source_packet_override_source = parsed.source_packet_override_source;
   }
   if (consumed.cleanup_warning) {
     options.cleanup_warning = consumed.cleanup_warning;
@@ -737,6 +761,8 @@ function invocationFromRecord(record, runtimeOptions = {}) {
     previous_source_attempt: runtimeOptions.previous_source_attempt ?? null,
     resend_confirmation_approved: runtimeOptions.resend_confirmation_approved === true,
     resume_without_source_resend: runtimeOptions.resume_without_source_resend === true,
+    source_packet_override_approved: runtimeOptions.source_packet_override_approved === true,
+    source_packet_override_source: runtimeOptions.source_packet_override_source ?? null,
     runtime_options_cleanup_warning: runtimeOptions.cleanup_warning ?? null,
     runtime_options_cleanup_path: runtimeOptions.cleanup_warning_path ?? null,
     started_at: record.started_at,
@@ -917,7 +943,7 @@ function cmdPreflight(rest) {
 async function cmdRun(rest) {
   const { options, positionals } = parseArgs(rest, {
     valueOptions: ["mode", "model", "cwd", "binary", "scope-base", "scope-paths", "override-dispose", "timeout-ms", "max-steps-per-turn", "lifecycle-events", "auth-mode"],
-    booleanOptions: ["background", "foreground"],
+    booleanOptions: ["background", "foreground", "allow-large-source-packet"],
   });
   rejectUnsupportedAuthMode(options);
   const mode = options.mode;
@@ -984,11 +1010,17 @@ async function cmdRun(rest) {
     timeout_ms: timeoutMs,
     max_steps_per_turn: maxStepsPerTurn,
     ...subscriptionRouteFacts({ sourceBearing: modeSendsSelectedSource(mode) }),
+    ...sourcePacketOverrideInvocationFields(options),
     started_at: new Date().toISOString(),
   });
 
   const queuedRecord = buildJobRecord(invocation, null, []);
-  writeRuntimeOptionsSidecar(workspaceRoot, jobId, { timeout_ms: timeoutMs, max_steps_per_turn: maxStepsPerTurn });
+  writeRuntimeOptionsSidecar(workspaceRoot, jobId, {
+    timeout_ms: timeoutMs,
+    max_steps_per_turn: maxStepsPerTurn,
+    source_packet_override_approved: invocation.source_packet_override_approved,
+    source_packet_override_source: invocation.source_packet_override_source,
+  });
   writeJobFile(workspaceRoot, jobId, queuedRecord);
   upsertJob(workspaceRoot, queuedRecord);
   const targetPrompt = scopedTargetPromptForOrExit(invocation, profile, prompt, lifecycleEvents);
@@ -1458,7 +1490,7 @@ async function cmdRunWorker(rest) {
 async function cmdContinue(rest) {
   const { options, positionals } = parseArgs(rest, {
     valueOptions: ["job", "cwd", "model", "binary", "timeout-ms", "max-steps-per-turn", "lifecycle-events", "auth-mode"],
-    booleanOptions: ["background", "foreground", "resend-confirmation-approved"],
+    booleanOptions: ["background", "foreground", "resend-confirmation-approved", "allow-large-source-packet"],
   });
   rejectUnsupportedAuthMode(options);
   if (!options.job) fail("bad_args", "--job <id> is required");
@@ -1557,6 +1589,7 @@ async function cmdContinue(rest) {
     previous_source_attempt: previousSourceAttempt,
     resend_confirmation_approved: options["resend-confirmation-approved"] === true,
     resume_without_source_resend: resumeWithoutSourceResend,
+    ...sourcePacketOverrideInvocationFields(options),
     started_at: new Date().toISOString(),
   });
 
@@ -1567,6 +1600,8 @@ async function cmdContinue(rest) {
     previous_source_attempt: previousSourceAttempt,
     resend_confirmation_approved: options["resend-confirmation-approved"] === true,
     resume_without_source_resend: resumeWithoutSourceResend,
+    source_packet_override_approved: invocation.source_packet_override_approved,
+    source_packet_override_source: invocation.source_packet_override_source,
   });
   writeJobFile(workspaceRoot, newJobId_, queuedRecord);
   upsertJob(workspaceRoot, queuedRecord);

--- a/plugins/kimi/scripts/lib/provider-route-policy.mjs
+++ b/plugins/kimi/scripts/lib/provider-route-policy.mjs
@@ -38,6 +38,8 @@ export const PROVIDER_POLICY_DOMAINS = Object.freeze([
       "selected_source_bytes",
       "source_packet_within_budget",
       "source_packet_action",
+      "source_packet_override_approved",
+      "source_packet_override_source",
       "source_send_approval_required",
       "source_send_approval_state",
       "source_content_transmission",
@@ -337,7 +339,7 @@ function previousReviewQualityReasons(previousAttempt = null) {
 function sourcePacketSuggestedAction(action, provider = null) {
   const target = provider ? `${provider} ` : "";
   if (action === "narrow_source_packet") {
-    return `Do not send selected source. Narrow or shard the ${target}source packet before retrying.`;
+    return `Do not send selected source. Narrow or shard the ${target}source packet before retrying, or use --allow-large-source-packet only after explicitly confirming the larger packet is intentional.`;
   }
   if (action === "resend_confirmation_required") {
     return `Treat the previous ${target}slot as failed. Do not automatically resend selected source without explicit resend confirmation or a narrowed source packet.`;
@@ -350,6 +352,9 @@ function sourcePacketSuggestedAction(action, provider = null) {
   }
   if (action === "send_after_resend_confirmation") {
     return "Proceed after explicit resend confirmation and record the approval tuple.";
+  }
+  if (action === "send_after_source_packet_override") {
+    return "Proceed with the explicitly approved large source packet and record the override tuple.";
   }
   return null;
 }
@@ -364,12 +369,15 @@ export function evaluateSourcePacketPolicy({
   previousAttempt = null,
   resendConfirmationApproved = false,
   resumeWithoutSourceResend = false,
+  sourcePacketOverrideApproved = false,
+  sourcePacketOverrideSource = null,
 } = {}) {
   const totals = selectedSourceTotals(selectedSource);
   const packetBudgetBytes = sourcePacketBudgetBytes(providerCapabilities, routeStep);
   const resumeWithoutResendSupported = sourcePacketResumeWithoutResendSupported(providerCapabilities, routeStep);
   const effectiveSourceBearing = sourceBearing === true || totals.bytes > 0 || totals.files > 0;
   const sourcePacketWithinBudget = totals.bytes <= packetBudgetBytes;
+  const sourcePacketOverride = sourcePacketOverrideApproved === true;
   const previousSource = previousSelectedSource(previousAttempt);
   const previousTotals = selectedSourceTotals(previousSource);
   const previousHash = sourcePacketHash(previousSource);
@@ -387,6 +395,10 @@ export function evaluateSourcePacketPolicy({
     source_packet_budget_bytes: packetBudgetBytes,
     selected_source_bytes: totals.bytes,
     source_packet_within_budget: sourcePacketWithinBudget,
+    source_packet_override_approved: sourcePacketOverride,
+    source_packet_override_source: sourcePacketOverride
+      ? (sourcePacketOverrideSource ?? "unknown")
+      : null,
     resend_confirmation_required: false,
     resume_without_source_resend: resumeWithoutSourceResend === true,
     review_surface_changed: reviewSurfaceChanged,
@@ -403,7 +415,7 @@ export function evaluateSourcePacketPolicy({
     });
   }
 
-  if (!sourcePacketWithinBudget) {
+  if (!sourcePacketWithinBudget && !sourcePacketOverride) {
     const action = "narrow_source_packet";
     return Object.freeze({
       ...base,
@@ -474,11 +486,13 @@ export function evaluateSourcePacketPolicy({
     });
   }
 
+  const action = sourcePacketWithinBudget ? "send" : "send_after_source_packet_override";
   return Object.freeze({
     ...base,
     source_send_allowed: true,
-    source_packet_action: "send",
+    source_packet_action: action,
     source_content_transmission: "may_be_sent",
+    suggested_action: sourcePacketSuggestedAction(action, provider),
   });
 }
 

--- a/plugins/kimi/scripts/lib/review-prompt.mjs
+++ b/plugins/kimi/scripts/lib/review-prompt.mjs
@@ -1081,6 +1081,8 @@ export function buildReviewAuditManifest({
     previousAttempt: route.previousAttempt ?? null,
     resendConfirmationApproved: route.resendConfirmationApproved === true,
     resumeWithoutSourceResend: route.resumeWithoutSourceResend === true,
+    sourcePacketOverrideApproved: route.sourcePacketOverrideApproved === true,
+    sourcePacketOverrideSource: route.sourcePacketOverrideSource ?? null,
   });
   return Object.freeze({
     schema_version: REVIEW_AUDIT_MANIFEST_VERSION,

--- a/scripts/lib/provider-route-policy.mjs
+++ b/scripts/lib/provider-route-policy.mjs
@@ -38,6 +38,8 @@ export const PROVIDER_POLICY_DOMAINS = Object.freeze([
       "selected_source_bytes",
       "source_packet_within_budget",
       "source_packet_action",
+      "source_packet_override_approved",
+      "source_packet_override_source",
       "source_send_approval_required",
       "source_send_approval_state",
       "source_content_transmission",
@@ -337,7 +339,7 @@ function previousReviewQualityReasons(previousAttempt = null) {
 function sourcePacketSuggestedAction(action, provider = null) {
   const target = provider ? `${provider} ` : "";
   if (action === "narrow_source_packet") {
-    return `Do not send selected source. Narrow or shard the ${target}source packet before retrying.`;
+    return `Do not send selected source. Narrow or shard the ${target}source packet before retrying, or use --allow-large-source-packet only after explicitly confirming the larger packet is intentional.`;
   }
   if (action === "resend_confirmation_required") {
     return `Treat the previous ${target}slot as failed. Do not automatically resend selected source without explicit resend confirmation or a narrowed source packet.`;
@@ -350,6 +352,9 @@ function sourcePacketSuggestedAction(action, provider = null) {
   }
   if (action === "send_after_resend_confirmation") {
     return "Proceed after explicit resend confirmation and record the approval tuple.";
+  }
+  if (action === "send_after_source_packet_override") {
+    return "Proceed with the explicitly approved large source packet and record the override tuple.";
   }
   return null;
 }
@@ -364,12 +369,15 @@ export function evaluateSourcePacketPolicy({
   previousAttempt = null,
   resendConfirmationApproved = false,
   resumeWithoutSourceResend = false,
+  sourcePacketOverrideApproved = false,
+  sourcePacketOverrideSource = null,
 } = {}) {
   const totals = selectedSourceTotals(selectedSource);
   const packetBudgetBytes = sourcePacketBudgetBytes(providerCapabilities, routeStep);
   const resumeWithoutResendSupported = sourcePacketResumeWithoutResendSupported(providerCapabilities, routeStep);
   const effectiveSourceBearing = sourceBearing === true || totals.bytes > 0 || totals.files > 0;
   const sourcePacketWithinBudget = totals.bytes <= packetBudgetBytes;
+  const sourcePacketOverride = sourcePacketOverrideApproved === true;
   const previousSource = previousSelectedSource(previousAttempt);
   const previousTotals = selectedSourceTotals(previousSource);
   const previousHash = sourcePacketHash(previousSource);
@@ -387,6 +395,10 @@ export function evaluateSourcePacketPolicy({
     source_packet_budget_bytes: packetBudgetBytes,
     selected_source_bytes: totals.bytes,
     source_packet_within_budget: sourcePacketWithinBudget,
+    source_packet_override_approved: sourcePacketOverride,
+    source_packet_override_source: sourcePacketOverride
+      ? (sourcePacketOverrideSource ?? "unknown")
+      : null,
     resend_confirmation_required: false,
     resume_without_source_resend: resumeWithoutSourceResend === true,
     review_surface_changed: reviewSurfaceChanged,
@@ -403,7 +415,7 @@ export function evaluateSourcePacketPolicy({
     });
   }
 
-  if (!sourcePacketWithinBudget) {
+  if (!sourcePacketWithinBudget && !sourcePacketOverride) {
     const action = "narrow_source_packet";
     return Object.freeze({
       ...base,
@@ -474,11 +486,13 @@ export function evaluateSourcePacketPolicy({
     });
   }
 
+  const action = sourcePacketWithinBudget ? "send" : "send_after_source_packet_override";
   return Object.freeze({
     ...base,
     source_send_allowed: true,
-    source_packet_action: "send",
+    source_packet_action: action,
     source_content_transmission: "may_be_sent",
+    suggested_action: sourcePacketSuggestedAction(action, provider),
   });
 }
 

--- a/scripts/lib/review-prompt.mjs
+++ b/scripts/lib/review-prompt.mjs
@@ -1081,6 +1081,8 @@ export function buildReviewAuditManifest({
     previousAttempt: route.previousAttempt ?? null,
     resendConfirmationApproved: route.resendConfirmationApproved === true,
     resumeWithoutSourceResend: route.resumeWithoutSourceResend === true,
+    sourcePacketOverrideApproved: route.sourcePacketOverrideApproved === true,
+    sourcePacketOverrideSource: route.sourcePacketOverrideSource ?? null,
   });
   return Object.freeze({
     schema_version: REVIEW_AUDIT_MANIFEST_VERSION,

--- a/specs/171-provider-architecture-parity/provider-parity-table.json
+++ b/specs/171-provider-architecture-parity/provider-parity-table.json
@@ -43,7 +43,7 @@
       "name": "packet budgets",
       "module": "scripts/lib/review-prompt.mjs",
       "interface": "buildReviewPrompt, buildReviewAuditManifest, evaluateSourcePacketPolicy",
-      "implementation": "Shared source packet policy records source_packet_budget_bytes, selected_source_bytes, source_packet_within_budget, source_packet_action, resend_confirmation_required, review_surface_changed, and source_content_transmission. It blocks over-budget source-bearing packets before source send, blocks automatic resend after source-sent failures unless explicitly confirmed or narrowed, uses shared git diff packets for branch-diff review across subscription and direct API paths, and permits same-session no-source repair for substantive invalid-verdict prose without losing the original source attempt across failed no-source repair chains.",
+      "implementation": "Shared source packet policy records source_packet_budget_bytes, selected_source_bytes, source_packet_within_budget, source_packet_action, source_packet_override_approved, source_packet_override_source, resend_confirmation_required, review_surface_changed, and source_content_transmission. It blocks over-budget source-bearing packets before source send unless the operator explicitly passes the shared large-packet override, blocks automatic resend after source-sent failures unless explicitly confirmed or narrowed, uses shared git diff packets for branch-diff review across subscription and direct API paths, and permits same-session no-source repair for substantive invalid-verdict prose without losing the original source attempt across failed no-source repair chains.",
       "adapters": [
         "claude",
         "gemini",
@@ -714,6 +714,8 @@
         "source_packet_policy",
         "source_send_allowed",
         "source_packet_policy_error_code",
+        "source_packet_override_approved",
+        "source_packet_override_source",
         "source_content_transmission",
         "resume_without_source_resend",
         "resume_without_source_resend_subset_of_resend_gated_failures",

--- a/tests/smoke/api-reviewers.smoke.test.mjs
+++ b/tests/smoke/api-reviewers.smoke.test.mjs
@@ -3827,6 +3827,52 @@ test("custom-review rejects over-budget source packets before direct API approva
   assert.doesNotMatch(result.stdout, /external_review_launched|secret-test-value/);
 });
 
+test("custom-review explicit large source override reaches direct API reviewers", async () => {
+  for (const { provider, model, envKey } of [
+    { provider: "deepseek", model: "deepseek-v4-pro", envKey: "DEEPSEEK_API_KEY" },
+    { provider: "glm", model: "glm-5.1", envKey: "ZAI_API_KEY" },
+  ]) {
+    const cwd = makeWorkspace();
+    const dataDir = mkdtempSync(path.join(tmpdir(), "api-reviewers-data-"));
+    const files = [];
+    for (let index = 0; index < 3; index += 1) {
+      const file = `packet-${index}.txt`;
+      files.push(file);
+      writeFileSync(path.join(cwd, file), "x".repeat(180 * 1024));
+    }
+
+    const result = await run([
+      "run",
+      "--provider", provider,
+      "--mode", "custom-review",
+      "--scope", "custom",
+      "--scope-paths", files.join(","),
+      "--foreground",
+      "--allow-large-source-packet",
+      "--prompt", "Check these files.",
+    ], {
+      cwd,
+      env: {
+        API_REVIEWERS_PLUGIN_DATA: dataDir,
+        API_REVIEWERS_MAX_PROMPT_CHARS: "2000000",
+        API_REVIEWERS_MOCK_RESPONSE: mockResponse(model),
+        [envKey]: "secret-test-value",
+      },
+    });
+
+    assert.equal(result.status, 0, `${provider}: ${result.stderr || result.stdout}`);
+    const record = parseJson(result.stdout);
+    assert.equal(record.status, "completed", provider);
+    assert.equal(record.external_review.source_content_transmission, "sent", provider);
+    const policy = record.review_metadata.audit_manifest.source_packet_policy;
+    assert.equal(policy.source_send_allowed, true, provider);
+    assert.equal(policy.source_packet_action, "send_after_source_packet_override", provider);
+    assert.equal(policy.source_packet_override_approved, true, provider);
+    assert.equal(policy.source_packet_override_source, "--allow-large-source-packet", provider);
+    assert.doesNotMatch(result.stdout, /secret-test-value/);
+  }
+});
+
 test("branch-diff default reviews committed changes against main with scrubbed git env", async () => {
   const cwd = makeBranchDiffWorkspace();
   const dataDir = mkdtempSync(path.join(tmpdir(), "api-reviewers-data-"));

--- a/tests/smoke/claude-companion.smoke.test.mjs
+++ b/tests/smoke/claude-companion.smoke.test.mjs
@@ -359,6 +359,37 @@ test("background custom-review rejects over-budget source packets before prompt 
   }
 });
 
+test("custom-review explicit large source override records policy and sends source to Claude", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "claude-source-packet-override-cwd-"));
+  fixtureSeedRepo(cwd);
+  const files = [];
+  for (let index = 0; index < 3; index += 1) {
+    const file = `packet-${index}.txt`;
+    files.push(file);
+    writeFileSync(path.join(cwd, file), "x".repeat(180 * 1024));
+  }
+
+  const { stdout, status, dataDir } = runCompanion(
+    ["run", "--mode=custom-review", "--foreground", "--model", "claude-haiku-4-5-20251001",
+     "--cwd", cwd, "--scope-paths", files.join(","), "--allow-large-source-packet", "--", "review selected source"],
+    { cwd, env: { CLAUDE_MOCK_ASSERT_PROMPT_INCLUDES: "CLAUDE FILE 1: packet-0.txt" } },
+  );
+  try {
+    assert.equal(status, 0, stdout);
+    const record = JSON.parse(stdout);
+    assert.equal(record.status, "completed");
+    assert.equal(record.external_review.source_content_transmission, "sent");
+    const policy = record.review_metadata.audit_manifest.source_packet_policy;
+    assert.equal(policy.source_send_allowed, true);
+    assert.equal(policy.source_packet_action, "send_after_source_packet_override");
+    assert.equal(policy.source_packet_override_approved, true);
+    assert.equal(policy.source_packet_override_source, "--allow-large-source-packet");
+  } finally {
+    cleanup(dataDir);
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test("custom-review guides substantive missing-verdict retry without automatic resend", () => {
   const cwd = mkdtempSync(path.join(tmpdir(), "claude-bad-verdict-cwd-"));
   const fixturePath = path.join(cwd, "claude-bad-verdict-fixture.json");

--- a/tests/smoke/gemini-companion.smoke.test.mjs
+++ b/tests/smoke/gemini-companion.smoke.test.mjs
@@ -1819,6 +1819,37 @@ test("gemini background custom-review rejects over-budget source packets before 
   }
 });
 
+test("gemini custom-review explicit large source override records policy and sends source", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "gemini-source-packet-override-cwd-"));
+  seedMinimalRepo(cwd);
+  const files = [];
+  for (let index = 0; index < 3; index += 1) {
+    const file = `packet-${index}.txt`;
+    files.push(file);
+    writeFileSync(path.join(cwd, file), "x".repeat(180 * 1024));
+  }
+
+  const { stdout, status, dataDir } = runCompanion(
+    ["run", "--mode=custom-review", "--foreground", "--cwd", cwd, "--scope-paths", files.join(","),
+     "--allow-large-source-packet", "--", "review selected source"],
+    { cwd, env: { GEMINI_MOCK_ASSERT_PROMPT_INCLUDES: "GEMINI FILE 1: packet-0.txt" } },
+  );
+  try {
+    assert.equal(status, 0, stdout);
+    const record = JSON.parse(stdout);
+    assert.equal(record.status, "completed");
+    assert.equal(record.external_review.source_content_transmission, "sent");
+    const policy = record.review_metadata.audit_manifest.source_packet_policy;
+    assert.equal(policy.source_send_allowed, true);
+    assert.equal(policy.source_packet_action, "send_after_source_packet_override");
+    assert.equal(policy.source_packet_override_approved, true);
+    assert.equal(policy.source_packet_override_source, "--allow-large-source-packet");
+  } finally {
+    rmTree(dataDir);
+    rmTree(cwd);
+  }
+});
+
 test("gemini review prompt omits provider-specific live verification context", () => {
   const cwd = mkdtempSync(path.join(tmpdir(), "gemini-review-context-cwd-"));
   const binDir = mkdtempSync(path.join(tmpdir(), "gemini-review-context-bin-"));

--- a/tests/smoke/grok-web.smoke.test.mjs
+++ b/tests/smoke/grok-web.smoke.test.mjs
@@ -458,7 +458,7 @@ if (sourceBearingDelayMs > 0 && prompt.includes("CLI_SOURCE_SECRET")) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, sourceBearingDelayMs);
 }
 process.stdout.write(JSON.stringify({
-  text: "Verdict: APPROVE\\n\\nBlocking findings\\n- None.\\n\\nNon-blocking concerns\\n- None.\\n\\nInspection status\\n- I inspected review.js from the selected source packet.\\n\\nChecklist item 1: Source packet was present and reviewed.\\nChecklist item 2: No behavioral regression found.\\nChecklist item 3: No missing test blocker found.\\nChecklist item 4: No unsafe fallback behavior found.\\nChecklist item 5: Result is ready for merge-readiness aggregation.",
+  text: "Verdict: APPROVE\\n\\nBlocking findings\\n- None. I inspected review.js, packet-1.js, and packet-2.js from the selected source packet and found no blocking issue.\\n\\nNon-blocking concerns\\n- None. The large-packet override only changes the source packet budget gate and does not alter route selection, CLI authentication, or fallback behavior.\\n\\nInspection status\\n- Source inspection completed for the explicitly scoped custom-review files. The prompt included the CLI source marker and the extra packet files, and this mock response confirms the selected source was reviewed before producing the approval.\\n\\nChecklist item 1: PASS source packet was present and reviewed.\\nChecklist item 2: PASS no behavioral regression found.\\nChecklist item 3: PASS no missing test blocker found.\\nChecklist item 4: PASS no unsafe fallback behavior found.\\nChecklist item 5: PASS result is ready for merge-readiness aggregation.",
   model: "grok-build",
   usage: { input_tokens: 1, output_tokens: 1 }
 }));
@@ -594,6 +594,54 @@ test("custom-review defaults to Grok CLI without contacting legacy tunnel", () =
     rmTree(authHome);
     rmTree(cwd);
     rmTree(dataDir);
+  }
+});
+
+test("custom-review explicit large source override reaches Grok CLI", () => {
+  const cwd = realpathSync(mkdtempSync(path.join(tmpdir(), "grok-cli-large-source-")));
+  const dataDir = mkdtempSync(path.join(tmpdir(), "grok-cli-large-data-"));
+  const authHome = mkdtempSync(path.join(tmpdir(), "grok-cli-large-auth-home-"));
+  const { binDir, grokPath } = makeFakeGrokCli();
+  writeGrokCliAuthFixture(cwd, authHome);
+  writeFileSync(path.join(cwd, "review.js"), `export const marker = 'CLI_SOURCE_SECRET';\n${"x".repeat(180 * 1024)}\n`);
+  writeFileSync(path.join(cwd, "packet-1.js"), `${"y".repeat(180 * 1024)}\n`);
+  writeFileSync(path.join(cwd, "packet-2.js"), `${"z".repeat(180 * 1024)}\n`);
+
+  try {
+    const result = run([
+      "run",
+      "--mode", "custom-review",
+      "--scope", "custom",
+      "--scope-paths", "review.js,packet-1.js,packet-2.js",
+      "--foreground",
+      "--allow-large-source-packet",
+      "--prompt", "Review selected source.",
+    ], {
+      cwd,
+      defaultTransport: false,
+      env: {
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        GROK_CLI_BINARY: grokPath,
+        GROK_CLI_AUTH_HOME: authHome,
+        GROK_PLUGIN_DATA: dataDir,
+        GROK_CLI_MAX_PROMPT_CHARS: "2000000",
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const record = parseStdout(result);
+    assert.equal(record.status, "completed");
+    assert.equal(record.external_review.source_content_transmission, "sent");
+    const policy = record.review_metadata.audit_manifest.source_packet_policy;
+    assert.equal(policy.source_send_allowed, true);
+    assert.equal(policy.source_packet_action, "send_after_source_packet_override", JSON.stringify(policy));
+    assert.equal(policy.source_packet_override_approved, true);
+    assert.equal(policy.source_packet_override_source, "--allow-large-source-packet");
+  } finally {
+    rmTree(authHome);
+    rmTree(cwd);
+    rmTree(dataDir);
+    rmTree(binDir);
   }
 });
 

--- a/tests/smoke/kimi-companion.smoke.test.mjs
+++ b/tests/smoke/kimi-companion.smoke.test.mjs
@@ -780,10 +780,15 @@ test("kimi background custom-review rejects over-budget source packets before pr
 
 test("kimi custom-review explicit large source override records policy and sends source", () => {
   const cwd = mkdtempSync(path.join(tmpdir(), "kimi-source-packet-override-cwd-"));
+  const files = [];
   let dataDir = null;
   try {
     fixtureSeedRepo(cwd);
-    writeFileSync(path.join(cwd, "large.txt"), "k".repeat(40 * 1024));
+    for (let index = 0; index < 3; index += 1) {
+      const file = `packet-${index}.txt`;
+      files.push(file);
+      writeFileSync(path.join(cwd, file), "k".repeat(180 * 1024));
+    }
     const result = runCompanion([
       "run",
       "--mode",
@@ -791,7 +796,7 @@ test("kimi custom-review explicit large source override records policy and sends
       "--cwd",
       cwd,
       "--scope-paths",
-      "large.txt",
+      files.join(","),
       "--foreground",
       "--allow-large-source-packet",
       "--",
@@ -799,7 +804,7 @@ test("kimi custom-review explicit large source override records policy and sends
     ], {
       cwd,
       env: {
-        KIMI_MOCK_ASSERT_PROMPT_INCLUDES: "KIMI FILE 1: large.txt",
+        KIMI_MOCK_ASSERT_PROMPT_INCLUDES: "KIMI FILE 1: packet-0.txt",
       },
     });
     dataDir = result.dataDir;
@@ -810,6 +815,8 @@ test("kimi custom-review explicit large source override records policy and sends
     const policy = record.review_metadata.audit_manifest.source_packet_policy;
     assert.equal(policy.source_send_allowed, true);
     assert.equal(policy.source_packet_action, "send_after_source_packet_override");
+    assert.equal(policy.source_packet_within_budget, false);
+    assert.ok(policy.selected_source_bytes > policy.source_packet_budget_bytes);
     assert.equal(policy.source_packet_override_approved, true);
     assert.equal(policy.source_packet_override_source, "--allow-large-source-packet");
   } finally {

--- a/tests/smoke/kimi-companion.smoke.test.mjs
+++ b/tests/smoke/kimi-companion.smoke.test.mjs
@@ -778,6 +778,46 @@ test("kimi background custom-review rejects over-budget source packets before pr
   }
 });
 
+test("kimi custom-review explicit large source override records policy and sends source", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "kimi-source-packet-override-cwd-"));
+  let dataDir = null;
+  try {
+    fixtureSeedRepo(cwd);
+    writeFileSync(path.join(cwd, "large.txt"), "k".repeat(40 * 1024));
+    const result = runCompanion([
+      "run",
+      "--mode",
+      "custom-review",
+      "--cwd",
+      cwd,
+      "--scope-paths",
+      "large.txt",
+      "--foreground",
+      "--allow-large-source-packet",
+      "--",
+      "Review this scope.",
+    ], {
+      cwd,
+      env: {
+        KIMI_MOCK_ASSERT_PROMPT_INCLUDES: "KIMI FILE 1: large.txt",
+      },
+    });
+    dataDir = result.dataDir;
+    assert.equal(result.status, 0, result.stdout);
+    const record = parseJson(result.stdout);
+    assert.equal(record.status, "completed");
+    assert.equal(record.external_review.source_content_transmission, "sent");
+    const policy = record.review_metadata.audit_manifest.source_packet_policy;
+    assert.equal(policy.source_send_allowed, true);
+    assert.equal(policy.source_packet_action, "send_after_source_packet_override");
+    assert.equal(policy.source_packet_override_approved, true);
+    assert.equal(policy.source_packet_override_source, "--allow-large-source-packet");
+  } finally {
+    if (dataDir) rmSync(dataDir, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test("kimi result --job-id aliases --job for a finished job", () => {
   const cwd = mkdtempSync(path.join(tmpdir(), "kimi-result-job-id-cwd-"));
   fixtureSeedRepo(cwd);

--- a/tests/unit/plugin-copies-in-sync.test.mjs
+++ b/tests/unit/plugin-copies-in-sync.test.mjs
@@ -610,6 +610,26 @@ test("Grok auto transport stays an adapter capability and uses shared source-tra
   assert.match(source, /cliRequestDiagnosticsForFallback/);
 });
 
+test("subscription rescue modes are source-bearing even though they are not review slots", () => {
+  for (const runtimePath of [
+    "plugins/claude/scripts/claude-companion.mjs",
+    "plugins/gemini/scripts/gemini-companion.mjs",
+    "plugins/kimi/scripts/kimi-companion.mjs",
+  ]) {
+    const source = readRepoFile(runtimePath);
+    assert.match(
+      source,
+      /modeSendsSelectedSource\(mode\)\s*\{[\s\S]*mode\s*===\s*"rescue"/,
+      `${runtimePath} must classify rescue as source-bearing for shared source-send policy`,
+    );
+    assert.match(
+      source,
+      /mode_profile_name\s*===\s*"rescue"[\s\S]*return null/,
+      `${runtimePath} must keep rescue out of review-quality audit semantics`,
+    );
+  }
+});
+
 test("reviewer runtimes use the shared privacy redactor", () => {
   const runtimePaths = [
     ["plugins/api-reviewers/scripts/api-reviewer.mjs", "./lib/privacy-redaction.mjs"],

--- a/tests/unit/plugin-copies-in-sync.test.mjs
+++ b/tests/unit/plugin-copies-in-sync.test.mjs
@@ -408,6 +408,8 @@ test("source-bearing launch paths enforce shared source packet policy before pro
     assert.match(source, /source_packet_policy/, `${runtimePath} must inspect the shared source packet policy`);
     assert.match(source, /source_send_allowed\s*!==\s*false/, `${runtimePath} must branch on source_send_allowed`);
     assert.match(source, /source_packet_policy_error_code/, `${runtimePath} must preserve the shared packet-policy error code`);
+    assert.match(source, /allow-large-source-packet/, `${runtimePath} must expose the shared large source-packet override`);
+    assert.match(source, /sourcePacketOverrideApproved/, `${runtimePath} must pass override state into the shared source packet policy`);
   }
 
   for (const runtimePath of [
@@ -467,7 +469,7 @@ test("source-bearing launch paths enforce shared source packet policy before pro
     },
     {
       runtimePath: "plugins/grok/scripts/grok-web-reviewer.mjs",
-      preflight: "execution = sourcePacketPolicyPreflight({ cfg, mode, prompt, scopeInfo });",
+      preflight: "execution = sourcePacketPolicyPreflight({ cfg, mode, prompt, scopeInfo, options });",
       launch: "execution = await callGrokCli(cfg, prompt, {",
     },
   ];

--- a/tests/unit/provider-route-policy.test.mjs
+++ b/tests/unit/provider-route-policy.test.mjs
@@ -151,6 +151,44 @@ test("source packet policy blocks over-budget packets for every provider and rev
       assert.equal(policy.source_packet_budget_bytes, 10);
       assert.equal(policy.selected_source_bytes, 11);
       assert.equal(policy.source_packet_within_budget, false);
+      assert.equal(policy.source_packet_override_approved, false);
+      assert.equal(policy.source_packet_override_source, null);
+      assert.equal(policy.resend_confirmation_required, false);
+    }
+  }
+});
+
+test("source packet policy permits explicit large packet override for every provider and route step", () => {
+  const contract = buildProviderPolicyContract();
+
+  for (const provider of contract.providers) {
+    for (const routeStep of PROVIDER_ROUTE_STEPS) {
+      const policy = evaluateSourcePacketPolicy({
+        provider,
+        mode: "custom-review",
+        routeStep,
+        providerCapabilities: {
+          subscription: { source_packet: { max_bytes: 10 } },
+          api: { source_packet: { max_bytes: 10 } },
+          openrouter: { source_packet: { max_bytes: 10 } },
+        },
+        selectedSource: selectedSourceFixture(11),
+        sourceBearing: true,
+        sourcePacketOverrideApproved: true,
+        sourcePacketOverrideSource: "--allow-large-source-packet",
+      });
+
+      assert.equal(policy.provider, provider);
+      assert.equal(policy.route_step, routeStep);
+      assert.equal(policy.source_send_allowed, true);
+      assert.equal(policy.source_packet_action, "send_after_source_packet_override");
+      assert.equal(policy.source_packet_policy_error_code, null);
+      assert.equal(policy.source_content_transmission, "may_be_sent");
+      assert.equal(policy.source_packet_budget_bytes, 10);
+      assert.equal(policy.selected_source_bytes, 11);
+      assert.equal(policy.source_packet_within_budget, false);
+      assert.equal(policy.source_packet_override_approved, true);
+      assert.equal(policy.source_packet_override_source, "--allow-large-source-packet");
       assert.equal(policy.resend_confirmation_required, false);
     }
   }
@@ -577,6 +615,8 @@ test("packaged provider route policy copies cover shared source-packet and route
       source_packet_budget_bytes: 64,
       selected_source_bytes: 0,
       source_packet_within_budget: true,
+      source_packet_override_approved: false,
+      source_packet_override_source: null,
       resend_confirmation_required: false,
       resume_without_source_resend: false,
       review_surface_changed: false,
@@ -614,6 +654,23 @@ test("packaged provider route policy copies cover shared source-packet and route
     assert.equal(tooLarge.source_send_allowed, false, plugin);
     assert.equal(tooLarge.source_packet_action, "narrow_source_packet", plugin);
     assert.match(tooLarge.suggested_action, /Narrow or shard/, plugin);
+
+    const override = mod.evaluateSourcePacketPolicy({
+      provider: plugin,
+      mode: "custom-review",
+      routeStep: "subscription",
+      providerCapabilities: {
+        subscription: { source_packet: { max_bytes: 10 } },
+      },
+      selectedSource: selectedSourceFixture(11),
+      sourceBearing: true,
+      sourcePacketOverrideApproved: true,
+      sourcePacketOverrideSource: "--allow-large-source-packet",
+    });
+    assert.equal(override.source_send_allowed, true, plugin);
+    assert.equal(override.source_packet_action, "send_after_source_packet_override", plugin);
+    assert.equal(override.source_packet_override_approved, true, plugin);
+    assert.equal(override.source_packet_override_source, "--allow-large-source-packet", plugin);
 
     const blocked = mod.evaluateSourcePacketPolicy({
       provider: plugin,

--- a/tests/unit/provider-route-policy.test.mjs
+++ b/tests/unit/provider-route-policy.test.mjs
@@ -126,7 +126,7 @@ test("provider policy contract exposes the full cross-cutting policy surface", (
   }
 });
 
-test("source packet policy blocks over-budget packets for every provider and review mode before source send", () => {
+test("source packet policy blocks over-budget packets for every provider and source-bearing mode before source send", () => {
   const contract = buildProviderPolicyContract();
 
   for (const provider of contract.providers) {
@@ -1182,7 +1182,7 @@ test("provider route policy normalizes provider-neutral approval scopes", () => 
   );
 });
 
-test("kimi source-bearing route facts are derived from review mode", () => {
+test("kimi source-bearing route facts are derived from mode classification", () => {
   const source = readFileSync(path.join(REPO_ROOT, "plugins/kimi/scripts/kimi-companion.mjs"), "utf8");
 
   assert.match(

--- a/tests/unit/provider-route-policy.test.mjs
+++ b/tests/unit/provider-route-policy.test.mjs
@@ -221,6 +221,23 @@ test("source packet policy prevents automatic resend after source-bearing failur
   assert.equal(blocked.review_surface_changed, false);
   assert.equal(blocked.source_content_transmission, "not_sent");
 
+  const overrideStillBlocked = evaluateSourcePacketPolicy({
+    ...baseInput,
+    providerCapabilities: {
+      subscription: { source_packet: { max_bytes: 7 } },
+    },
+    sourcePacketOverrideApproved: true,
+    sourcePacketOverrideSource: "--allow-large-source-packet",
+  });
+  assert.equal(overrideStillBlocked.source_send_allowed, false);
+  assert.equal(overrideStillBlocked.source_packet_action, "resend_confirmation_required");
+  assert.equal(overrideStillBlocked.source_packet_policy_error_code, "resend_confirmation_required");
+  assert.equal(overrideStillBlocked.source_packet_within_budget, false);
+  assert.equal(overrideStillBlocked.source_packet_override_approved, true);
+  assert.equal(overrideStillBlocked.source_packet_override_source, "--allow-large-source-packet");
+  assert.equal(overrideStillBlocked.resend_confirmation_required, true);
+  assert.equal(overrideStillBlocked.source_content_transmission, "not_sent");
+
   const confirmed = evaluateSourcePacketPolicy({
     ...baseInput,
     resendConfirmationApproved: true,


### PR DESCRIPTION
Closes #173.

## Summary

This PR is the source-packet safety slice that remains after #171 was merged.
It does not claim to finish every provider-neutral execution gap. It specifically
fixes the shared source-bearing packet path so large selected-source sends are
budgeted, auditable, and explicit across the external-review provider stack.

Key changes:

- Add provider-neutral large source-packet override state:
  `source_packet_override_approved` and `source_packet_override_source`.
- Enforce shared source-packet policy before source is sent, including:
  over-budget blocking,
  explicit large-packet override,
  no automatic resend after source-bearing failures,
  and audit metadata for the selected action.
- Wire the same policy through Claude, Gemini, Kimi, Grok, DeepSeek, and GLM
  paths instead of treating this as a Claude-only usage issue.
- Keep the shared resend gate stronger than the large-packet override:
  `--allow-large-source-packet` does not bypass explicit resend confirmation.
- Classify `rescue` as source-bearing for Claude/Gemini/Kimi source-send policy
  while keeping rescue out of review-quality / review-approval-slot semantics.
- Add contract/sync coverage so packaged provider copies and shared source
  packet policy fields do not drift silently.
- Harden Kimi smoke coverage so the override test is deterministically
  over-budget and cannot pass accidentally when the packet is within budget.

## Why Merge This PR

The immediate root problem behind #173 was not "Claude was used"; it was that
source-bearing review packets could be sent without a shared hard budget,
without an auditable explicit override path, and without a resend policy that
prevented repeated source-bearing sends after failed review slots.

This PR fixes that source-packet policy layer provider-neutrally and is fully
green at the current head. Merging it gives us the shared guardrail now instead
of holding it behind broader provider execution work.

Important boundary: this PR does **not** close the remaining provider-neutral
execution gaps exposed by Kimi and Grok:

- Kimi still needs a provider-neutral prompt/runtime compatibility fix so review
  slots reliably produce usable verdicts.
- Grok still needs the normal generated review command path to use the intended
  CLI-first `auto` transport policy, rather than requiring callers to remember
  it manually.

Those are real follow-up issues. They should be fixed through shared
command/execution policy with adapter capability facts, not by one-off Kimi or
Grok patches. This PR is being merged as the completed source-packet safety
slice, with those broader gaps explicitly not claimed as solved here.

## Verification

Local verification run for the current PR shape:

- `node --test --test-name-pattern "prevents automatic resend|permits explicit large packet override" tests/unit/provider-route-policy.test.mjs`
- `node --test --test-name-pattern "kimi custom-review explicit large source override" tests/smoke/kimi-companion.smoke.test.mjs`
- `node --test tests/unit/provider-route-policy.test.mjs tests/unit/plugin-copies-in-sync.test.mjs`
- `node --test --test-name-pattern "source packet|source-packet|large source override|large source-packet override|explicit large source override|source override|automatic resend|resend-confirmation" tests/smoke/kimi-companion.smoke.test.mjs`
- `npm run lint:sync`

GitHub CI at `f993e711644b4a5316a561d8edb76b6bb84466ac`:

- `lint`: SUCCESS
- `test`: SUCCESS
- `smoke (claude)`: SUCCESS
- `smoke (gemini)`: SUCCESS
- `smoke (kimi)`: SUCCESS
- `smoke (grok)`: SUCCESS
- `smoke (api-reviewers)`: SUCCESS
- SonarCloud Code Analysis: SUCCESS

## Review Findings And Disposition

### Gemini Code Assist

Initial Gemini Code Assist comments were high-priority and valid for the earlier
Claude-shaped version:

- New budget/override fields were not persisted/restored through JobRecord.
- `continue` and `approval-request` paths did not consistently carry the new
  budget controls.
- The implementation was too Claude-specific.

Disposition:

- Reworked the PR on top of merged #171 so the fix uses shared provider policy
  fields instead of Claude-only budget fields.
- Propagated `--allow-large-source-packet` and audit state through run,
  continuation, approval/audit, and packaged provider paths.
- Resolved the review threads with current provider-neutral evidence.

### External Model Reviews

Broad review at prior head `929f1da`:

- Claude: APPROVE, no blocking findings. Non-blocking concern: Kimi override
  smoke used a small 40 KiB file and could become brittle if Kimi budget changed.
- Gemini: APPROVE, no blocking findings.
- Grok: APPROVE, no blocking findings at that head.
- GLM: no blocking findings.
- DeepSeek: no blocking findings.
- Kimi: not a usable broad approval on the larger packet; this was treated as a
  provider/runtime symptom, not as approval.

Follow-up fix from review feedback:

- Commit `f993e71` made the Kimi override smoke deterministically over-budget.
- Commit `f993e71` added a unit test proving large-packet override does not
  bypass resend-confirmation gating.

Latest-head delta review for `929f1da..f993e71`:

- Claude `794739fa-524f-495e-9155-4a4aa70f8929`: APPROVE, blocking findings none.
- Gemini `7d591355-9d49-4dcd-8691-b6a06d576fc1`: APPROVE, blocking findings none.
- Kimi `8d587cbb-333f-4d21-8f19-0f77390c2724`: APPROVE, blocking findings none.
- GLM `job_532ebae8-e544-4714-aa3c-939cffbd4bd8`: APPROVE, blocking findings none.
- DeepSeek `job_9fb0fcd8-6aec-4572-8c81-9ea249bc2729`: APPROVE, blocking findings none.
- Grok `job_28da3a2f-2ff6-42f1-86e3-14dff037b098`: blocked before source send
  with `grok_cli_login_required`; source was not sent.

Non-blocking review suggestions left intentionally unpatched to avoid another
churn cycle on test-only polish:

- Assert every synthetic Kimi packet file appears in the prompt, not only
  `packet-0.txt`.
- Add an extra matrix case for "override flag set + resend confirmation set".
- Make the existing fixture-size relationship even more explicit in the unit
  test setup.

These suggestions are useful test polish, but none changes the production
policy behavior, CI result, or blocking review disposition.

## Known Follow-Up

The next provider-neutral work should fix the shared command/execution contract
so Kimi prompt/runtime compatibility and Grok CLI/web `auto` fallback are not
handled as provider-specific operator surprises. Grok has a legitimate adapter
difference because it has two subscription-backed transports; the shared command
contract still needs to make the normal review path choose the intended policy
without manual flag memory.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a shared `--allow-large-source-packet` override gate to the source-packet budget enforcement layer, wiring new `source_packet_override_approved` / `source_packet_override_source` state through all six provider paths (Claude, Gemini, Kimi, Grok, api-reviewers, shared) and explicitly classifying `rescue` as source-bearing for companion providers. The resend gate correctly takes priority over the override flag, and unit/smoke coverage proves the policy holds end-to-end.

- The shared `evaluateSourcePacketPolicy` function and all packaged copies are updated atomically to carry the two new override fields and emit the `send_after_source_packet_override` action when applicable.
- Three structural violations exist across the provider implementations: the string literal `\"--allow-large-source-packet\"` is hardcoded in five separate files instead of being exported from the shared policy module; the helper function `sourcePacketOverrideRouteFields` carries the same name but different input types in claude/gemini (invocation object) vs. grok/api-reviewers (options object); and kimi inlines the override field extraction in `reviewAuditManifest` rather than using the same helper that claude/gemini use, creating divergent code paths that the sync tests do not fully catch.

<h3>Confidence Score: 3/5</h3>

The policy enforcement logic itself is correct, but three structural violations in the implementation create real drift risk across providers.

The flag literal `"--allow-large-source-packet"` is defined five times independently across the provider files. If the flag name changes, an un-patched copy silently records `null` as the override source in the audit manifest instead of the real flag string. Alongside this, `sourcePacketOverrideRouteFields` accepts an invocation in claude/gemini but an options object in grok/api-reviewers (same name, different input contract), and kimi's `reviewAuditManifest` inlines the same field extraction rather than using the helper. Any future addition to the override tuple would propagate through the helper in claude/gemini but silently miss kimi's inline copy.

All five provider companion files share the `LARGE_SOURCE_PACKET_FLAG` duplication; `kimi-companion.mjs` additionally diverges by inlining override extraction; `grok-web-reviewer.mjs` and `api-reviewer.mjs` use `sourcePacketOverrideRouteFields` with a different input contract than the claude/gemini copies.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/lib/provider-route-policy.mjs | Adds sourcePacketOverrideApproved/sourcePacketOverrideSource parameters to evaluateSourcePacketPolicy; skips the narrow_source_packet gate when override is set; emits send_after_source_packet_override action. Logic is correct; resend gate correctly takes priority over override. Does not export the LARGE_SOURCE_PACKET_FLAG constant despite it being referenced across all five provider files. |
| plugins/claude/scripts/claude-companion.mjs | Correctly wires --allow-large-source-packet through run/continue/approval paths and runtime sidecar. Defines LARGE_SOURCE_PACKET_FLAG locally (duplicated in four other files). Properly separates sourcePacketOverrideInvocationFields (options→invocation) from sourcePacketOverrideRouteFields (invocation→route), but grok/api-reviewers use the same second name for a different signature. |
| plugins/gemini/scripts/gemini-companion.mjs | Mirrors claude-companion changes faithfully; adds override through approval, run, continue and sidecar paths; same LARGE_SOURCE_PACKET_FLAG duplication issue as claude; consistent with claude's two-helper pattern. |
| plugins/kimi/scripts/kimi-companion.mjs | Adds override to run/continue paths and sidecar; classifies rescue as source-bearing. Differs from claude/gemini by inlining override field extraction in reviewAuditManifest rather than using a helper, creating a dual-path maintenance hazard. LARGE_SOURCE_PACKET_FLAG also locally duplicated. |
| plugins/grok/scripts/grok-web-reviewer.mjs | Adds override to preflight, fallback-preflight, and review-metadata paths. Uses sourcePacketOverrideRouteFields(options) (options→camelCase), the same name but different input type from claude/gemini's invocation→camelCase variant. LARGE_SOURCE_PACKET_FLAG locally duplicated. |
| plugins/api-reviewers/scripts/api-reviewer.mjs | Propagates override into approval-audit manifest and review-metadata in both cmdRun approval and review paths. Same sourcePacketOverrideRouteFields(options) signature inconsistency and LARGE_SOURCE_PACKET_FLAG duplication as grok. |
| tests/unit/provider-route-policy.test.mjs | Strong coverage: proves override works, resend gate trumps override, and all packaged provider copies pass the same contract. New tests are deterministic and well-structured. |
| tests/unit/plugin-copies-in-sync.test.mjs | Adds sync assertions for allow-large-source-packet exposure and sourcePacketOverrideApproved pass-through across provider runtimes; adds test that rescue is source-bearing for claude/gemini/kimi only. Coverage is good but the inline vs helper divergence in kimi is not caught by these pattern-match tests. |

</details>

</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22seungpyoson%2Fcodex-plugin-multi%22%20on%20the%20existing%20branch%20%22issue-173-claude-custom-review-packet-budget%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22issue-173-claude-custom-review-packet-budget%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aplugins%2Fclaude%2Fscripts%2Fclaude-companion.mjs%3A470%0A**Hardcoded%20constant%20duplicated%20across%20five%20provider%20files**%0A%0A%60LARGE_SOURCE_PACKET_FLAG%20%3D%20%22--allow-large-source-packet%22%60%20is%20defined%20verbatim%20in%20every%20provider%20companion%20%28claude%20line%20470%2C%20gemini%20line%20388%2C%20kimi%20line%20414%2C%20grok%20line%201563%2C%20api-reviewers%20line%202374%29.%20If%20the%20flag%20name%20ever%20changes%2C%20all%20five%20copies%20must%20be%20updated%20atomically%20%E2%80%94%20a%20silently%20diverging%20copy%20would%20produce%20an%20incorrect%20%60source_packet_override_source%60%20audit%20value%20%28%60null%60%20instead%20of%20the%20real%20flag%20string%29.%20Per%20the%20no-hardcoding%20principle%2C%20this%20shared%20literal%20belongs%20in%20the%20shared%20%60scripts%2Flib%2Fprovider-route-policy.mjs%60%20%28or%20equivalent%20shared%20library%29%20as%20an%20exported%20constant%2C%20then%20imported%20by%20each%20provider.%0A%0A%23%23%23%20Issue%202%20of%203%0Aplugins%2Fgrok%2Fscripts%2Fgrok-web-reviewer.mjs%3A1565-1571%0A**%60sourcePacketOverrideRouteFields%60%20has%20conflicting%20signatures%20across%20providers%20%28dual-path%20violation%29**%0A%0AIn%20claude%20and%20gemini%2C%20%60sourcePacketOverrideRouteFields%28invocation%29%60%20accepts%20an%20*invocation*%20object%20with%20snake_case%20keys%20%28%60invocation.source_packet_override_approved%60%29.%20Here%20in%20grok%20%28and%20in%20api-reviewers%29%2C%20the%20same%20function%20name%20accepts%20an%20*options*%20object%20with%20kebab-case%20keys%20%28%60options%5B%22allow-large-source-packet%22%5D%60%29.%20The%20two%20are%20functionally%20equivalent%20outputs%20but%20semantically%20different%20inputs%20%E2%80%94%20a%20contributor%20following%20the%20claude%2Fgemini%20pattern%20would%20wire%20the%20wrong%20input%20and%20silently%20discard%20the%20override.%20Kimi%20avoids%20the%20helper%20entirely%20and%20inlines%20the%20extraction%2C%20creating%20a%20third%20variant%20of%20the%20same%20operation.%20All%20providers%20should%20use%20the%20same%20helper%20with%20a%20consistent%20input%20contract%3B%20the%20conversion%20from%20CLI%20options%20to%20invocation%20fields%20%28%60sourcePacketOverrideInvocationFields%60%29%20and%20from%20invocation%20to%20route%20fields%20%28%60sourcePacketOverrideRouteFields%60%29%20should%20carry%20uniform%20signatures%20across%20every%20plugin.%0A%0A%23%23%23%20Issue%203%20of%203%0Aplugins%2Fkimi%2Fscripts%2Fkimi-companion.mjs%3A361-364%0A**Kimi%20inlines%20override%20field%20extraction%20instead%20of%20using%20the%20shared%20helper%20%28dual-path%20violation%29**%0A%0AClaude%20and%20gemini%20both%20call%20%60...sourcePacketOverrideRouteFields%28invocation%29%60%20at%20this%20point%20in%20%60reviewAuditManifest%60%2C%20but%20kimi%20expands%20the%20same%20two%20fields%20inline.%20If%20a%20third%20field%20is%20ever%20added%20to%20the%20override%20tuple%20%28e.g.%2C%20an%20override%20timestamp%20for%20auditing%29%2C%20kimi's%20inline%20copy%20will%20silently%20omit%20it%20while%20the%20claude%2Fgemini%20helper%20picks%20it%20up%20automatically.%20This%20is%20a%20direct%20dual-path%20violation%3A%20the%20same%20extraction%20logic%20exists%20in%20two%20forms%2C%20with%20only%20shallow%20unit%2Fsync%20tests%20to%20catch%20drift.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aplugins%2Fclaude%2Fscripts%2Fclaude-companion.mjs%3A470%0A**Hardcoded%20constant%20duplicated%20across%20five%20provider%20files**%0A%0A%60LARGE_SOURCE_PACKET_FLAG%20%3D%20%22--allow-large-source-packet%22%60%20is%20defined%20verbatim%20in%20every%20provider%20companion%20%28claude%20line%20470%2C%20gemini%20line%20388%2C%20kimi%20line%20414%2C%20grok%20line%201563%2C%20api-reviewers%20line%202374%29.%20If%20the%20flag%20name%20ever%20changes%2C%20all%20five%20copies%20must%20be%20updated%20atomically%20%E2%80%94%20a%20silently%20diverging%20copy%20would%20produce%20an%20incorrect%20%60source_packet_override_source%60%20audit%20value%20%28%60null%60%20instead%20of%20the%20real%20flag%20string%29.%20Per%20the%20no-hardcoding%20principle%2C%20this%20shared%20literal%20belongs%20in%20the%20shared%20%60scripts%2Flib%2Fprovider-route-policy.mjs%60%20%28or%20equivalent%20shared%20library%29%20as%20an%20exported%20constant%2C%20then%20imported%20by%20each%20provider.%0A%0A%23%23%23%20Issue%202%20of%203%0Aplugins%2Fgrok%2Fscripts%2Fgrok-web-reviewer.mjs%3A1565-1571%0A**%60sourcePacketOverrideRouteFields%60%20has%20conflicting%20signatures%20across%20providers%20%28dual-path%20violation%29**%0A%0AIn%20claude%20and%20gemini%2C%20%60sourcePacketOverrideRouteFields%28invocation%29%60%20accepts%20an%20*invocation*%20object%20with%20snake_case%20keys%20%28%60invocation.source_packet_override_approved%60%29.%20Here%20in%20grok%20%28and%20in%20api-reviewers%29%2C%20the%20same%20function%20name%20accepts%20an%20*options*%20object%20with%20kebab-case%20keys%20%28%60options%5B%22allow-large-source-packet%22%5D%60%29.%20The%20two%20are%20functionally%20equivalent%20outputs%20but%20semantically%20different%20inputs%20%E2%80%94%20a%20contributor%20following%20the%20claude%2Fgemini%20pattern%20would%20wire%20the%20wrong%20input%20and%20silently%20discard%20the%20override.%20Kimi%20avoids%20the%20helper%20entirely%20and%20inlines%20the%20extraction%2C%20creating%20a%20third%20variant%20of%20the%20same%20operation.%20All%20providers%20should%20use%20the%20same%20helper%20with%20a%20consistent%20input%20contract%3B%20the%20conversion%20from%20CLI%20options%20to%20invocation%20fields%20%28%60sourcePacketOverrideInvocationFields%60%29%20and%20from%20invocation%20to%20route%20fields%20%28%60sourcePacketOverrideRouteFields%60%29%20should%20carry%20uniform%20signatures%20across%20every%20plugin.%0A%0A%23%23%23%20Issue%203%20of%203%0Aplugins%2Fkimi%2Fscripts%2Fkimi-companion.mjs%3A361-364%0A**Kimi%20inlines%20override%20field%20extraction%20instead%20of%20using%20the%20shared%20helper%20%28dual-path%20violation%29**%0A%0AClaude%20and%20gemini%20both%20call%20%60...sourcePacketOverrideRouteFields%28invocation%29%60%20at%20this%20point%20in%20%60reviewAuditManifest%60%2C%20but%20kimi%20expands%20the%20same%20two%20fields%20inline.%20If%20a%20third%20field%20is%20ever%20added%20to%20the%20override%20tuple%20%28e.g.%2C%20an%20override%20timestamp%20for%20auditing%29%2C%20kimi's%20inline%20copy%20will%20silently%20omit%20it%20while%20the%20claude%2Fgemini%20helper%20picks%20it%20up%20automatically.%20This%20is%20a%20direct%20dual-path%20violation%3A%20the%20same%20extraction%20logic%20exists%20in%20two%20forms%2C%20with%20only%20shallow%20unit%2Fsync%20tests%20to%20catch%20drift.%0A%0A&repo=seungpyoson%2Fcodex-plugin-multi&pr=174&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
plugins/claude/scripts/claude-companion.mjs:470
**Hardcoded constant duplicated across five provider files**

`LARGE_SOURCE_PACKET_FLAG = "--allow-large-source-packet"` is defined verbatim in every provider companion (claude line 470, gemini line 388, kimi line 414, grok line 1563, api-reviewers line 2374). If the flag name ever changes, all five copies must be updated atomically — a silently diverging copy would produce an incorrect `source_packet_override_source` audit value (`null` instead of the real flag string). Per the no-hardcoding principle, this shared literal belongs in the shared `scripts/lib/provider-route-policy.mjs` (or equivalent shared library) as an exported constant, then imported by each provider.

### Issue 2 of 3
plugins/grok/scripts/grok-web-reviewer.mjs:1565-1571
**`sourcePacketOverrideRouteFields` has conflicting signatures across providers (dual-path violation)**

In claude and gemini, `sourcePacketOverrideRouteFields(invocation)` accepts an *invocation* object with snake_case keys (`invocation.source_packet_override_approved`). Here in grok (and in api-reviewers), the same function name accepts an *options* object with kebab-case keys (`options["allow-large-source-packet"]`). The two are functionally equivalent outputs but semantically different inputs — a contributor following the claude/gemini pattern would wire the wrong input and silently discard the override. Kimi avoids the helper entirely and inlines the extraction, creating a third variant of the same operation. All providers should use the same helper with a consistent input contract; the conversion from CLI options to invocation fields (`sourcePacketOverrideInvocationFields`) and from invocation to route fields (`sourcePacketOverrideRouteFields`) should carry uniform signatures across every plugin.

### Issue 3 of 3
plugins/kimi/scripts/kimi-companion.mjs:361-364
**Kimi inlines override field extraction instead of using the shared helper (dual-path violation)**

Claude and gemini both call `...sourcePacketOverrideRouteFields(invocation)` at this point in `reviewAuditManifest`, but kimi expands the same two fields inline. If a third field is ever added to the override tuple (e.g., an override timestamp for auditing), kimi's inline copy will silently omit it while the claude/gemini helper picks it up automatically. This is a direct dual-path violation: the same extraction logic exists in two forms, with only shallow unit/sync tests to catch drift.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: harden source packet override guar..."](https://github.com/seungpyoson/codex-plugin-multi/commit/f993e711644b4a5316a561d8edb76b6bb84466ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33751569)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - You will be acting as an AI code reviewer. Your go... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->