### PR TITLE
Fix Codex relay marketplace install policy

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -83,7 +83,7 @@
         "path": "./plugins/api-reviewers"
       },
       "policy": {
-        "installation": "HIDDEN",
+        "installation": "NOT_AVAILABLE",
         "authentication": "ON_USE"
       },
       "category": "Coding"

--- a/scripts/ci/check-manifests-self-test.mjs
+++ b/scripts/ci/check-manifests-self-test.mjs
@@ -10,6 +10,7 @@ import { fileURLToPath } from "node:url";
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const LINTER = resolve(REPO_ROOT, "scripts/ci/check-manifests.mjs");
+const MARKETPLACE_SCHEMA = resolve(REPO_ROOT, "scripts/lib/codex-marketplace-schema.mjs");
 
 let failed = 0;
 
@@ -33,6 +34,8 @@ async function fixture(name, setup) {
     // Copy linter script to a discoverable relative path.
     await mkdir(join(dir, "scripts/ci"), { recursive: true });
     await cp(LINTER, join(dir, "scripts/ci/check-manifests.mjs"));
+    await mkdir(join(dir, "scripts/lib"), { recursive: true });
+    await cp(MARKETPLACE_SCHEMA, join(dir, "scripts/lib/codex-marketplace-schema.mjs"));
     await setup(dir);
     const res = spawnSync("node", ["scripts/ci/check-manifests.mjs"], {
       cwd: dir,

--- a/scripts/ci/check-manifests.mjs
+++ b/scripts/ci/check-manifests.mjs
@@ -45,9 +45,9 @@ const AGENT_FRONTMATTER_KEYS = new Set([
 ]);
 
 // Allowed installation / authentication values per marketplace schema
-// (verified 2026-04-23: "NEVER" is rejected; ON_INSTALL|ON_USE are the only
+// (verified 2026-05-31: Codex rejects "HIDDEN"; ON_INSTALL|ON_USE are the only
 // accepted authentication values).
-const INSTALLATION_ENUM = ["AVAILABLE", "DEFAULT", "HIDDEN"];
+const INSTALLATION_ENUM = ["AVAILABLE", "NOT_AVAILABLE", "INSTALLED_BY_DEFAULT"];
 const AUTHENTICATION_ENUM = ["ON_INSTALL", "ON_USE"];
 
 // Semver (simplified): MAJOR.MINOR.PATCH with optional prerelease.

--- a/scripts/ci/check-manifests.mjs
+++ b/scripts/ci/check-manifests.mjs
@@ -6,6 +6,10 @@
 import { readFile, readdir } from "node:fs/promises";
 import { resolve, dirname, basename } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  CODEX_MARKETPLACE_AUTHENTICATION_POLICIES,
+  CODEX_MARKETPLACE_INSTALLATION_POLICIES,
+} from "../lib/codex-marketplace-schema.mjs";
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
@@ -43,12 +47,6 @@ const AGENT_FRONTMATTER_KEYS = new Set([
   "tools",
   "skills",
 ]);
-
-// Allowed installation / authentication values per marketplace schema
-// (verified 2026-05-31: Codex rejects "HIDDEN"; ON_INSTALL|ON_USE are the only
-// accepted authentication values).
-const INSTALLATION_ENUM = ["AVAILABLE", "NOT_AVAILABLE", "INSTALLED_BY_DEFAULT"];
-const AUTHENTICATION_ENUM = ["ON_INSTALL", "ON_USE"];
 
 // Semver (simplified): MAJOR.MINOR.PATCH with optional prerelease.
 const SEMVER = /^\d+\.\d+\.\d+(-[a-z0-9.-]+)?$/;
@@ -153,8 +151,12 @@ function readMarketplacePluginSourcePath(plugin, path) {
 function checkMarketplacePluginPolicy(plugin, path) {
   checkType(plugin, "policy", "object", path);
   if (!plugin.policy) return;
-  oneOf(plugin.policy, "installation", INSTALLATION_ENUM, path, { required: true });
-  oneOf(plugin.policy, "authentication", AUTHENTICATION_ENUM, path, { required: true });
+  oneOf(plugin.policy, "installation", CODEX_MARKETPLACE_INSTALLATION_POLICIES, path, {
+    required: true,
+  });
+  oneOf(plugin.policy, "authentication", CODEX_MARKETPLACE_AUTHENTICATION_POLICIES, path, {
+    required: true,
+  });
 }
 
 function normalizeSourcePath(sourcePath) {

--- a/scripts/lib/codex-marketplace-schema.mjs
+++ b/scripts/lib/codex-marketplace-schema.mjs
@@ -1,0 +1,10 @@
+// Codex marketplace policy values accepted by the current marketplace parser
+// (verified 2026-05-31: Codex rejects "HIDDEN"; ON_INSTALL|ON_USE are the only
+// accepted authentication values).
+export const CODEX_MARKETPLACE_INSTALLATION_POLICIES = [
+  "AVAILABLE",
+  "NOT_AVAILABLE",
+  "INSTALLED_BY_DEFAULT",
+];
+
+export const CODEX_MARKETPLACE_AUTHENTICATION_POLICIES = ["ON_INSTALL", "ON_USE"];

--- a/tests/unit/manifests.test.mjs
+++ b/tests/unit/manifests.test.mjs
@@ -5,6 +5,10 @@ import { existsSync, readFileSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  CODEX_MARKETPLACE_AUTHENTICATION_POLICIES,
+  CODEX_MARKETPLACE_INSTALLATION_POLICIES,
+} from "../../scripts/lib/codex-marketplace-schema.mjs";
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
 const DESCRIPTION_MAX_LENGTH = 88;
@@ -260,12 +264,27 @@ test("marketplace.json: valid schema", () => {
     assert.equal(typeof p.name, "string");
     assert.ok(/^[a-z0-9]+(-[a-z0-9]+)*$/.test(p.name), `${p.name} not bare`);
     assert.ok(
-      ["AVAILABLE", "NOT_AVAILABLE", "INSTALLED_BY_DEFAULT"].includes(p.policy.installation),
+      CODEX_MARKETPLACE_INSTALLATION_POLICIES.includes(p.policy.installation),
       `${p.name} has Codex-unsupported installation policy ${p.policy.installation}`,
     );
-    assert.ok(["ON_INSTALL", "ON_USE"].includes(p.policy.authentication));
+    assert.ok(CODEX_MARKETPLACE_AUTHENTICATION_POLICIES.includes(p.policy.authentication));
     assert.ok(["local", "git"].includes(p.source.source));
   }
+});
+
+test("Codex marketplace policy enums come from one shared schema source", () => {
+  assert.deepEqual(CODEX_MARKETPLACE_INSTALLATION_POLICIES, [
+    "AVAILABLE",
+    "NOT_AVAILABLE",
+    "INSTALLED_BY_DEFAULT",
+  ]);
+  assert.deepEqual(CODEX_MARKETPLACE_AUTHENTICATION_POLICIES, ["ON_INSTALL", "ON_USE"]);
+
+  const linter = readFileSync(path.join(REPO_ROOT, "scripts/ci/check-manifests.mjs"), "utf8");
+  assert.match(linter, /CODEX_MARKETPLACE_INSTALLATION_POLICIES/);
+  assert.match(linter, /CODEX_MARKETPLACE_AUTHENTICATION_POLICIES/);
+  assert.doesNotMatch(linter, /const INSTALLATION_ENUM = \[/);
+  assert.doesNotMatch(linter, /const AUTHENTICATION_ENUM = \[/);
 });
 
 test("claude plugin.json: valid schema", () => {

--- a/tests/unit/manifests.test.mjs
+++ b/tests/unit/manifests.test.mjs
@@ -259,7 +259,10 @@ test("marketplace.json: valid schema", () => {
   for (const p of m.plugins) {
     assert.equal(typeof p.name, "string");
     assert.ok(/^[a-z0-9]+(-[a-z0-9]+)*$/.test(p.name), `${p.name} not bare`);
-    assert.ok(["AVAILABLE", "DEFAULT", "HIDDEN"].includes(p.policy.installation));
+    assert.ok(
+      ["AVAILABLE", "NOT_AVAILABLE", "INSTALLED_BY_DEFAULT"].includes(p.policy.installation),
+      `${p.name} has Codex-unsupported installation policy ${p.policy.installation}`,
+    );
     assert.ok(["ON_INSTALL", "ON_USE"].includes(p.policy.authentication));
     assert.ok(["local", "git"].includes(p.source.source));
   }

--- a/tests/unit/relay-public-naming.test.mjs
+++ b/tests/unit/relay-public-naming.test.mjs
@@ -7,13 +7,17 @@ function readJson(relPath) {
   return JSON.parse(readFileSync(relPath, "utf8"));
 }
 
+function codexPublicPlugins(plugins) {
+  return plugins.filter((plugin) => plugin.policy.installation !== "NOT_AVAILABLE");
+}
+
 test("repo package and marketplace expose Relay public names", () => {
   const pkg = readJson("package.json");
   assert.equal(pkg.name, "relay");
   assert.equal(pkg.repository.url, "https://github.com/seungpyoson/relay.git");
 
   const marketplace = readJson(".agents/plugins/marketplace.json");
-  const publicPlugins = marketplace.plugins.filter((plugin) => plugin.policy.installation === "AVAILABLE");
+  const publicPlugins = codexPublicPlugins(marketplace.plugins);
   assert.equal(marketplace.name, "relay-for-codex");
   assert.equal(marketplace.interface.displayName, "Relay for Codex");
   assert.deepEqual(
@@ -33,6 +37,19 @@ test("repo package and marketplace expose Relay public names", () => {
       plugin.name === "api-reviewers" && plugin.policy.installation === "NOT_AVAILABLE"
     ),
     true,
+  );
+});
+
+test("Codex public plugin predicate includes installed-by-default plugins", () => {
+  const publicPlugins = codexPublicPlugins([
+    { name: "available", policy: { installation: "AVAILABLE" } },
+    { name: "default", policy: { installation: "INSTALLED_BY_DEFAULT" } },
+    { name: "not-available", policy: { installation: "NOT_AVAILABLE" } },
+  ]);
+
+  assert.deepEqual(
+    publicPlugins.map((plugin) => plugin.name),
+    ["available", "default"],
   );
 });
 

--- a/tests/unit/relay-public-naming.test.mjs
+++ b/tests/unit/relay-public-naming.test.mjs
@@ -13,7 +13,7 @@ test("repo package and marketplace expose Relay public names", () => {
   assert.equal(pkg.repository.url, "https://github.com/seungpyoson/relay.git");
 
   const marketplace = readJson(".agents/plugins/marketplace.json");
-  const publicPlugins = marketplace.plugins.filter((plugin) => plugin.policy.installation !== "HIDDEN");
+  const publicPlugins = marketplace.plugins.filter((plugin) => plugin.policy.installation === "AVAILABLE");
   assert.equal(marketplace.name, "relay-for-codex");
   assert.equal(marketplace.interface.displayName, "Relay for Codex");
   assert.deepEqual(
@@ -30,7 +30,7 @@ test("repo package and marketplace expose Relay public names", () => {
   assert.equal(publicPlugins.some((plugin) => plugin.name === "api-reviewers"), false);
   assert.equal(
     marketplace.plugins.some((plugin) =>
-      plugin.name === "api-reviewers" && plugin.policy.installation === "HIDDEN"
+      plugin.name === "api-reviewers" && plugin.policy.installation === "NOT_AVAILABLE"
     ),
     true,
   );


### PR DESCRIPTION
## Summary
- replace unsupported Codex marketplace installation policy `HIDDEN` with `NOT_AVAILABLE` for the shared api-reviewers runtime
- tighten manifest lint/tests to Codex's accepted installation enum
- keep Claude relay marketplace hidden-runtime behavior unchanged

## Test Plan
- node --test tests/unit/manifests.test.mjs tests/unit/relay-public-naming.test.mjs
- npm run lint
- node scripts/ci/sync-relay-build.mjs --check
- git diff --check
- env CODEX_HOME=/private/tmp/codex-relay-install-smoke codex plugin marketplace add /Users/spson/Projects/Claude/codex-plugin-multi
- env CODEX_HOME=/private/tmp/codex-relay-install-smoke codex plugin marketplace list
- env CODEX_HOME=/private/tmp/codex-relay-install-smoke codex plugin list

## Notes
Two local full-suite runs hit different unrelated timing-sensitive failures; all four failed test names passed in isolation after the full runs.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the unsupported Codex marketplace `HIDDEN` installation policy on the `api-reviewers` plugin with `NOT_AVAILABLE`, and updates the lint enum and test assertions to reflect the three values Codex actually accepts (`AVAILABLE`, `NOT_AVAILABLE`, `INSTALLED_BY_DEFAULT`).

- **`marketplace.json`**: single-field change for `api-reviewers` — `HIDDEN` → `NOT_AVAILABLE`; Claude relay marketplace is untouched.
- **`check-manifests.mjs` / `manifests.test.mjs`**: `INSTALLATION_ENUM` updated in both places from `[AVAILABLE, DEFAULT, HIDDEN]` to the correct Codex-accepted set; a better assertion error message is added in the test.
- **`relay-public-naming.test.mjs`**: Codex relay public-plugin filter tightened to `=== \"AVAILABLE\"`; Claude relay test keeps `HIDDEN` checks intentionally.

<h3>Confidence Score: 4/5</h3>

The change is narrowly scoped and directly fixes a Codex enum mismatch; no runtime logic is affected.

The core fix is correct and the Claude relay path is deliberately untouched. Two maintainability concerns exist: the accepted-installation enum is duplicated verbatim across the linter and the test file, and the tightened publicPlugins filter silently excludes any future INSTALLED_BY_DEFAULT plugin from test coverage without explanation.

The duplicated enum in scripts/ci/check-manifests.mjs and tests/unit/manifests.test.mjs, and the filter change in tests/unit/relay-public-naming.test.mjs.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .agents/plugins/marketplace.json | Single-field change: api-reviewers installation policy updated from HIDDEN to NOT_AVAILABLE, matching Codex's accepted enum. |
| scripts/ci/check-manifests.mjs | INSTALLATION_ENUM updated from [AVAILABLE, DEFAULT, HIDDEN] to [AVAILABLE, NOT_AVAILABLE, INSTALLED_BY_DEFAULT]; enum values are duplicated verbatim in the test file with no shared source. |
| tests/unit/manifests.test.mjs | Enum list updated to match check-manifests.mjs; improved error message added to the installation policy assertion. |
| tests/unit/relay-public-naming.test.mjs | Codex relay test tightened to filter publicPlugins as === AVAILABLE only; Claude relay test still uses HIDDEN intentionally. The semantic shift silently excludes INSTALLED_BY_DEFAULT plugins from the public list going forward. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Plugin Entry in marketplace.json] --> B{installation policy}
    B -->|AVAILABLE| C[Public / user-installable]
    B -->|NOT_AVAILABLE NEW for api-reviewers| D[Not installable via marketplace]
    B -->|INSTALLED_BY_DEFAULT| E[Pre-installed automatically]
    B -->|HIDDEN Rejected by Codex| F[Lint/CI error]

    C --> G[publicPlugins filter === AVAILABLE]
    E --> H[Excluded from publicPlugins no explicit test coverage]
    D --> I[Excluded from publicPlugins asserted by relay-public-naming.test]

    subgraph Claude relay marketplace
        J{installation policy} -->|HIDDEN| K[Hidden runtime Kept unchanged]
        J -->|not HIDDEN| L[Claude public plugins]
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22seungpyoson%2Fcodex-plugin-multi%22%20on%20the%20existing%20branch%20%22codex%2Ffix-codex-marketplace-install%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ffix-codex-marketplace-install%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fci%2Fcheck-manifests.mjs%3A50%0A**Enum%20duplicated%20across%20lint%20and%20test%20without%20a%20shared%20source**%0A%0A%60INSTALLATION_ENUM%60%20is%20defined%20verbatim%20in%20both%20%60check-manifests.mjs%60%20%28line%2050%29%20and%20%60tests%2Funit%2Fmanifests.test.mjs%60%20%28line%20260%29.%20The%20next%20time%20an%20accepted%20value%20changes%2C%20one%20of%20the%20two%20will%20be%20left%20stale%20and%20the%20lint%2Ftest%20will%20diverge%20silently%20%E2%80%94%20exactly%20the%20scenario%20this%20PR%20is%20fixing.%20Exporting%20the%20constant%20from%20a%20shared%20module%20%28or%20generating%20both%20from%20a%20single%20source-of-truth%29%20would%20keep%20them%20in%20sync%20automatically.%0A%0A%23%23%23%20Issue%202%20of%202%0Atests%2Funit%2Frelay-public-naming.test.mjs%3A16%0A**%60INSTALLED_BY_DEFAULT%60%20plugins%20silently%20excluded%20from%20%60publicPlugins%60**%0A%0AThe%20filter%20changed%20from%20%60!%3D%3D%20%22HIDDEN%22%60%20to%20%60%3D%3D%3D%20%22AVAILABLE%22%60.%20Under%20the%20new%20Codex%20enum%2C%20any%20plugin%20with%20%60installation%3A%20%22INSTALLED_BY_DEFAULT%22%60%20would%20be%20omitted%20from%20%60publicPlugins%60%20and%20would%20not%20appear%20in%20the%20%60deepEqual%60%20name%20list.%20If%20a%20plugin%20with%20that%20policy%20is%20ever%20added%2C%20the%20test%20will%20pass%20%28no%20assertion%20failure%29%20but%20the%20assertion%20at%20line%2019%E2%80%9329%20will%20silently%20fail%20to%20cover%20it.%20A%20comment%20explaining%20this%20intentional%20scope%20would%20prevent%20future%20confusion.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fci%2Fcheck-manifests.mjs%3A50%0A**Enum%20duplicated%20across%20lint%20and%20test%20without%20a%20shared%20source**%0A%0A%60INSTALLATION_ENUM%60%20is%20defined%20verbatim%20in%20both%20%60check-manifests.mjs%60%20%28line%2050%29%20and%20%60tests%2Funit%2Fmanifests.test.mjs%60%20%28line%20260%29.%20The%20next%20time%20an%20accepted%20value%20changes%2C%20one%20of%20the%20two%20will%20be%20left%20stale%20and%20the%20lint%2Ftest%20will%20diverge%20silently%20%E2%80%94%20exactly%20the%20scenario%20this%20PR%20is%20fixing.%20Exporting%20the%20constant%20from%20a%20shared%20module%20%28or%20generating%20both%20from%20a%20single%20source-of-truth%29%20would%20keep%20them%20in%20sync%20automatically.%0A%0A%23%23%23%20Issue%202%20of%202%0Atests%2Funit%2Frelay-public-naming.test.mjs%3A16%0A**%60INSTALLED_BY_DEFAULT%60%20plugins%20silently%20excluded%20from%20%60publicPlugins%60**%0A%0AThe%20filter%20changed%20from%20%60!%3D%3D%20%22HIDDEN%22%60%20to%20%60%3D%3D%3D%20%22AVAILABLE%22%60.%20Under%20the%20new%20Codex%20enum%2C%20any%20plugin%20with%20%60installation%3A%20%22INSTALLED_BY_DEFAULT%22%60%20would%20be%20omitted%20from%20%60publicPlugins%60%20and%20would%20not%20appear%20in%20the%20%60deepEqual%60%20name%20list.%20If%20a%20plugin%20with%20that%20policy%20is%20ever%20added%2C%20the%20test%20will%20pass%20%28no%20assertion%20failure%29%20but%20the%20assertion%20at%20line%2019%E2%80%9329%20will%20silently%20fail%20to%20cover%20it.%20A%20comment%20explaining%20this%20intentional%20scope%20would%20prevent%20future%20confusion.%0A%0A&repo=seungpyoson%2Fcodex-plugin-multi&pr=197&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
scripts/ci/check-manifests.mjs:50
**Enum duplicated across lint and test without a shared source**

`INSTALLATION_ENUM` is defined verbatim in both `check-manifests.mjs` (line 50) and `tests/unit/manifests.test.mjs` (line 260). The next time an accepted value changes, one of the two will be left stale and the lint/test will diverge silently — exactly the scenario this PR is fixing. Exporting the constant from a shared module (or generating both from a single source-of-truth) would keep them in sync automatically.

### Issue 2 of 2
tests/unit/relay-public-naming.test.mjs:16
**`INSTALLED_BY_DEFAULT` plugins silently excluded from `publicPlugins`**

The filter changed from `!== "HIDDEN"` to `=== "AVAILABLE"`. Under the new Codex enum, any plugin with `installation: "INSTALLED_BY_DEFAULT"` would be omitted from `publicPlugins` and would not appear in the `deepEqual` name list. If a plugin with that policy is ever added, the test will pass (no assertion failure) but the assertion at line 19–29 will silently fail to cover it. A comment explaining this intentional scope would prevent future confusion.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix Codex relay marketplace policy"](https://github.com/seungpyoson/codex-plugin-multi/commit/2f1293016022dd880b8d5d835f4f12729d88f049) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34804060)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->