### PR TITLE
Report Grok auto transport readiness

### DIFF
--- a/plugins/grok/scripts/grok-web-reviewer.mjs
+++ b/plugins/grok/scripts/grok-web-reviewer.mjs
@@ -1545,8 +1545,18 @@ function isGrokCliAuthPromptFailure(stderr) {
   return /failed to get default browser|open this url to sign in|login timed out|auth:\s*timed out|OSStatus error -10661/i.test(text);
 }
 
+function grokCliAuthHttpStatus(stderr) {
+  const text = String(stderr ?? "");
+  if (/\b401\s+Unauthorized\b/i.test(text)) return 401;
+  if (/\b403\s+Forbidden\b/i.test(text)) return 403;
+  const match = text.match(/(?:http_status["'\s:=]+|status["'\s:=]+)(401|403)\b/i);
+  return match ? Number(match[1]) : null;
+}
+
 function isGrokCliAuthRepairCode(errorCode) {
-  return errorCode === "grok_cli_login_required" || errorCode === "grok_cli_auth_timeout";
+  return errorCode === "grok_cli_login_required"
+    || errorCode === "grok_cli_auth_timeout"
+    || errorCode === "grok_cli_auth_unavailable";
 }
 
 function providerCapabilitiesForConfig(cfg) {
@@ -2013,11 +2023,15 @@ async function callGrokCli(cfg, prompt, { sourceBearing = true, baseDiagnostics 
   if (result.error || result.status !== 0) {
     const timedOut = result.error?.code === "ETIMEDOUT" || result.signal === "SIGTERM";
     const authPromptFailed = !sourceBearing && isGrokCliAuthPromptFailure(result.stderr);
-    const reason = authPromptFailed ? "grok_cli_auth_timeout" : (timedOut ? "grok_cli_timeout" : "grok_cli_failed");
+    const authHttpStatus = !sourceBearing ? grokCliAuthHttpStatus(result.stderr) : null;
+    const authRejected = authHttpStatus === 401 || authHttpStatus === 403;
+    const reason = authPromptFailed
+      ? "grok_cli_auth_timeout"
+      : (authRejected ? "grok_cli_auth_unavailable" : (timedOut ? "grok_cli_timeout" : "grok_cli_failed"));
     return providerFailureWithDiagnostic(
       reason,
       grokCliCommandError("grok --prompt-file", result),
-      null,
+      authHttpStatus,
       trimText(result.stdout).slice(0, 2000) || null,
       grokCliSourceTransmissionForResult(sourceBearing, result),
       diagnostics,
@@ -3110,6 +3124,9 @@ function suggestedAction(errorCode, errorMessage = "", tunnelStart = null) {
   }
   if (errorCode === "grok_cli_auth_timeout") {
     return "Complete `grok login` in a normal terminal or fix default-browser auth handling, ensure `grok models` reports a logged-in account and lists grok-build, then retry the Grok CLI reviewer. Do not switch provider or transport in default CLI mode.";
+  }
+  if (errorCode === "grok_cli_auth_unavailable") {
+    return "Refresh Grok CLI auth with `grok login --device-auth` or `grok login --oauth`, ensure a source-free `grok --prompt-file` request can complete, then retry the Grok CLI reviewer. Do not switch provider or transport in default CLI mode.";
   }
   if (String(errorCode ?? "").startsWith("grok_cli_")) return "Treat this Grok CLI slot as failed. Inspect runtime diagnostics, repair the local Grok CLI auth/binary/runtime issue, and retry without falling back to another provider or transport.";
   return sharedDiagnostic?.suggested_action ?? "Inspect error_message and repair the local Grok web tunnel before retrying.";

--- a/plugins/grok/scripts/grok-web-reviewer.mjs
+++ b/plugins/grok/scripts/grok-web-reviewer.mjs
@@ -4031,7 +4031,8 @@ function doctorRouteSummary(doctor) {
   };
 }
 
-function trustedCliDoctorFailure(cfg, errorMessage) {
+function trustedCliDoctorFailure(cfg, errorMessage, env = process.env) {
+  const ignoredEnvCredentials = ignoredGrokDirectApiEnvKeys(cfg, env);
   return {
     provider: cfg.provider,
     status: "ok",
@@ -4054,6 +4055,8 @@ function trustedCliDoctorFailure(cfg, errorMessage) {
     default_model: null,
     logged_in: null,
     model_ready: null,
+    ignored_env_credentials: ignoredEnvCredentials,
+    auth_policy: ignoredEnvCredentials.length > 0 ? "api_key_env_ignored" : null,
     timeout_ms: cfg.timeout_ms,
     max_turns: cfg.max_turns,
     transport: cfg.transport,
@@ -4095,7 +4098,7 @@ async function autoDoctorFields(cfg, env = process.env) {
     });
     primary = await cliDoctorFields(trustedCfg, env);
   } catch (error) {
-    primary = trustedCliDoctorFailure(cfg, redactor(env)(error?.message ?? String(error)));
+    primary = trustedCliDoctorFailure(cfg, redactor(env)(error?.message ?? String(error)), env);
   }
 
   if (primary.ready === true || !GROK_CLI_AUTO_FALLBACK_CODES.has(primary.error_code)) {
@@ -4118,6 +4121,7 @@ async function autoDoctorFields(cfg, env = process.env) {
   const fallbackReady = fallback.ready === true;
   const fallbackReason = primary.error_code ?? "grok_cli_unavailable";
   return {
+    ...fallback,
     provider: "grok",
     status: fallbackReady ? "fallback_ready" : "fallback_not_ready",
     ready: fallbackReady,
@@ -4167,7 +4171,7 @@ async function doctorFields(env = process.env, options = {}) {
       });
     } catch (error) {
       const errorMessage = redactor(env)(error?.message ?? String(error));
-      return trustedCliDoctorFailure(cfg, errorMessage);
+      return trustedCliDoctorFailure(cfg, errorMessage, env);
     }
     return cliDoctorFields(cfg, env);
   }

--- a/plugins/grok/scripts/grok-web-reviewer.mjs
+++ b/plugins/grok/scripts/grok-web-reviewer.mjs
@@ -3967,6 +3967,7 @@ async function cliDoctorFields(cfg, env = process.env) {
       ? "Run a Grok CLI review."
       : suggestedAction(errorCode, preflight?.parsed?.error ?? ""),
     auth_mode: cfg.auth_mode,
+    selected_route: cfg.auth_mode,
     credential_ref: null,
     endpoint: null,
     probe_endpoint: null,
@@ -4017,7 +4018,7 @@ function doctorRouteSummary(doctor) {
     auth_mode: doctor.auth_mode ?? null,
     transport: doctor.transport ?? null,
     selected_transport: doctor.selected_transport ?? doctor.transport ?? null,
-    selected_route: doctor.selected_route ?? (doctor.auth_mode ?? null),
+    selected_route: doctor.selected_route ?? null,
     fallback_from: doctor.fallback_from ?? null,
     fallback_reason: doctor.fallback_reason ?? null,
     error_code: doctor.error_code ?? null,
@@ -4042,6 +4043,7 @@ function trustedCliDoctorFailure(cfg, errorMessage) {
     summary: "Grok subscription-backed CLI reviewer binary is not trusted.",
     next_action: suggestedAction("grok_cli_untrusted_binary", errorMessage),
     auth_mode: cfg.auth_mode,
+    selected_route: cfg.auth_mode,
     credential_ref: null,
     endpoint: null,
     probe_endpoint: null,
@@ -4217,6 +4219,7 @@ async function doctorFields(env = process.env, options = {}) {
       ? "Run a Grok web review."
       : suggestedAction(errorCode, "", tunnelStart),
     auth_mode: cfg.auth_mode,
+    selected_route: cfg.auth_mode,
     credential_ref: cfg.credential_ref,
     endpoint: cfg.base_url,
     probe_endpoint: probe.probe_endpoint,

--- a/plugins/grok/scripts/grok-web-reviewer.mjs
+++ b/plugins/grok/scripts/grok-web-reviewer.mjs
@@ -3993,8 +3993,152 @@ async function cliDoctorFields(cfg, env = process.env) {
   };
 }
 
+function doctorRouteSummary(doctor) {
+  return {
+    provider: doctor.provider ?? null,
+    ready: doctor.ready === true,
+    auth_mode: doctor.auth_mode ?? null,
+    transport: doctor.transport ?? null,
+    selected_transport: doctor.selected_transport ?? doctor.transport ?? null,
+    selected_route: doctor.selected_route ?? (doctor.auth_mode ?? null),
+    fallback_from: doctor.fallback_from ?? null,
+    fallback_reason: doctor.fallback_reason ?? null,
+    error_code: doctor.error_code ?? null,
+    logged_in: doctor.logged_in ?? null,
+    model_ready: doctor.model_ready ?? null,
+    models_ready: doctor.models_ready ?? null,
+    chat_ready: doctor.chat_ready ?? null,
+    readiness_layers: doctor.readiness_layers ?? null,
+    next_action: doctor.next_action ?? null,
+  };
+}
+
+function trustedCliDoctorFailure(cfg, errorMessage) {
+  return {
+    provider: cfg.provider,
+    status: "ok",
+    ready: false,
+    reachable: false,
+    models_ready: null,
+    model_count: null,
+    chat_ready: false,
+    summary: "Grok subscription-backed CLI reviewer binary is not trusted.",
+    next_action: suggestedAction("grok_cli_untrusted_binary", errorMessage),
+    auth_mode: cfg.auth_mode,
+    credential_ref: null,
+    endpoint: null,
+    probe_endpoint: null,
+    chat_probe_endpoint: null,
+    model: cfg.model,
+    binary: cfg.binary,
+    grok_version: null,
+    default_model: null,
+    logged_in: null,
+    model_ready: null,
+    timeout_ms: cfg.timeout_ms,
+    max_turns: cfg.max_turns,
+    transport: cfg.transport,
+    readiness_layers: {
+      cli_binary: {
+        status: "failed",
+        error_code: "grok_cli_untrusted_binary",
+      },
+      models: {
+        status: "not_checked",
+        model: cfg.model,
+        default_model: null,
+      },
+      cli_login: {
+        status: "not_checked",
+        logged_in: null,
+      },
+      source_free_prompt: {
+        status: "skipped",
+        parse_mode: null,
+        prompt_cleanup: null,
+        grok_home_cleanup: null,
+      },
+    },
+    error_code: "grok_cli_untrusted_binary",
+    error_message: errorMessage,
+    http_status: null,
+    chat_http_status: null,
+  };
+}
+
+async function autoDoctorFields(cfg, env = process.env) {
+  let primary;
+  try {
+    const trustedCfg = resolveTrustedGrokCliConfig(cfg, {
+      cwd: process.cwd(),
+      workspaceRoot: bestEffortWorkspaceRoot(process.cwd()),
+      env,
+    });
+    primary = await cliDoctorFields(trustedCfg, env);
+  } catch (error) {
+    primary = trustedCliDoctorFailure(cfg, redactor(env)(error?.message ?? String(error)));
+  }
+
+  if (primary.ready === true || !GROK_CLI_AUTO_FALLBACK_CODES.has(primary.error_code)) {
+    return {
+      ...primary,
+      requested_transport: "auto",
+      transport: "auto",
+      selected_transport: "cli",
+      selected_route: "subscription_cli",
+      fallback_from: null,
+      fallback_reason: null,
+      auto_transport: {
+        primary: doctorRouteSummary(primary),
+        fallback: null,
+      },
+    };
+  }
+
+  const fallback = await doctorFields(env, { transport: "web" });
+  const fallbackReady = fallback.ready === true;
+  const fallbackReason = primary.error_code ?? "grok_cli_unavailable";
+  return {
+    provider: "grok",
+    status: fallbackReady ? "fallback_ready" : "fallback_not_ready",
+    ready: fallbackReady,
+    reachable: fallback.reachable ?? false,
+    models_ready: fallback.models_ready ?? null,
+    model_count: fallback.model_count ?? null,
+    chat_ready: fallback.chat_ready ?? false,
+    summary: fallbackReady
+      ? "Grok auto transport CLI primary is not ready, but the local web fallback is ready."
+      : "Grok auto transport CLI primary and local web fallback are not ready.",
+    next_action: fallbackReady
+      ? `${primary.next_action} Until CLI auth is repaired, rerun with --transport auto to use the ready local web fallback while preserving the CLI failure metadata.`
+      : `${primary.next_action} Local web fallback is also not ready: ${fallback.next_action}`,
+    auth_mode: fallback.auth_mode ?? primary.auth_mode,
+    credential_ref: fallback.credential_ref ?? primary.credential_ref,
+    endpoint: fallback.endpoint ?? primary.endpoint,
+    probe_endpoint: fallback.probe_endpoint ?? primary.probe_endpoint,
+    chat_probe_endpoint: fallback.chat_probe_endpoint ?? primary.chat_probe_endpoint,
+    model: fallback.model ?? primary.model,
+    timeout_ms: fallback.timeout_ms ?? primary.timeout_ms,
+    transport: "auto",
+    requested_transport: "auto",
+    selected_transport: "web",
+    selected_route: "subscription_web",
+    fallback_from: "cli",
+    fallback_reason: fallbackReason,
+    auto_transport: {
+      primary: doctorRouteSummary(primary),
+      fallback: doctorRouteSummary(fallback),
+    },
+    error_code: fallbackReady ? null : (fallback.error_code ?? fallbackReason),
+    error_message: fallbackReady ? null : (fallback.error_message ?? primary.error_message ?? null),
+    http_status: fallback.http_status ?? primary.http_status ?? null,
+    chat_http_status: fallback.chat_http_status ?? primary.chat_http_status ?? null,
+  };
+}
+
 async function doctorFields(env = process.env, options = {}) {
   let cfg = config(env, options);
+  if (cfg.transport === "cli" && cfg.requested_transport === "auto") return autoDoctorFields(cfg, env);
   if (cfg.transport === "cli") {
     try {
       cfg = resolveTrustedGrokCliConfig(cfg, {
@@ -4004,56 +4148,7 @@ async function doctorFields(env = process.env, options = {}) {
       });
     } catch (error) {
       const errorMessage = redactor(env)(error?.message ?? String(error));
-      return {
-        provider: cfg.provider,
-        status: "ok",
-        ready: false,
-        reachable: false,
-        models_ready: null,
-        model_count: null,
-        chat_ready: false,
-        summary: "Grok subscription-backed CLI reviewer binary is not trusted.",
-        next_action: suggestedAction("grok_cli_untrusted_binary", errorMessage),
-        auth_mode: cfg.auth_mode,
-        credential_ref: null,
-        endpoint: null,
-        probe_endpoint: null,
-        chat_probe_endpoint: null,
-        model: cfg.model,
-        binary: cfg.binary,
-        grok_version: null,
-        default_model: null,
-        logged_in: null,
-        model_ready: null,
-        timeout_ms: cfg.timeout_ms,
-        max_turns: cfg.max_turns,
-        transport: cfg.transport,
-        readiness_layers: {
-          cli_binary: {
-            status: "failed",
-            error_code: "grok_cli_untrusted_binary",
-          },
-          models: {
-            status: "not_checked",
-            model: cfg.model,
-            default_model: null,
-          },
-          cli_login: {
-            status: "not_checked",
-            logged_in: null,
-          },
-          source_free_prompt: {
-            status: "skipped",
-            parse_mode: null,
-            prompt_cleanup: null,
-            grok_home_cleanup: null,
-          },
-        },
-        error_code: "grok_cli_untrusted_binary",
-        error_message: errorMessage,
-        http_status: null,
-        chat_http_status: null,
-      };
+      return trustedCliDoctorFailure(cfg, errorMessage);
     }
     return cliDoctorFields(cfg, env);
   }
@@ -4113,6 +4208,7 @@ async function doctorFields(env = process.env, options = {}) {
     timeout_ms: cfg.timeout_ms,
     doctor_timeout_ms: cfg.doctor_timeout_ms,
     chat_doctor_timeout_ms: cfg.chat_doctor_timeout_ms,
+    transport: cfg.transport,
     tunnel_start_timeout_ms: cfg.tunnel_start_timeout_ms,
     tunnel_cleanup_timeout_ms: cfg.tunnel_cleanup_timeout_ms,
     tunnel_start: tunnelStart,

--- a/specs/176-grok-cli-readiness-auto/evidence-map.md
+++ b/specs/176-grok-cli-readiness-auto/evidence-map.md
@@ -1,0 +1,50 @@
+# #176 Grok CLI readiness / transport auto evidence map
+
+## Issue Evidence
+
+- Issue #176 reported repeated `grok_cli_login_required` on the CLI primary path while
+  `--transport auto` successfully completed through the subscription web fallback.
+- Fresh local doctor evidence on 2026-05-26 shows the current machine has both transports
+  ready:
+  - `doctor --transport cli`: `ready:true`, `auth_mode:"subscription_cli"`,
+    `logged_in:true`, `model_ready:true`, selected CLI binary
+    `/Users/spson/.grok/downloads/grok-0.1.219-macos-aarch64`.
+  - `doctor --transport web`: `ready:true`, `auth_mode:"subscription_web"`,
+    chat probe HTTP 200 through `http://127.0.0.1:8000/v1`.
+  - `doctor --transport auto`: `ready:true`, `requested_transport:"auto"`,
+    `selected_transport:"cli"`, `selected_route:"subscription_cli"`,
+    `fallback_reason:null`, and `auto_transport.primary.logged_in:true`.
+
+## Root Cause
+
+`run --transport auto` already treated Grok's CLI and web transports as adapter
+capability facts: CLI is tried first, source is sent only after a successful selected
+route, and pre-source CLI failures can fall back to subscription web with
+`runtime_diagnostics.cli_request` and `fallback_reason` recorded.
+
+The missing piece was `doctor --transport auto`. It reused the CLI doctor output and
+stopped after CLI failure, so operators could not see whether auto routing would have
+a ready subscription web fallback before launching a review.
+
+## Fix
+
+- Keep shared route/source policy untouched.
+- Add Grok adapter-level auto-doctor reporting:
+  - CLI primary readiness is always reported in `auto_transport.primary`.
+  - If the CLI primary is ready, auto doctor selects `subscription_cli` and does not
+    probe fallback.
+  - If the CLI primary fails with an auto-fallback-eligible pre-source reason, auto
+    doctor probes the subscription web fallback and reports `selected_route`,
+    `fallback_reason`, and `auto_transport.fallback`.
+  - The next action preserves the deterministic CLI repair path while making the
+    `--transport auto` fallback behavior explicit.
+
+## Verification Map
+
+- Regression test: `doctor auto transport reports CLI login failure and ready web fallback`.
+- Existing route test retained: `custom-review auto transport falls back from Grok CLI
+  login failure to local web tunnel`.
+- Existing budget test retained: `custom-review auto transport preserves CLI diagnostics
+  when web fallback prompt is too large`.
+- Existing readiness tests retained for explicit CLI-login and explicit web doctor paths.
+

--- a/specs/176-grok-cli-readiness-auto/evidence-map.md
+++ b/specs/176-grok-cli-readiness-auto/evidence-map.md
@@ -14,6 +14,12 @@
   - `doctor --transport auto`: `ready:true`, `requested_transport:"auto"`,
     `selected_transport:"cli"`, `selected_route:"subscription_cli"`,
     `fallback_reason:null`, and `auto_transport.primary.logged_in:true`.
+- A live Grok self-review on the first PR #184 head found a second pre-source
+  readiness edge: `doctor --transport auto` selected CLI as ready, but the immediate
+  source-free run preflight returned CLI 403 from
+  `https://cli-chat-proxy.grok.com/v1/responses`. The selected source was not sent,
+  but the failure was classified as generic `grok_cli_failed`, so `--transport auto`
+  did not try the ready web fallback.
 
 ## Root Cause
 
@@ -25,6 +31,10 @@ route, and pre-source CLI failures can fall back to subscription web with
 The missing piece was `doctor --transport auto`. It reused the CLI doctor output and
 stopped after CLI failure, so operators could not see whether auto routing would have
 a ready subscription web fallback before launching a review.
+
+The live review also showed that a source-free CLI prompt can fail with 401/403 after
+`grok models` reports logged-in/model-ready. That is still a pre-source auth
+readiness failure, but it was not mapped to an auto-fallback-eligible reason.
 
 ## Fix
 
@@ -38,13 +48,18 @@ a ready subscription web fallback before launching a review.
     `fallback_reason`, and `auto_transport.fallback`.
   - The next action preserves the deterministic CLI repair path while making the
     `--transport auto` fallback behavior explicit.
+- Classify source-free CLI prompt 401/403 failures as `grok_cli_auth_unavailable`.
+  This keeps the failed CLI readiness visible, keeps source transmission as not sent
+  for the CLI attempt, and lets explicit auto mode try subscription web with
+  `fallback_reason:"grok_cli_auth_unavailable"`.
 
 ## Verification Map
 
 - Regression test: `doctor auto transport reports CLI login failure and ready web fallback`.
+- Regression test: `custom-review auto transport falls back from source-free Grok CLI
+  auth rejection`.
 - Existing route test retained: `custom-review auto transport falls back from Grok CLI
   login failure to local web tunnel`.
 - Existing budget test retained: `custom-review auto transport preserves CLI diagnostics
   when web fallback prompt is too large`.
 - Existing readiness tests retained for explicit CLI-login and explicit web doctor paths.
-

--- a/tests/smoke/grok-web.smoke.test.mjs
+++ b/tests/smoke/grok-web.smoke.test.mjs
@@ -1215,6 +1215,73 @@ test("custom-review auto transport falls back from Grok CLI login failure to loc
   }
 });
 
+test("doctor auto transport reports CLI login failure and ready web fallback", async () => {
+  const dataDir = mkdtempSync(path.join(tmpdir(), "grok-auto-doctor-fallback-data-"));
+  const authHome = mkdtempSync(path.join(tmpdir(), "grok-auto-doctor-fallback-auth-home-"));
+  const { binDir, grokPath, logPath } = makeFakeGrokCli({ modelsOutput: GROK_MODELS_READY_LOGGED_OUT });
+  writeFileSync(path.join(authHome, "auth.json"), "{\"token\":\"fake\"}\n");
+  writeFileSync(path.join(authHome, "config.toml"), "[models]\ndefault = \"grok-build\"\n");
+  const webRequests = [];
+
+  try {
+    await withServer(async (req, res) => {
+      webRequests.push(`${req.method} ${req.url}`);
+      res.setHeader("content-type", "application/json");
+      if (req.url === "/api/models") {
+        res.end(JSON.stringify({ data: [{ id: "grok-4.20-fast" }] }));
+        return;
+      }
+      if (req.url === "/api/chat/completions") {
+        res.end(JSON.stringify({
+          id: "chatcmpl-auto-doctor",
+          model: "grok-4.20-fast",
+          choices: [{ message: { content: "ok" } }],
+        }));
+        return;
+      }
+      res.writeHead(404);
+      res.end(JSON.stringify({ error: { message: "not found" } }));
+    }, async (baseUrl) => {
+      const result = await runAsync(["doctor", "--transport", "auto"], {
+        defaultTransport: false,
+        env: {
+          PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+          GROK_CLI_BINARY: grokPath,
+          GROK_CLI_AUTH_HOME: authHome,
+          GROK_PLUGIN_DATA: dataDir,
+          GROK_WEB_BASE_URL: baseUrl,
+        },
+      });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      const parsed = parseStdout(result);
+      assert.equal(parsed.status, "fallback_ready");
+      assert.equal(parsed.ready, true);
+      assert.equal(parsed.transport, "auto");
+      assert.equal(parsed.selected_transport, "web");
+      assert.equal(parsed.selected_route, "subscription_web");
+      assert.equal(parsed.fallback_from, "cli");
+      assert.equal(parsed.fallback_reason, "grok_cli_login_required");
+      assert.equal(parsed.auto_transport.primary.auth_mode, "subscription_cli");
+      assert.equal(parsed.auto_transport.primary.ready, false);
+      assert.equal(parsed.auto_transport.primary.error_code, "grok_cli_login_required");
+      assert.equal(parsed.auto_transport.primary.logged_in, false);
+      assert.equal(parsed.auto_transport.fallback.auth_mode, "subscription_web");
+      assert.equal(parsed.auto_transport.fallback.transport, "web");
+      assert.equal(parsed.auto_transport.fallback.ready, true);
+      assert.equal(parsed.auto_transport.fallback.error_code, null);
+      assert.match(parsed.next_action, /grok login/i);
+      assert.match(parsed.next_action, /--transport auto/i);
+      assert.deepEqual(readGrokCliLog(logPath).map((line) => line.args[0]), ["--version", "models"]);
+      assert.deepEqual(webRequests, ["GET /api/models", "POST /api/chat/completions"]);
+      assert.doesNotMatch(result.stdout, /fake|CLI_SOURCE_SECRET/);
+    });
+  } finally {
+    rmTree(authHome);
+    rmTree(dataDir);
+  }
+});
+
 test("custom-review auto transport preserves CLI diagnostics when web fallback prompt is too large", async () => {
   const cwd = realpathSync(mkdtempSync(path.join(tmpdir(), "grok-auto-web-budget-workspace-")));
   const dataDir = mkdtempSync(path.join(tmpdir(), "grok-auto-web-budget-data-"));

--- a/tests/smoke/grok-web.smoke.test.mjs
+++ b/tests/smoke/grok-web.smoke.test.mjs
@@ -1294,6 +1294,79 @@ test("doctor auto transport reports CLI login failure and ready web fallback", a
   }
 });
 
+test("doctor auto transport reports source-free CLI auth rejection and ready web fallback", async () => {
+  const dataDir = mkdtempSync(path.join(tmpdir(), "grok-auto-doctor-source-free-auth-data-"));
+  const authHome = mkdtempSync(path.join(tmpdir(), "grok-auto-doctor-source-free-auth-home-"));
+  const { binDir, grokPath, logPath } = makeFakeGrokCli({
+    sourceFreeAuthStderr: [
+      "ERROR responses API error status=403 Forbidden error_message=error code: 1000",
+      "Request URL: https://cli-chat-proxy.grok.com/v1/responses",
+      "model_id=grok-build",
+      "",
+    ].join("\n"),
+  });
+  writeFileSync(path.join(authHome, "auth.json"), "{\"token\":\"fake\"}\n");
+  writeFileSync(path.join(authHome, "config.toml"), "[models]\ndefault = \"grok-build\"\n");
+  const webRequests = [];
+
+  try {
+    await withServer(async (req, res) => {
+      webRequests.push(`${req.method} ${req.url}`);
+      res.setHeader("content-type", "application/json");
+      if (req.url === "/api/models") {
+        res.end(JSON.stringify({ data: [{ id: "grok-4.20-fast" }] }));
+        return;
+      }
+      if (req.url === "/api/chat/completions") {
+        res.end(JSON.stringify({
+          id: "chatcmpl-auto-doctor-source-free-auth",
+          model: "grok-4.20-fast",
+          choices: [{ message: { content: "ok" } }],
+        }));
+        return;
+      }
+      res.writeHead(404);
+      res.end(JSON.stringify({ error: { message: "not found" } }));
+    }, async (baseUrl) => {
+      const result = await runAsync(["doctor", "--transport", "auto"], {
+        defaultTransport: false,
+        env: {
+          PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+          GROK_CLI_BINARY: grokPath,
+          GROK_CLI_AUTH_HOME: authHome,
+          GROK_PLUGIN_DATA: dataDir,
+          GROK_WEB_BASE_URL: baseUrl,
+        },
+      });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      const parsed = parseStdout(result);
+      assert.equal(parsed.status, "fallback_ready");
+      assert.equal(parsed.ready, true);
+      assert.equal(parsed.transport, "auto");
+      assert.equal(parsed.selected_transport, "web");
+      assert.equal(parsed.selected_route, "subscription_web");
+      assert.equal(parsed.fallback_from, "cli");
+      assert.equal(parsed.fallback_reason, "grok_cli_auth_unavailable");
+      assert.equal(parsed.auto_transport.primary.auth_mode, "subscription_cli");
+      assert.equal(parsed.auto_transport.primary.ready, false);
+      assert.equal(parsed.auto_transport.primary.error_code, "grok_cli_auth_unavailable");
+      assert.equal(parsed.auto_transport.primary.logged_in, true);
+      assert.equal(parsed.auto_transport.primary.model_ready, true);
+      assert.equal(parsed.auto_transport.fallback.auth_mode, "subscription_web");
+      assert.equal(parsed.auto_transport.fallback.ready, true);
+      const cliInvocations = readGrokCliLog(logPath);
+      assert.equal(cliInvocations.at(-1).promptHasSource, false);
+      assert.deepEqual(webRequests, ["GET /api/models", "POST /api/chat/completions"]);
+      assert.doesNotMatch(result.stdout, /CLI_SOURCE_SECRET/);
+    });
+  } finally {
+    rmTree(authHome);
+    rmTree(dataDir);
+    rmTree(binDir);
+  }
+});
+
 test("doctor auto transport reports untrusted CLI auth policy fields", () => {
   const cwd = realpathSync(mkdtempSync(path.join(tmpdir(), "grok-auto-doctor-untrusted-workspace-")));
   const dataDir = mkdtempSync(path.join(tmpdir(), "grok-auto-doctor-untrusted-data-"));

--- a/tests/smoke/grok-web.smoke.test.mjs
+++ b/tests/smoke/grok-web.smoke.test.mjs
@@ -1282,6 +1282,75 @@ test("doctor auto transport reports CLI login failure and ready web fallback", a
   }
 });
 
+test("custom-review auto transport falls back from source-free Grok CLI auth rejection", async () => {
+  const cwd = realpathSync(mkdtempSync(path.join(tmpdir(), "grok-auto-source-free-auth-workspace-")));
+  const dataDir = mkdtempSync(path.join(tmpdir(), "grok-auto-source-free-auth-data-"));
+  const authHome = mkdtempSync(path.join(tmpdir(), "grok-auto-source-free-auth-home-"));
+  const { binDir, grokPath } = makeFakeGrokCli({
+    sourceFreeAuthStderr: [
+      "ERROR responses API error status=403 Forbidden error_message=error code: 1000",
+      "Request URL: https://cli-chat-proxy.grok.com/v1/responses",
+      "model_id=grok-build",
+      "",
+    ].join("\n"),
+  });
+  writeGrokCliAuthFixture(cwd, authHome);
+  const webRequests = [];
+
+  try {
+    await withServer(async (req, res) => {
+      webRequests.push(`${req.method} ${req.url}`);
+      assert.equal(req.url, "/api/chat/completions");
+      const body = await readJsonRequest(req);
+      assert.match(body.messages[0].content, /BEGIN GROK FILE 1: review\.js/);
+      assert.match(body.messages[0].content, /CLI_SOURCE_SECRET/);
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({
+        id: "grok-auto-source-free-auth-fallback",
+        model: "grok-4.20-fast",
+        choices: [{ message: { content: substantiveReviewFixture("Auto fallback handled source-free auth rejection.") } }],
+      }));
+    }, async (baseUrl) => {
+      const result = await runAsync([
+        "run",
+        "--transport", "auto",
+        "--mode", "custom-review",
+        "--scope", "custom",
+        "--scope-paths", "review.js",
+        "--foreground",
+        "--prompt", "Review selected source.",
+      ], {
+        cwd,
+        defaultTransport: false,
+        env: {
+          PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+          GROK_CLI_BINARY: grokPath,
+          GROK_CLI_AUTH_HOME: authHome,
+          GROK_PLUGIN_DATA: dataDir,
+          GROK_WEB_BASE_URL: baseUrl,
+        },
+      });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      const record = parseStdout(result);
+      assert.equal(record.provider, "grok-web");
+      assert.equal(record.transport, "web");
+      assert.equal(record.fallback_from, "cli");
+      assert.equal(record.review_metadata.audit_manifest.selected_route, "subscription_web");
+      assert.equal(record.review_metadata.audit_manifest.fallback_reason, "grok_cli_auth_unavailable");
+      assert.equal(record.external_review.source_content_transmission, "sent");
+      assert.equal(record.runtime_diagnostics.cli_request.error_code, "grok_cli_auth_unavailable");
+      assert.equal(record.runtime_diagnostics.cli_request.logged_in, true);
+      assert.equal(record.runtime_diagnostics.cli_request.model_ready, true);
+      assert.deepEqual(webRequests, ["POST /api/chat/completions"]);
+    });
+  } finally {
+    rmTree(authHome);
+    rmTree(cwd);
+    rmTree(dataDir);
+  }
+});
+
 test("custom-review auto transport preserves CLI diagnostics when web fallback prompt is too large", async () => {
   const cwd = realpathSync(mkdtempSync(path.join(tmpdir(), "grok-auto-web-budget-workspace-")));
   const dataDir = mkdtempSync(path.join(tmpdir(), "grok-auto-web-budget-data-"));

--- a/tests/smoke/grok-web.smoke.test.mjs
+++ b/tests/smoke/grok-web.smoke.test.mjs
@@ -1260,6 +1260,15 @@ test("doctor auto transport reports CLI login failure and ready web fallback", a
       assert.equal(parsed.transport, "auto");
       assert.equal(parsed.selected_transport, "web");
       assert.equal(parsed.selected_route, "subscription_web");
+      assert.equal(parsed.chat_ready, true);
+      assert.deepEqual(parsed.durability_warnings, []);
+      assert.equal(parsed.readiness_layers.listener.status, "reachable");
+      assert.equal(parsed.readiness_layers.chat_probe.status, "ready");
+      assert.equal(parsed.chat_probe.status, "ready");
+      assert.equal(parsed.session_diagnostics.status, "not_checked");
+      assert.equal(parsed.cost_quota_readiness.status, "unknown_not_probed");
+      assert.ok(Number.isInteger(parsed.doctor_timeout_ms));
+      assert.ok(Number.isInteger(parsed.chat_doctor_timeout_ms));
       assert.equal(parsed.fallback_from, "cli");
       assert.equal(parsed.fallback_reason, "grok_cli_login_required");
       assert.equal(parsed.auto_transport.primary.auth_mode, "subscription_cli");
@@ -1280,6 +1289,44 @@ test("doctor auto transport reports CLI login failure and ready web fallback", a
     });
   } finally {
     rmTree(authHome);
+    rmTree(dataDir);
+    rmTree(binDir);
+  }
+});
+
+test("doctor auto transport reports untrusted CLI auth policy fields", () => {
+  const cwd = realpathSync(mkdtempSync(path.join(tmpdir(), "grok-auto-doctor-untrusted-workspace-")));
+  const dataDir = mkdtempSync(path.join(tmpdir(), "grok-auto-doctor-untrusted-data-"));
+  const workspaceBin = path.join(cwd, "node_modules", ".bin");
+  const { binDir, grokPath, logPath } = makeFakeGrokCli();
+  mkdirSync(workspaceBin, { recursive: true });
+  cpSync(grokPath, path.join(workspaceBin, "grok"));
+  chmodSync(path.join(workspaceBin, "grok"), 0o700);
+
+  try {
+    const result = run(["doctor", "--transport", "auto"], {
+      cwd,
+      defaultTransport: false,
+      env: {
+        PATH: `${workspaceBin}${path.delimiter}${process.env.PATH ?? ""}`,
+        GROK_PLUGIN_DATA: dataDir,
+        XAI_API_KEY: "direct-api-key-must-not-leak",
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const parsed = parseStdout(result);
+    assert.equal(parsed.ready, false);
+    assert.equal(parsed.transport, "auto");
+    assert.equal(parsed.selected_transport, "cli");
+    assert.equal(parsed.selected_route, "subscription_cli");
+    assert.equal(parsed.error_code, "grok_cli_untrusted_binary");
+    assert.deepEqual(parsed.ignored_env_credentials, ["XAI_API_KEY"]);
+    assert.equal(parsed.auth_policy, "api_key_env_ignored");
+    assert.deepEqual(readGrokCliLog(logPath), []);
+    assert.doesNotMatch(result.stdout, /direct-api-key-must-not-leak/);
+  } finally {
+    rmTree(cwd);
     rmTree(dataDir);
     rmTree(binDir);
   }

--- a/tests/smoke/grok-web.smoke.test.mjs
+++ b/tests/smoke/grok-web.smoke.test.mjs
@@ -1263,11 +1263,13 @@ test("doctor auto transport reports CLI login failure and ready web fallback", a
       assert.equal(parsed.fallback_from, "cli");
       assert.equal(parsed.fallback_reason, "grok_cli_login_required");
       assert.equal(parsed.auto_transport.primary.auth_mode, "subscription_cli");
+      assert.equal(parsed.auto_transport.primary.selected_route, "subscription_cli");
       assert.equal(parsed.auto_transport.primary.ready, false);
       assert.equal(parsed.auto_transport.primary.error_code, "grok_cli_login_required");
       assert.equal(parsed.auto_transport.primary.logged_in, false);
       assert.equal(parsed.auto_transport.fallback.auth_mode, "subscription_web");
       assert.equal(parsed.auto_transport.fallback.transport, "web");
+      assert.equal(parsed.auto_transport.fallback.selected_route, "subscription_web");
       assert.equal(parsed.auto_transport.fallback.ready, true);
       assert.equal(parsed.auto_transport.fallback.error_code, null);
       assert.match(parsed.next_action, /grok login/i);
@@ -1279,6 +1281,7 @@ test("doctor auto transport reports CLI login failure and ready web fallback", a
   } finally {
     rmTree(authHome);
     rmTree(dataDir);
+    rmTree(binDir);
   }
 });
 
@@ -1348,6 +1351,7 @@ test("custom-review auto transport falls back from source-free Grok CLI auth rej
     rmTree(authHome);
     rmTree(cwd);
     rmTree(dataDir);
+    rmTree(binDir);
   }
 });
 


### PR DESCRIPTION
Closes #176.

## Problem and Root Cause
`run --transport auto` already had the intended Grok behavior: try subscription CLI first, fall back to subscription web only for pre-source CLI readiness/auth/model failures, preserve CLI failure diagnostics, and never use paid xAI API fallback.

The gap was the readiness and preflight surface. `doctor --transport auto` reused CLI-only doctor output, so operators could not see whether subscription web fallback was ready. A live Grok self-review also exposed a source-free CLI 403 path: `grok models` can report logged-in/model-ready while a later source-free CLI review preflight is rejected before source send.

## Why This Is Not Model-Specific Policy
This does not change shared route/source policy or add provider-specific approval/source-send rules. Grok has two subscription transports, so the Grok adapter reports transport capability facts and fallback diagnostics. Selected source is still sent only through the selected ready route.

## Implementation Summary
- Added auto-doctor reporting for Grok:
  - CLI primary readiness is exposed under `auto_transport.primary`.
  - CLI-ready auto doctor selects `subscription_cli` and does not probe fallback.
  - CLI pre-source fallback-eligible failures probe subscription web and expose `selected_transport`, `selected_route`, `fallback_from`, `fallback_reason`, and `auto_transport.fallback`.
  - Auto web fallback preserves standard web doctor diagnostics at the top level (`readiness_layers`, `chat_probe`, `session_diagnostics`, timeout fields, durability warnings, cost-quota readiness).
- Hardened source-free CLI auth rejection:
  - Source-free CLI 401/403 stderr is classified as `grok_cli_auth_unavailable` with `source_content_transmission:not_sent`.
  - `--transport auto` may fall back to web for that pre-source auth failure while keeping CLI diagnostics.
- Kept existing auto-review policy intact: CLI-first, web fallback only for allowed pre-source CLI failures, no direct paid API fallback.
- Added `specs/176-grok-cli-readiness-auto/evidence-map.md` with fresh doctor/self-review evidence.

## Review Findings Addressed
- Greptile: verified and fixed missing `binDir` cleanup in new tests.
- Greptile: verified and fixed `selected_route` inference by explicitly emitting and asserting route fields.
- Gemini Code Assist: verified and fixed missing untrusted-CLI auth-policy fields.
- Gemini Code Assist: verified and fixed auto web fallback schema consistency by preserving standard web doctor diagnostics.
- DeepSeek: verified its missing-constant claim was invalid (`grok_cli_auth_unavailable` was already in `GROK_CLI_AUTO_FALLBACK_CODES`), but accepted the useful coverage gap and added a doctor-auto source-free 403 fallback regression test.

## Verification
Head: `685c8cac30933fd341505c0728aacb7f4ae078f4`
Base: `origin/main` / `384768789fd6efe59688637cf3031c1404c659a7`

Fresh live readiness evidence on this machine:
- `doctor --transport cli`: `ready:true`, `auth_mode:"subscription_cli"`, `logged_in:true`, `model_ready:true`.
- `doctor --transport web`: `ready:true`, `auth_mode:"subscription_web"`, chat probe HTTP 200 through local tunnel.
- `doctor --transport auto`: `ready:true`, `requested_transport:"auto"`, `selected_transport:"cli"`, `selected_route:"subscription_cli"`, `fallback_reason:null`.

Commands/checks:
- `npm ci --ignore-scripts` - pass.
- Focused Grok auto-doctor tests - pass.
- `git diff --check` - pass.
- `npm run lint:sync` - pass.
- `node --test tests/smoke/grok-web.smoke.test.mjs` - pass 155/155.
- GitHub CI for `685c8ca` - pass: lint, test, smoke (`api-reviewers`, `claude`, `gemini`, `grok`, `kimi`), SonarCloud.

## Exact-Head Whole-PR Review
All reviews below used head `685c8cac30933fd341505c0728aacb7f4ae078f4` against base `384768789fd6efe59688637cf3031c1404c659a7`.

- Claude Code: APPROVE.
- GLM direct API: APPROVE on retry. First GLM slot failed review-quality only because it marked absent prior comments as `NOT REVIEWED`; no code finding from that failed slot was accepted.
- Gemini CLI: REQUEST_CHANGES, but verified invalid. It claimed `grok_cli_auth_unavailable` was missing from `GROK_CLI_AUTO_FALLBACK_CODES`; local source at head and `origin/main` both contain it, and the new source-free 403 doctor test passes.
- Grok CLI: REQUEST_CHANGES with the same missing-constant claim, but its own result stated the review environment had no git repo and did not inspect the constant definition. Verified invalid against source and diff.
- DeepSeek direct API: REQUEST_CHANGES with the same missing-constant/scope-gap claim. Verified invalid: the constant already contained `grok_cli_auth_unavailable` in `origin/main`, so this PR reuses the existing fallback-eligible error code for the new source-free 401/403 path.

No reviewer finding that survived local verification remains open.