### PR TITLE
Deduplicate Grok fallback adapter configs

### DIFF
--- a/plugins/grok/scripts/lib/grok-transport-adapters.mjs
+++ b/plugins/grok/scripts/lib/grok-transport-adapters.mjs
@@ -59,6 +59,12 @@ function parsePositiveIntegerEnv(env, name, fallback, unit = "number of millisec
   return parsed;
 }
 
+function envWithoutKeys(env, keys) {
+  const safeEnv = { ...env };
+  for (const key of keys) delete safeEnv[key];
+  return safeEnv;
+}
+
 function cliConfig(options = {}, env = process.env) {
   return {
     provider: GROK_CANONICAL_PROVIDER,
@@ -87,30 +93,11 @@ function cliConfig(options = {}, env = process.env) {
 }
 
 function cliFallbackConfig(options = {}, env = process.env) {
-  return {
-    provider: GROK_CANONICAL_PROVIDER,
-    canonical_provider: GROK_CANONICAL_PROVIDER,
-    display_name: "Grok CLI",
-    auth_mode: "subscription_cli",
-    selected_route: "subscription_cli",
-    transport: "cli",
-    requested_transport: options.requestedTransport ?? "cli",
-    fallback_from: options.fallbackFrom ?? null,
-    fallback_reason: options.fallbackReason ?? null,
-    binary: env.GROK_CLI_BINARY || "grok",
-    base_url: null,
-    model: env.GROK_CLI_MODEL || DEFAULT_CLI_MODEL,
-    timeout_ms: DEFAULT_TIMEOUT_MS,
-    max_prompt_chars: DEFAULT_MAX_PROMPT_CHARS,
-    max_turns: DEFAULT_CLI_MAX_TURNS,
-    prompt_budget_env: "GROK_CLI_MAX_PROMPT_CHARS",
-    default_model_env: "GROK_CLI_MODEL",
-    timeout_env: "GROK_CLI_TIMEOUT_MS",
-    legacy: false,
-    credential_ref: null,
-    credential_value: null,
-    api_capability: providerApiCapability(GROK_CANONICAL_PROVIDER),
-  };
+  return cliConfig(options, envWithoutKeys(env, [
+    "GROK_CLI_TIMEOUT_MS",
+    "GROK_CLI_MAX_PROMPT_CHARS",
+    "GROK_CLI_MAX_TURNS",
+  ]));
 }
 
 function webConfig(options = {}, env = process.env) {
@@ -146,35 +133,14 @@ function webConfig(options = {}, env = process.env) {
 }
 
 function webFallbackConfig(options = {}, env = process.env) {
-  const rawTransport = String(options.transport ?? env.GROK_TRANSPORT ?? "web").trim().toLowerCase();
-  return {
-    provider: "grok-web",
-    canonical_provider: GROK_CANONICAL_PROVIDER,
-    display_name: "Grok Web",
-    auth_mode: "subscription_web",
-    selected_route: "subscription_web",
-    transport: "web",
-    requested_transport: options.requestedTransport ?? "web",
-    fallback_from: options.fallbackFrom ?? null,
-    fallback_reason: options.fallbackReason ?? null,
-    base_url: normalizeBaseUrl(env.GROK_WEB_BASE_URL),
-    model: env.GROK_WEB_MODEL || DEFAULT_WEB_MODEL,
-    timeout_ms: DEFAULT_TIMEOUT_MS,
-    doctor_timeout_ms: DEFAULT_DOCTOR_TIMEOUT_MS,
-    chat_doctor_timeout_ms: DEFAULT_CHAT_DOCTOR_TIMEOUT_MS,
-    tunnel_start_timeout_ms: DEFAULT_TUNNEL_START_TIMEOUT_MS,
-    tunnel_cleanup_timeout_ms: DEFAULT_TUNNEL_CLEANUP_TIMEOUT_MS,
-    max_prompt_chars: DEFAULT_MAX_PROMPT_CHARS,
-    prompt_budget_env: "GROK_WEB_MAX_PROMPT_CHARS",
-    default_model_env: "GROK_WEB_MODEL",
-    timeout_env: "GROK_WEB_TIMEOUT_MS",
-    legacy: rawTransport === "legacy" || rawTransport === "tunnel" || rawTransport === "grok-web",
-    credential_ref: env.GROK_WEB_TUNNEL_API_KEY ? "GROK_WEB_TUNNEL_API_KEY" : null,
-    credential_value: env.GROK_WEB_TUNNEL_API_KEY || null,
-    grok2api_base_url: normalizeGrok2ApiBaseUrl(env.GROK2API_BASE_URL, env.GROK_WEB_BASE_URL),
-    grok2api_admin_key: env.GROK2API_ADMIN_KEY || DEFAULT_GROK2API_ADMIN_KEY,
-    api_capability: providerApiCapability(GROK_CANONICAL_PROVIDER),
-  };
+  return webConfig(options, envWithoutKeys(env, [
+    "GROK_WEB_TIMEOUT_MS",
+    "GROK_WEB_DOCTOR_TIMEOUT_MS",
+    "GROK_WEB_CHAT_DOCTOR_TIMEOUT_MS",
+    "GROK_WEB_TUNNEL_START_TIMEOUT_MS",
+    "GROK_WEB_TUNNEL_CLEANUP_TIMEOUT_MS",
+    "GROK_WEB_MAX_PROMPT_CHARS",
+  ]));
 }
 
 export function resolveGrokTransportMode(options = {}, env = process.env) {

--- a/tests/smoke/grok-web.smoke.test.mjs
+++ b/tests/smoke/grok-web.smoke.test.mjs
@@ -2046,7 +2046,7 @@ test("Grok runtime reads direct API credential names from provider metadata", ()
   );
   assert.match(
     transportAdapterSource,
-    /function webFallbackConfig[\s\S]{0,1800}provider:\s*["']grok-web["'],\s*canonical_provider:\s*GROK_CANONICAL_PROVIDER/,
+    /function webFallbackConfig[\s\S]{0,500}\breturn\s+webConfig\(/,
   );
   assert.match(transportAdapterSource, /providerApiCapability\(GROK_CANONICAL_PROVIDER\)/);
   assert.doesNotMatch(transportAdapterSource, /providerApiCapability\(["']grok["']\)/);

--- a/tests/unit/grok-transport-adapters.test.mjs
+++ b/tests/unit/grok-transport-adapters.test.mjs
@@ -121,6 +121,10 @@ test("fallback helpers expose web fallback config and redacted CLI diagnostics",
 
 test("resolveGrokFallbackConfig uses safe web defaults for early error records", () => {
   const fallback = resolveGrokFallbackConfig({ transport: "web" }, {
+    GROK_WEB_BASE_URL: "http://127.0.0.1:7654/v1",
+    GROK2API_BASE_URL: "http://127.0.0.1:8765/api",
+    GROK_WEB_MODEL: "grok-web-fallback",
+    GROK_WEB_TUNNEL_API_KEY: "tunnel-token",
     GROK_WEB_TIMEOUT_MS: "not-a-number",
     GROK_WEB_DOCTOR_TIMEOUT_MS: "not-a-number",
     GROK_WEB_CHAT_DOCTOR_TIMEOUT_MS: "not-a-number",
@@ -137,10 +141,17 @@ test("resolveGrokFallbackConfig uses safe web defaults for early error records",
   assert.equal(fallback.tunnel_start_timeout_ms, 8000);
   assert.equal(fallback.tunnel_cleanup_timeout_ms, 2000);
   assert.equal(fallback.max_prompt_chars, 400000);
+  assert.equal(fallback.base_url, "http://127.0.0.1:7654/v1");
+  assert.equal(fallback.grok2api_base_url, "http://127.0.0.1:8765");
+  assert.equal(fallback.model, "grok-web-fallback");
+  assert.equal(fallback.credential_ref, "GROK_WEB_TUNNEL_API_KEY");
+  assert.equal(fallback.credential_value, "tunnel-token");
 });
 
 test("resolveGrokFallbackConfig uses safe CLI defaults for early error records", () => {
   const fallback = resolveGrokFallbackConfig({ transport: "cli" }, {
+    GROK_CLI_BINARY: "grok-dev",
+    GROK_CLI_MODEL: "grok-cli-fallback",
     GROK_CLI_TIMEOUT_MS: "not-a-number",
     GROK_CLI_MAX_PROMPT_CHARS: "not-a-number",
     GROK_CLI_MAX_TURNS: "not-a-number",
@@ -152,6 +163,8 @@ test("resolveGrokFallbackConfig uses safe CLI defaults for early error records",
   assert.equal(fallback.timeout_ms, 900000);
   assert.equal(fallback.max_prompt_chars, 400000);
   assert.equal(fallback.max_turns, 8);
+  assert.equal(fallback.binary, "grok-dev");
+  assert.equal(fallback.model, "grok-cli-fallback");
 });
 
 test("resolveGrokConfig exposes web adapter facts and legacy aliases", () => {

--- a/tests/unit/plugin-copies-in-sync.test.mjs
+++ b/tests/unit/plugin-copies-in-sync.test.mjs
@@ -98,6 +98,27 @@ function allIndicesOf(source, needle) {
   return indices;
 }
 
+function uniqueSortedStrings(values) {
+  return [...new Set(values)].sort();
+}
+
+function numericEnvKeysParsedByFunction(source, name) {
+  const body = functionBody(source, name);
+  const keys = uniqueSortedStrings([...body.matchAll(/parsePositiveIntegerEnv\s*\(\s*env\s*,\s*"([^"]+)"/g)]
+    .map((entry) => entry[1]));
+  assert.ok(keys.length > 0, `${name} must parse at least one numeric env key`);
+  return keys;
+}
+
+function envKeysStrippedByFallbackFunction(source, name) {
+  const body = functionBody(source, name);
+  const match = body.match(/envWithoutKeys\s*\(\s*env\s*,\s*\[([\s\S]*?)\]\s*\)/);
+  assert.ok(match, `${name} must strip numeric env keys through envWithoutKeys(env, [...])`);
+  const keys = uniqueSortedStrings([...match[1].matchAll(/"([^"]+)"/g)].map((entry) => entry[1]));
+  assert.ok(keys.length > 0, `${name} must strip at least one numeric env key`);
+  return keys;
+}
+
 function parseStringSetLiteral(source, name, label) {
   const match = source.match(new RegExp(`const ${name} = new Set\\(\\[([\\s\\S]*?)\\]\\);`));
   assert.ok(match, `${label} missing ${name}`);
@@ -122,6 +143,20 @@ function next() {
   const body = functionBody(source, "target");
   assert.match(body, /\breturn\s+cliConfig\(/);
   assert.doesNotMatch(body, /\breturn\s+webConfig\(/);
+});
+
+test("Grok fallback configs strip every numeric env key parsed by their delegate", () => {
+  const adapterSource = readRepoFile("plugins/grok/scripts/lib/grok-transport-adapters.mjs");
+  assert.deepEqual(
+    numericEnvKeysParsedByFunction(adapterSource, "cliConfig"),
+    envKeysStrippedByFallbackFunction(adapterSource, "cliFallbackConfig"),
+    "cliFallbackConfig must strip every numeric env key parsed by cliConfig",
+  );
+  assert.deepEqual(
+    numericEnvKeysParsedByFunction(adapterSource, "webConfig"),
+    envKeysStrippedByFallbackFunction(adapterSource, "webFallbackConfig"),
+    "webFallbackConfig must strip every numeric env key parsed by webConfig",
+  );
 });
 
 const PROVIDER_RUNTIME_POLICY_ENTRYPOINTS = Object.freeze([

--- a/tests/unit/plugin-copies-in-sync.test.mjs
+++ b/tests/unit/plugin-copies-in-sync.test.mjs
@@ -32,6 +32,19 @@ function readRepoFile(relPath) {
   return readFileSync(path.join(REPO_ROOT, relPath), "utf8");
 }
 
+function functionBody(source, name) {
+  const signature = source.match(new RegExp(`function\\s+${name}\\s*\\([^)]*\\)\\s*\\{`));
+  assert.ok(signature, `missing function ${name}`);
+  const bodyStart = signature.index + signature[0].length;
+  let depth = 1;
+  for (let index = bodyStart; index < source.length; index += 1) {
+    if (source[index] === "{") depth += 1;
+    if (source[index] === "}") depth -= 1;
+    if (depth === 0) return source.slice(bodyStart, index);
+  }
+  assert.fail(`unterminated function ${name}`);
+}
+
 function indexOfRequired(source, needle, label) {
   const index = source.indexOf(needle);
   assert.notEqual(index, -1, `${label} missing ${needle}`);
@@ -672,6 +685,18 @@ test("Grok auto transport stays an adapter capability and uses shared source-tra
     adapterSource,
     /providerApiCapability\(GROK_CANONICAL_PROVIDER\)/,
     "Grok transport adapter must derive direct API credential names from canonical provider metadata",
+  );
+  const cliFallbackBody = functionBody(adapterSource, "cliFallbackConfig");
+  const webFallbackBody = functionBody(adapterSource, "webFallbackConfig");
+  assert.match(
+    cliFallbackBody,
+    /\breturn\s+cliConfig\(/,
+    "Grok CLI fallback config must delegate to cliConfig instead of copying transport facts",
+  );
+  assert.match(
+    webFallbackBody,
+    /\breturn\s+webConfig\(/,
+    "Grok web fallback config must delegate to webConfig instead of copying transport facts",
   );
   assert.doesNotMatch(
     adapterSource,

--- a/tests/unit/plugin-copies-in-sync.test.mjs
+++ b/tests/unit/plugin-copies-in-sync.test.mjs
@@ -37,9 +37,46 @@ function functionBody(source, name) {
   assert.ok(signature, `missing function ${name}`);
   const bodyStart = signature.index + signature[0].length;
   let depth = 1;
+  let quote = null;
+  let comment = null;
   for (let index = bodyStart; index < source.length; index += 1) {
-    if (source[index] === "{") depth += 1;
-    if (source[index] === "}") depth -= 1;
+    const char = source[index];
+    const next = source[index + 1];
+    if (comment === "line") {
+      if (char === "\n") comment = null;
+      continue;
+    }
+    if (comment === "block") {
+      if (char === "*" && next === "/") {
+        comment = null;
+        index += 1;
+      }
+      continue;
+    }
+    if (quote !== null) {
+      if (char === "\\") {
+        index += 1;
+        continue;
+      }
+      if (char === quote) quote = null;
+      continue;
+    }
+    if (char === "/" && next === "/") {
+      comment = "line";
+      index += 1;
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      comment = "block";
+      index += 1;
+      continue;
+    }
+    if (char === "\"" || char === "'" || char === "`") {
+      quote = char;
+      continue;
+    }
+    if (char === "{") depth += 1;
+    if (char === "}") depth -= 1;
     if (depth === 0) return source.slice(bodyStart, index);
   }
   assert.fail(`unterminated function ${name}`);
@@ -70,6 +107,22 @@ function parseStringSetLiteral(source, name, label) {
 function readRepoJson(relPath) {
   return JSON.parse(readRepoFile(relPath));
 }
+
+test("functionBody ignores braces inside strings and comments", () => {
+  const source = `
+function target() {
+  // }
+  return cliConfig(options, env);
+}
+function next() {
+  return webConfig(options, env);
+}
+`;
+
+  const body = functionBody(source, "target");
+  assert.match(body, /\breturn\s+cliConfig\(/);
+  assert.doesNotMatch(body, /\breturn\s+webConfig\(/);
+});
 
 const PROVIDER_RUNTIME_POLICY_ENTRYPOINTS = Object.freeze([
   Object.freeze({


### PR DESCRIPTION
## Summary
- Replace duplicated Grok CLI/web fallback config object literals with delegation to the primary config builders after stripping only numeric env override keys.
- Preserve early-error safe defaults for malformed timeout/budget/max-turn env values.
- Add an architecture guard that fallback config builders delegate instead of copying transport facts.

## Context
Follow-up to Greptile review comments on PR #188 about duplicated fallback config paths in `grok-transport-adapters.mjs`.

## Verification
- `node --test tests/unit/grok-transport-adapters.test.mjs tests/unit/plugin-copies-in-sync.test.mjs`
- `node --test --test-name-pattern "auto transport preserves CLI diagnostics when web fallback prompt is too large|rendered prompt over Grok CLI budget names CLI cap|explicit --transport web|custom-review auto transport" tests/smoke/grok-web.smoke.test.mjs`
- `npm run lint`
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR deduplicates `cliFallbackConfig` and `webFallbackConfig` in `grok-transport-adapters.mjs` by replacing their copied config object literals with delegation to `cliConfig`/`webConfig`, stripping only the numeric (timeout/budget/turns) env-override keys before delegating so those fall back to safe defaults.

- A new `envWithoutKeys` helper shallow-copies the env object and removes a given list of keys, allowing the fallback builders to reuse the primary builders without inheriting per-instance numeric overrides.
- Tests are expanded to assert that non-numeric env values (base URLs, model names, tunnel credentials) flow through fallback configs unchanged, and a new architecture guard in `plugin-copies-in-sync.test.mjs` enforces the delegation pattern via source-text inspection.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the delegation is logically equivalent to the removed object literals and the test additions are well-scoped.

The core refactoring is correct — non-numeric env values (URLs, models, credentials) pass through unchanged, numeric env overrides are properly stripped so defaults apply in fallback contexts, and both fallback paths are now a single delegating expression. The only concern is the naive brace-counter in the new architecture guard, which skips string/comment parsing and could misfire if those two small functions grow in complexity.

tests/unit/plugin-copies-in-sync.test.mjs — the new functionBody helper warrants a second look for future-proofing its brace-counting logic.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| plugins/grok/scripts/lib/grok-transport-adapters.mjs | Duplicated fallback config objects replaced with delegation to primary builders via envWithoutKeys; logic is equivalent to the removed code and non-numeric env values pass through correctly. |
| tests/unit/grok-transport-adapters.test.mjs | Tests extended to assert that non-numeric env values (URLs, model, credentials) are preserved through fallback configs, providing good coverage of the new delegation behavior. |
| tests/unit/plugin-copies-in-sync.test.mjs | Adds functionBody parser and architecture guard asserting fallback builders delegate to primary builders; the brace-counting parser is naive and could silently misparse if function bodies ever contain braces in string/comment/template literal contexts. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["resolveGrokFallbackConfig(options, env)"] --> B{transport?}
    B -->|web| C["webFallbackConfig(options, env)"]
    B -->|cli / auto| D["cliFallbackConfig(options, env)"]

    C --> E["envWithoutKeys(env, webNumericKeys)"]
    E --> F["webConfig(options, strippedEnv)"]
    F --> G["Web fallback config\n(defaults for timeouts/budget,\nenv URLs/model/credentials preserved)"]

    D --> H["envWithoutKeys(env, cliNumericKeys)"]
    H --> I["cliConfig(options, strippedEnv)"]
    I --> J["CLI fallback config\n(defaults for timeout/budget/turns,\nenv binary/model preserved)"]

    style E fill:#f9f,stroke:#333
    style H fill:#f9f,stroke:#333
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22seungpyoson%2Fcodex-plugin-multi%22%20on%20the%20existing%20branch%20%22followup-188-grok-fallback-config-dedupe%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22followup-188-grok-fallback-config-dedupe%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Funit%2Fplugin-copies-in-sync.test.mjs%3A35-46%0AThe%20%60functionBody%60%20parser%20counts%20raw%20%60%7B%60%20%2F%20%60%7D%60%20characters%20without%20skipping%20string%20literals%2C%20template%20literals%2C%20comments%2C%20or%20regex%20literals.%20Currently%20%60cliFallbackConfig%60%20and%20%60webFallbackConfig%60%20contain%20only%20a%20plain%20%60return%60%20expression%20%28no%20braces%20in%20their%20bodies%29%2C%20so%20the%20guard%20works.%20If%20either%20function%20is%20ever%20refactored%20to%20include%2C%20say%2C%20a%20destructured%20default%20%28%60%7B%20fallbackFrom%20%3D%20null%20%7D%20%3D%20options%60%29%20or%20an%20inline%20object%20literal%2C%20the%20brace%20counter%20will%20close%20early%20and%20the%20%60assert.match%60%20against%20%60%5Cbreturn%5Cs%2BcliConfig%5C%28%60%20or%20%60%5Cbreturn%5Cs%2BwebConfig%5C%28%60%20could%20silently%20pass%20or%20fail%20for%20the%20wrong%20reason.%0A%0A%60%60%60suggestion%0Afunction%20functionBody%28source%2C%20name%29%20%7B%0A%20%20const%20signature%20%3D%20source.match%28new%20RegExp%28%60function%5C%5Cs%2B%24%7Bname%7D%5C%5Cs*%5C%5C%28%5B%5E%29%5D*%5C%5C%29%5C%5Cs*%5C%5C%7B%60%29%29%3B%0A%20%20assert.ok%28signature%2C%20%60missing%20function%20%24%7Bname%7D%60%29%3B%0A%20%20const%20bodyStart%20%3D%20signature.index%20%2B%20signature%5B0%5D.length%3B%0A%20%20let%20depth%20%3D%201%3B%0A%20%20let%20inString%20%3D%20false%3B%0A%20%20let%20stringChar%20%3D%20%22%22%3B%0A%20%20for%20%28let%20index%20%3D%20bodyStart%3B%20index%20%3C%20source.length%3B%20index%20%2B%3D%201%29%20%7B%0A%20%20%20%20const%20ch%20%3D%20source%5Bindex%5D%3B%0A%20%20%20%20if%20%28inString%29%20%7B%0A%20%20%20%20%20%20if%20%28ch%20%3D%3D%3D%20%22%5C%5C%22%29%20%7B%20index%20%2B%3D%201%3B%20continue%3B%20%7D%0A%20%20%20%20%20%20if%20%28ch%20%3D%3D%3D%20stringChar%29%20inString%20%3D%20false%3B%0A%20%20%20%20%20%20continue%3B%0A%20%20%20%20%7D%0A%20%20%20%20if%20%28ch%20%3D%3D%3D%20'%22'%20%7C%7C%20ch%20%3D%3D%3D%20%22'%22%20%7C%7C%20ch%20%3D%3D%3D%20%22%60%22%29%20%7B%20inString%20%3D%20true%3B%20stringChar%20%3D%20ch%3B%20continue%3B%20%7D%0A%20%20%20%20if%20%28ch%20%3D%3D%3D%20%22%7B%22%29%20depth%20%2B%3D%201%3B%0A%20%20%20%20if%20%28ch%20%3D%3D%3D%20%22%7D%22%29%20depth%20-%3D%201%3B%0A%20%20%20%20if%20%28depth%20%3D%3D%3D%200%29%20return%20source.slice%28bodyStart%2C%20index%29%3B%0A%20%20%7D%0A%20%20assert.fail%28%60unterminated%20function%20%24%7Bname%7D%60%29%3B%0A%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Funit%2Fplugin-copies-in-sync.test.mjs%3A35-46%0AThe%20%60functionBody%60%20parser%20counts%20raw%20%60%7B%60%20%2F%20%60%7D%60%20characters%20without%20skipping%20string%20literals%2C%20template%20literals%2C%20comments%2C%20or%20regex%20literals.%20Currently%20%60cliFallbackConfig%60%20and%20%60webFallbackConfig%60%20contain%20only%20a%20plain%20%60return%60%20expression%20%28no%20braces%20in%20their%20bodies%29%2C%20so%20the%20guard%20works.%20If%20either%20function%20is%20ever%20refactored%20to%20include%2C%20say%2C%20a%20destructured%20default%20%28%60%7B%20fallbackFrom%20%3D%20null%20%7D%20%3D%20options%60%29%20or%20an%20inline%20object%20literal%2C%20the%20brace%20counter%20will%20close%20early%20and%20the%20%60assert.match%60%20against%20%60%5Cbreturn%5Cs%2BcliConfig%5C%28%60%20or%20%60%5Cbreturn%5Cs%2BwebConfig%5C%28%60%20could%20silently%20pass%20or%20fail%20for%20the%20wrong%20reason.%0A%0A%60%60%60suggestion%0Afunction%20functionBody%28source%2C%20name%29%20%7B%0A%20%20const%20signature%20%3D%20source.match%28new%20RegExp%28%60function%5C%5Cs%2B%24%7Bname%7D%5C%5Cs*%5C%5C%28%5B%5E%29%5D*%5C%5C%29%5C%5Cs*%5C%5C%7B%60%29%29%3B%0A%20%20assert.ok%28signature%2C%20%60missing%20function%20%24%7Bname%7D%60%29%3B%0A%20%20const%20bodyStart%20%3D%20signature.index%20%2B%20signature%5B0%5D.length%3B%0A%20%20let%20depth%20%3D%201%3B%0A%20%20let%20inString%20%3D%20false%3B%0A%20%20let%20stringChar%20%3D%20%22%22%3B%0A%20%20for%20%28let%20index%20%3D%20bodyStart%3B%20index%20%3C%20source.length%3B%20index%20%2B%3D%201%29%20%7B%0A%20%20%20%20const%20ch%20%3D%20source%5Bindex%5D%3B%0A%20%20%20%20if%20%28inString%29%20%7B%0A%20%20%20%20%20%20if%20%28ch%20%3D%3D%3D%20%22%5C%5C%22%29%20%7B%20index%20%2B%3D%201%3B%20continue%3B%20%7D%0A%20%20%20%20%20%20if%20%28ch%20%3D%3D%3D%20stringChar%29%20inString%20%3D%20false%3B%0A%20%20%20%20%20%20continue%3B%0A%20%20%20%20%7D%0A%20%20%20%20if%20%28ch%20%3D%3D%3D%20'%22'%20%7C%7C%20ch%20%3D%3D%3D%20%22'%22%20%7C%7C%20ch%20%3D%3D%3D%20%22%60%22%29%20%7B%20inString%20%3D%20true%3B%20stringChar%20%3D%20ch%3B%20continue%3B%20%7D%0A%20%20%20%20if%20%28ch%20%3D%3D%3D%20%22%7B%22%29%20depth%20%2B%3D%201%3B%0A%20%20%20%20if%20%28ch%20%3D%3D%3D%20%22%7D%22%29%20depth%20-%3D%201%3B%0A%20%20%20%20if%20%28depth%20%3D%3D%3D%200%29%20return%20source.slice%28bodyStart%2C%20index%29%3B%0A%20%20%7D%0A%20%20assert.fail%28%60unterminated%20function%20%24%7Bname%7D%60%29%3B%0A%7D%0A%60%60%60%0A%0A&repo=seungpyoson%2Fcodex-plugin-multi&pr=191&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
tests/unit/plugin-copies-in-sync.test.mjs:35-46
The `functionBody` parser counts raw `{` / `}` characters without skipping string literals, template literals, comments, or regex literals. Currently `cliFallbackConfig` and `webFallbackConfig` contain only a plain `return` expression (no braces in their bodies), so the guard works. If either function is ever refactored to include, say, a destructured default (`{ fallbackFrom = null } = options`) or an inline object literal, the brace counter will close early and the `assert.match` against `\breturn\s+cliConfig\(` or `\breturn\s+webConfig\(` could silently pass or fail for the wrong reason.

```suggestion
function functionBody(source, name) {
  const signature = source.match(new RegExp(`function\\s+${name}\\s*\\([^)]*\\)\\s*\\{`));
  assert.ok(signature, `missing function ${name}`);
  const bodyStart = signature.index + signature[0].length;
  let depth = 1;
  let inString = false;
  let stringChar = "";
  for (let index = bodyStart; index < source.length; index += 1) {
    const ch = source[index];
    if (inString) {
      if (ch === "\\") { index += 1; continue; }
      if (ch === stringChar) inString = false;
      continue;
    }
    if (ch === '"' || ch === "'" || ch === "`") { inString = true; stringChar = ch; continue; }
    if (ch === "{") depth += 1;
    if (ch === "}") depth -= 1;
    if (depth === 0) return source.slice(bodyStart, index);
  }
  assert.fail(`unterminated function ${name}`);
}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Deduplicate Grok fallback adapter config..."](https://github.com/seungpyoson/codex-plugin-multi/commit/c8fd1101a51128fa69631dd1271de4095388101e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34546924)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->