### PR TITLE
Route custom-review base refs through branch-diff packets

### DIFF
--- a/plugins/claude/scripts/lib/companion-common.mjs
+++ b/plugins/claude/scripts/lib/companion-common.mjs
@@ -351,7 +351,7 @@ export function startExternalReviewHeartbeat(
 }
 
 export function effectiveProfileForOptions(profile, options) {
-  if (profile.name === "review" && scopeBaseForOptions(options) !== null) {
+  if ((profile.name === "review" || profile.name === "custom-review") && scopeBaseForOptions(options) !== null) {
     return Object.freeze({ ...profile, scope: "branch-diff" });
   }
   return profile;

--- a/plugins/gemini/scripts/lib/companion-common.mjs
+++ b/plugins/gemini/scripts/lib/companion-common.mjs
@@ -351,7 +351,7 @@ export function startExternalReviewHeartbeat(
 }
 
 export function effectiveProfileForOptions(profile, options) {
-  if (profile.name === "review" && scopeBaseForOptions(options) !== null) {
+  if ((profile.name === "review" || profile.name === "custom-review") && scopeBaseForOptions(options) !== null) {
     return Object.freeze({ ...profile, scope: "branch-diff" });
   }
   return profile;

--- a/plugins/kimi/scripts/lib/companion-common.mjs
+++ b/plugins/kimi/scripts/lib/companion-common.mjs
@@ -351,7 +351,7 @@ export function startExternalReviewHeartbeat(
 }
 
 export function effectiveProfileForOptions(profile, options) {
-  if (profile.name === "review" && scopeBaseForOptions(options) !== null) {
+  if ((profile.name === "review" || profile.name === "custom-review") && scopeBaseForOptions(options) !== null) {
     return Object.freeze({ ...profile, scope: "branch-diff" });
   }
   return profile;

--- a/scripts/lib/companion-common.mjs
+++ b/scripts/lib/companion-common.mjs
@@ -351,7 +351,7 @@ export function startExternalReviewHeartbeat(
 }
 
 export function effectiveProfileForOptions(profile, options) {
-  if (profile.name === "review" && scopeBaseForOptions(options) !== null) {
+  if ((profile.name === "review" || profile.name === "custom-review") && scopeBaseForOptions(options) !== null) {
     return Object.freeze({ ...profile, scope: "branch-diff" });
   }
   return profile;

--- a/specs/177-kimi-review-verdict-reliability/evidence-map.md
+++ b/specs/177-kimi-review-verdict-reliability/evidence-map.md
@@ -1,0 +1,45 @@
+# Issue #177 Evidence Map
+
+## Scope
+
+Issue #177 remains after #175 and #181 for Kimi review reliability on packets that
+cannot safely be sent as one full-file `custom-review` bundle. The fix should be
+provider-neutral unless the evidence proves a Kimi-only capability difference.
+
+## Current Evidence
+
+- #175 merged Kimi adapter capability facts: subscription source packets are capped
+  at 32 KiB, no-source repair after source-bearing step-limit failures is
+  unsupported, and Kimi source-bearing reviews use prompt-contained source without
+  workspace file tools.
+- #181 merged provider-neutral review-slot disposition: failed, missing, timed-out,
+  stale, source-sent-unusable, and no-verdict slots do not count as approval.
+- Live #177 comments show Kimi now passes source-free readiness and can complete
+  under-budget branch-diff shards after the account upgrade.
+- The remaining #177 evidence is packet-shape, not auth: full PR or full-file
+  `custom-review` bundles can exceed Kimi's adapter packet cap, while equivalent
+  branch-diff shards can stay under the cap.
+- Current shared `effectiveProfileForOptions` only converts `review --scope-base`
+  into `branch-diff`. A `custom-review --scope-paths ... --scope-base ...` keeps
+  effective scope `custom`, so committed explicit-path shards still follow the
+  full-file custom-scope path instead of the provider-neutral branch-diff packet
+  path.
+
+## Root Cause
+
+The shared scope/profile normalization does not treat an explicit base ref as a
+committed-diff source contract for `custom-review`. Operators can provide both
+explicit paths and a base ref, but the companion still classifies the review as
+custom scope. That preserves the historical full-file packet path that caused
+Kimi burn, even when a safer branch-diff packet is available.
+
+## Acceptance
+
+- `custom-review --scope-paths ... --scope-base <ref>` uses effective
+  `branch-diff` scope across companion-backed providers.
+- Explicit `--scope-paths` remains the shard filter; no implicit broadening.
+- `custom-review` without `--scope-base` remains explicit full-file custom scope
+  for non-git bundles and intentional file-body review.
+- The behavior lives in shared companion policy, with packaged copies in sync.
+- Kimi failed slots remain failed slots and no-source continuations remain
+  `source_content_transmission:not_sent`.

--- a/tests/smoke/kimi-companion.smoke.test.mjs
+++ b/tests/smoke/kimi-companion.smoke.test.mjs
@@ -2786,6 +2786,7 @@ test("kimi review --scope-base preserves branch-diff scope through target execut
 
 test("kimi custom-review with scope-base uses branch-diff packet instead of full file body", () => {
   const cwd = mkdtempSync(path.join(tmpdir(), "kimi-custom-review-scope-base-"));
+  let dataDir = null;
   try {
     const lines = Array.from({ length: 3000 }, (_, index) => `unchanged line ${index}`);
     lines[0] = "FULL_FILE_ONLY_SENTINEL";
@@ -2821,6 +2822,7 @@ test("kimi custom-review with scope-base uses branch-diff packet instead of full
         KIMI_MOCK_ASSERT_PROMPT_EXCLUDES: "FULL_FILE_ONLY_SENTINEL",
       },
     });
+    dataDir = result.dataDir;
     assert.equal(result.status, 0, result.stderr);
     const record = parseJson(result.stdout);
     assert.equal(record.scope, "branch-diff");
@@ -2835,6 +2837,7 @@ test("kimi custom-review with scope-base uses branch-diff packet instead of full
     assert.equal(manifest.source_packet_policy.source_send_allowed, true);
     assert.equal(manifest.source_packet_policy.selected_source_bytes < 32 * 1024, true);
   } finally {
+    if (dataDir) rmSync(dataDir, { recursive: true, force: true });
     rmSync(cwd, { recursive: true, force: true });
   }
 });

--- a/tests/smoke/kimi-companion.smoke.test.mjs
+++ b/tests/smoke/kimi-companion.smoke.test.mjs
@@ -2784,6 +2784,61 @@ test("kimi review --scope-base preserves branch-diff scope through target execut
   }
 });
 
+test("kimi custom-review with scope-base uses branch-diff packet instead of full file body", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "kimi-custom-review-scope-base-"));
+  try {
+    const lines = Array.from({ length: 3000 }, (_, index) => `unchanged line ${index}`);
+    lines[0] = "FULL_FILE_ONLY_SENTINEL";
+    lines[200] = "original target line";
+    fixtureSeedRepo(cwd, {
+      fileName: "doc.md",
+      fileContents: `${lines.join("\n")}\n`,
+      message: "base",
+    });
+    const base = fixtureGit(cwd, ["rev-parse", "HEAD"]).stdout.trim();
+    lines[200] = "changed target line";
+    writeFileSync(path.join(cwd, "doc.md"), `${lines.join("\n")}\n`);
+    assert.equal(fixtureGit(cwd, ["add", "doc.md"]).status, 0);
+    assert.equal(fixtureGit(cwd, ["commit", "-q", "-m", "feature"]).status, 0);
+
+    const result = runCompanion([
+      "run",
+      "--mode",
+      "custom-review",
+      "--cwd",
+      cwd,
+      "--scope-base",
+      base,
+      "--scope-paths",
+      "doc.md",
+      "--foreground",
+      "--",
+      "Review this committed shard.",
+    ], {
+      cwd,
+      env: {
+        KIMI_MOCK_ASSERT_PROMPT_INCLUDES: "changed target line",
+        KIMI_MOCK_ASSERT_PROMPT_EXCLUDES: "FULL_FILE_ONLY_SENTINEL",
+      },
+    });
+    assert.equal(result.status, 0, result.stderr);
+    const record = parseJson(result.stdout);
+    assert.equal(record.scope, "branch-diff");
+    assert.equal(record.scope_base, base);
+    assert.deepEqual(record.scope_paths, ["doc.md"]);
+    assert.equal(record.external_review.source_content_transmission, "sent");
+    const manifest = record.review_metadata.audit_manifest;
+    assert.equal(manifest.scope_resolution.scope, "branch-diff");
+    assert.deepEqual(manifest.scope_resolution.scope_paths, ["doc.md"]);
+    assert.deepEqual(manifest.selected_source.files.map((file) => file.path), ["doc.md"]);
+    assert.equal(manifest.source_packet_policy.source_packet_action, "send");
+    assert.equal(manifest.source_packet_policy.source_send_allowed, true);
+    assert.equal(manifest.source_packet_policy.selected_source_bytes < 32 * 1024, true);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test("kimi continue preserves prior review branch-diff scope through target execution", () => {
   const cwd = mkdtempSync(path.join(tmpdir(), "kimi-continue-scope-base-"));
   try {

--- a/tests/unit/companion-common.test.mjs
+++ b/tests/unit/companion-common.test.mjs
@@ -227,7 +227,11 @@ test("shared companion helpers cover small provider-agnostic behavior", () => {
   assert.equal(effectiveProfileForOptions(reviewProfile, { "scope-base": "" }), reviewProfile);
   assert.equal(effectiveProfileForOptions(reviewProfile, { "scope-base": "   " }), reviewProfile);
   const customProfile = Object.freeze({ name: "custom-review", scope: "custom" });
-  assert.equal(effectiveProfileForOptions(customProfile, { "scope-base": "origin/main" }), customProfile);
+  assert.deepEqual(effectiveProfileForOptions(customProfile, { "scope-base": "origin/main" }), {
+    name: "custom-review",
+    scope: "branch-diff",
+  });
+  assert.equal(effectiveProfileForOptions(customProfile, { "scope-base": "" }), customProfile);
   assert.match(cancelUnverifiableSuggestedAction(1234), /pid 1234/);
   assert.match(cancelUnverifiableSuggestedAction(1234), /ownership/);
   assert.match(cancelNoPidInfoSuggestedAction(), /verify process ownership/);
@@ -794,7 +798,11 @@ async function assertCopyHelperBranches(mod, plugin) {
   assert.equal(mod.effectiveProfileForOptions(reviewProfile, { "scope-base": "" }), reviewProfile);
   assert.equal(mod.effectiveProfileForOptions(reviewProfile, { "scope-base": "   " }), reviewProfile);
   const customProfile = Object.freeze({ name: "custom-review", scope: "custom" });
-  assert.equal(mod.effectiveProfileForOptions(customProfile, { "scope-base": "origin/main" }), customProfile);
+  assert.deepEqual(mod.effectiveProfileForOptions(customProfile, { "scope-base": "origin/main" }), {
+    name: "custom-review",
+    scope: "branch-diff",
+  });
+  assert.equal(mod.effectiveProfileForOptions(customProfile, { "scope-base": "" }), customProfile);
   assert.match(mod.cancelUnverifiableSuggestedAction(1234), /pid 1234/);
   assert.match(mod.cancelUnverifiableSuggestedAction(1234), /ownership/);
   assert.match(mod.cancelNoPidInfoSuggestedAction(), /verify process ownership/);


### PR DESCRIPTION
Closes #177.

## Problem and Root Cause
Kimi #177 no longer points at auth/readiness as the primary blocker: live issue evidence shows source-free Kimi readiness is OK and under-budget branch-diff shards can complete after the account upgrade. The remaining failure class is packet shape. Explicit-path `custom-review` remained classified as `custom` even when the operator supplied `--scope-base <ref>`, preserving the full-file custom-scope path that can exceed provider packet budgets.

The root cause was shared profile normalization: `effectiveProfileForOptions` only converted `review --scope-base ...` to `branch-diff`; `custom-review --scope-paths ... --scope-base ...` stayed `custom`.

## Why This Is Provider-Neutral
This is not a Kimi-only shortcut. The behavior lives in shared `companion-common.mjs` and is synced to Claude, Gemini, and Kimi packaged copies. Provider-specific Kimi facts from #175 remain capability facts only: Kimi has a 32 KiB source-packet cap and unsupported no-source repair after source-bearing step-limit failures. Shared policy now lets committed explicit-path shards use branch-diff packets when a base ref is supplied.

## Implementation Summary
- Treat `custom-review --scope-base <ref>` as effective `branch-diff` scope while preserving explicit `--scope-paths` as the shard filter.
- Keep `custom-review` without `--scope-base` as explicit full-file custom scope for non-git bundles or intentional file-body review.
- Added #177 evidence map under `specs/177-kimi-review-verdict-reliability/`.
- Added shared helper/unit coverage and Kimi smoke coverage proving a large full file with a tiny committed diff sends the branch-diff packet, excludes a full-file-only sentinel, cleans up `runCompanion` data dir, and stays below Kimi's 32 KiB cap.

## Verification
Head: `848fc665d27cb0eef7dfd999bb502b3c256b207f`
Base: `origin/main` / `3cd27ef3c095c64009829ae4e9b6a3da51e65bc5`

Fresh local verification on clean detached exact-head worktree:
- `npm ci` - pass.
- `git diff --check origin/main...HEAD` - pass.
- `npm run lint:sync` - pass.
- `node --test --test-name-pattern "kimi custom-review with scope-base uses branch-diff packet|kimi review --scope-base preserves branch-diff scope" tests/smoke/kimi-companion.smoke.test.mjs` - pass 2/2.
- `node --test tests/unit/companion-common.test.mjs tests/smoke/kimi-companion.smoke.test.mjs tests/unit/plugin-copies-in-sync.test.mjs` - pass 168/168.

Remote CI:
- GitHub Actions `pull-request-ci` run `26431756565` - success.
- Jobs green: `lint`, `test`, `smoke (api-reviewers)`, `smoke (claude)`, `smoke (gemini)`, `smoke (grok)`, `smoke (kimi)`.
- SonarQube quality gate passed with 0 new issues.

External reviews at exact head `848fc66`, whole PR scope `origin/main...HEAD`:
- Gemini adversarial review - APPROVE.
- Claude adversarial review - APPROVE.
- Kimi adversarial review - APPROVE.
- Grok adversarial review - APPROVE.
- DeepSeek adversarial review - APPROVE.
- GLM adversarial review - APPROVE.

Review finding verification:
- Gemini Code Assist temp-dir cleanup finding was valid and fixed in `848fc66`.
- DeepSeek's note about missing DeepSeek/GLM `companion-common.mjs` copies was checked and is not valid: API reviewers do not package `companion-common.mjs`.
- DeepSeek's option-key-shape concern was checked and is not a bug: companion `parseArgs` stores `--scope-base` as `options["scope-base"]`, and the Kimi smoke test exercises the real CLI path.
- Whitespace-only custom-review `scope-base` is a minor test-parity note, not a behavior gap: `scopeBaseForOptions` tests whitespace handling directly, and both `review` and `custom-review` flow through that same helper.

## Remaining Scope
#176 Grok readiness/transport remains separate and should be handled in its own PR after #177 merges or is explicitly paused.