### PR TITLE
Fix Claude relay runtime packaging

### DIFF
--- a/relay/.claude-plugin/marketplace.json
+++ b/relay/.claude-plugin/marketplace.json
@@ -54,7 +54,7 @@
       "name": "relay-api-reviewers",
       "description": "Shared hidden direct API runtime for Relay Claude Code plugins.",
       "version": "0.1.0",
-      "source": "../plugins/api-reviewers",
+      "source": "./relay-api-reviewers",
       "author": {
         "name": "seungpyoson"
       },

--- a/relay/relay-api-reviewers
+++ b/relay/relay-api-reviewers
@@ -1,0 +1,1 @@
+../plugins/api-reviewers

--- a/relay/relay-deepseek/scripts/api-reviewer.mjs
+++ b/relay/relay-deepseek/scripts/api-reviewer.mjs
@@ -4,6 +4,7 @@ const candidates = [
   new URL("../../relay-api-reviewers/scripts/relay-entrypoint.mjs", import.meta.url).href,
   new URL("../../api-reviewers/scripts/relay-entrypoint.mjs", import.meta.url).href,
   new URL("../../../plugins/api-reviewers/scripts/relay-entrypoint.mjs", import.meta.url).href,
+  new URL("../../../relay-api-reviewers/0.1.0/scripts/relay-entrypoint.mjs", import.meta.url).href,
 ].filter(Boolean);
 const helper = await Promise.any(candidates.map((candidate) => import(candidate))).catch(() => null);
 if (!helper) { console.error("api_reviewer_entrypoint_missing: install the shared api-reviewers runtime"); process.exit(1); }

--- a/relay/relay-glm/scripts/api-reviewer.mjs
+++ b/relay/relay-glm/scripts/api-reviewer.mjs
@@ -4,6 +4,7 @@ const candidates = [
   new URL("../../relay-api-reviewers/scripts/relay-entrypoint.mjs", import.meta.url).href,
   new URL("../../api-reviewers/scripts/relay-entrypoint.mjs", import.meta.url).href,
   new URL("../../../plugins/api-reviewers/scripts/relay-entrypoint.mjs", import.meta.url).href,
+  new URL("../../../relay-api-reviewers/0.1.0/scripts/relay-entrypoint.mjs", import.meta.url).href,
 ].filter(Boolean);
 const helper = await Promise.any(candidates.map((candidate) => import(candidate))).catch(() => null);
 if (!helper) { console.error("api_reviewer_entrypoint_missing: install the shared api-reviewers runtime"); process.exit(1); }

--- a/scripts/lib/relay-build.mjs
+++ b/scripts/lib/relay-build.mjs
@@ -4,7 +4,9 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  realpathSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { join, relative } from "node:path";
@@ -108,14 +110,14 @@ export function buildRelayPlugin({ provider, repoRoot = process.cwd(), outRoot =
 export function buildRelaySuite({ repoRoot = process.cwd(), outRoot = join(repoRoot, "relay") } = {}) {
   rmSync(outRoot, { recursive: true, force: true });
   const pluginRoots = RELAY_PROVIDER_ORDER.map((provider) => buildRelayPlugin({ provider, repoRoot, outRoot }));
-  const sharedDirectApiRuntimeRoot = buildRelayDirectApiRuntimePlugin({ repoRoot });
+  const sharedDirectApiRuntimeRoot = buildRelayDirectApiRuntimePlugin({ repoRoot, outRoot });
   writeClaudeRelayMarketplace({ outRoot, pluginRoots, sharedDirectApiRuntimeRoot });
   return pluginRoots;
 }
 
 export function renderClaudeRelayMarketplace(
   pluginManifests,
-  { hiddenPluginNames = new Set(), sourceOverrides = new Map() } = {},
+  { hiddenPluginNames = new Set() } = {},
 ) {
   return {
     name: RELAY_FOR_CLAUDE_MARKETPLACE,
@@ -126,7 +128,7 @@ export function renderClaudeRelayMarketplace(
         name: manifest.name,
         description: manifest.description,
         version: manifest.version,
-        source: sourceOverrides.get(manifest.name) ?? `./${manifest.name}`,
+        source: `./${manifest.name}`,
         author: manifest.author,
       };
       if (hiddenPluginNames.has(manifest.name)) {
@@ -147,20 +149,17 @@ function writeClaudeRelayMarketplace({ outRoot, pluginRoots, sharedDirectApiRunt
     join(outRoot, ".claude-plugin", "marketplace.json"),
     renderClaudeRelayMarketplace([...visibleManifests, ...hiddenManifests], {
       hiddenPluginNames: new Set(hiddenManifests.map((manifest) => manifest.name)),
-      sourceOverrides: new Map([
-        [RELAY_SHARED_DIRECT_API_RUNTIME, marketplaceSource({ fromRoot: outRoot, toRoot: sharedDirectApiRuntimeRoot })],
-      ]),
     }),
   );
 }
 
-function buildRelayDirectApiRuntimePlugin({ repoRoot }) {
+function buildRelayDirectApiRuntimePlugin({ repoRoot, outRoot }) {
   const sourceRoot = join(repoRoot, "plugins", "api-reviewers");
-  const pluginRoot = sourceRoot;
-  mkdirSync(join(pluginRoot, ".claude-plugin"), { recursive: true });
+  const pluginRoot = join(outRoot, RELAY_SHARED_DIRECT_API_RUNTIME);
+  mkdirSync(join(sourceRoot, ".claude-plugin"), { recursive: true });
 
   const sourceManifest = readJson(join(sourceRoot, ".codex-plugin", "plugin.json"));
-  writeJson(join(pluginRoot, ".claude-plugin", "plugin.json"), {
+  writeJson(join(sourceRoot, ".claude-plugin", "plugin.json"), {
     name: RELAY_SHARED_DIRECT_API_RUNTIME,
     version: sourceManifest.version,
     description: "Shared hidden direct API runtime for Relay Claude Code plugins.",
@@ -170,6 +169,8 @@ function buildRelayDirectApiRuntimePlugin({ repoRoot }) {
     repository: RELAY_REPOSITORY,
   });
 
+  rmSync(pluginRoot, { recursive: true, force: true });
+  symlinkSync(relative(realpathSync(outRoot), realpathSync(sourceRoot)).replaceAll("\\", "/"), pluginRoot, "dir");
   return pluginRoot;
 }
 
@@ -180,17 +181,12 @@ const candidates = [
   new URL("../../relay-api-reviewers/scripts/relay-entrypoint.mjs", import.meta.url).href,
   new URL("../../api-reviewers/scripts/relay-entrypoint.mjs", import.meta.url).href,
   new URL("../../../plugins/api-reviewers/scripts/relay-entrypoint.mjs", import.meta.url).href,
+  new URL("../../../relay-api-reviewers/0.1.0/scripts/relay-entrypoint.mjs", import.meta.url).href,
 ].filter(Boolean);
 const helper = await Promise.any(candidates.map((candidate) => import(candidate))).catch(() => null);
 if (!helper) { console.error("api_reviewer_entrypoint_missing: install the shared api-reviewers runtime"); process.exit(1); }
 helper.runRelayDirectApiEntrypoint({ provider: ${JSON.stringify(provider)}, scriptUrl: import.meta.url });
 `;
-}
-
-function marketplaceSource({ fromRoot, toRoot }) {
-  const relativePath = relative(fromRoot, toRoot).replaceAll("\\", "/");
-  if (relativePath.startsWith(".")) return relativePath;
-  return `./${relativePath}`;
 }
 
 export function renderClaudePluginManifest(codexManifest, { provider, description: descriptionOverride } = {}) {

--- a/tests/unit/relay-build-contracts.test.mjs
+++ b/tests/unit/relay-build-contracts.test.mjs
@@ -24,6 +24,10 @@ function writeStubDirectApiRuntime(pluginRoot) {
   );
 }
 
+function readManifestVersion(manifestPath) {
+  return JSON.parse(readFileSync(manifestPath, "utf8")).version;
+}
+
 test("relayPluginName: prefixes provider plugins for relay", () => {
   assert.equal(relayPluginName("gemini"), "relay-gemini");
   assert.equal(relayPluginName("deepseek"), "relay-deepseek");
@@ -216,9 +220,11 @@ test("buildRelayPlugin: direct API wrapper resolves installed relay-api-reviewer
   const cacheRoot = mkdtempSync(path.join(tmpdir(), "relay-api-cache-"));
   try {
     const pluginRoot = buildRelayPlugin({ provider: "glm", repoRoot: process.cwd(), outRoot });
-    const installedPluginRoot = path.join(cacheRoot, "relay-for-claude", "relay-glm", "0.1.0");
+    const pluginVersion = readManifestVersion(path.join(pluginRoot, ".claude-plugin", "plugin.json"));
+    const sharedRuntimeVersion = readManifestVersion("plugins/api-reviewers/.claude-plugin/plugin.json");
+    const installedPluginRoot = path.join(cacheRoot, "relay-for-claude", "relay-glm", pluginVersion);
     cpSync(pluginRoot, installedPluginRoot, { recursive: true });
-    writeStubDirectApiRuntime(path.join(cacheRoot, "relay-for-claude", "relay-api-reviewers", "0.1.0"));
+    writeStubDirectApiRuntime(path.join(cacheRoot, "relay-for-claude", "relay-api-reviewers", sharedRuntimeVersion));
 
     const result = spawnSync(process.execPath, [path.join(installedPluginRoot, "scripts", "api-reviewer.mjs"), "--help"], {
       encoding: "utf8",

--- a/tests/unit/relay-build-contracts.test.mjs
+++ b/tests/unit/relay-build-contracts.test.mjs
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { cpSync, existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -149,12 +149,13 @@ test("buildRelaySuite: emits the full Claude relay provider suite without relay-
     assert.equal(marketplace.name, "relay-for-claude");
     assert.deepEqual(publicPlugins.map((plugin) => plugin.name).sort(), pluginNames);
     assert.deepEqual(hiddenPlugins.map((plugin) => plugin.name), ["relay-api-reviewers"]);
-    assert.notEqual(hiddenPlugins[0].source, "./relay-api-reviewers");
+    assert.equal(hiddenPlugins[0].source, "./relay-api-reviewers");
     assert.equal(
       existsSync(path.resolve(outRoot, hiddenPlugins[0].source, ".claude-plugin", "plugin.json")),
       true,
     );
-    assert.equal(existsSync(path.join(outRoot, "relay-api-reviewers")), false);
+    assert.equal(existsSync(path.join(outRoot, "relay-api-reviewers")), true);
+    assert.equal(lstatSync(path.join(outRoot, "relay-api-reviewers")).isSymbolicLink(), true);
     for (const plugin of publicPlugins) {
       assert.equal(plugin.source, `./${plugin.name}`);
     }
@@ -207,6 +208,28 @@ test("buildRelayPlugin: direct API wrapper resolves sibling relay-api-reviewers 
     assert.match(result.stdout, /"providers":\["glm"\]/);
   } finally {
     rmSync(outRoot, { recursive: true, force: true });
+  }
+});
+
+test("buildRelayPlugin: direct API wrapper resolves installed relay-api-reviewers cache runtime", () => {
+  const outRoot = mkdtempSync(path.join(tmpdir(), "relay-api-cache-source-"));
+  const cacheRoot = mkdtempSync(path.join(tmpdir(), "relay-api-cache-"));
+  try {
+    const pluginRoot = buildRelayPlugin({ provider: "glm", repoRoot: process.cwd(), outRoot });
+    const installedPluginRoot = path.join(cacheRoot, "relay-for-claude", "relay-glm", "0.1.0");
+    cpSync(pluginRoot, installedPluginRoot, { recursive: true });
+    writeStubDirectApiRuntime(path.join(cacheRoot, "relay-for-claude", "relay-api-reviewers", "0.1.0"));
+
+    const result = spawnSync(process.execPath, [path.join(installedPluginRoot, "scripts", "api-reviewer.mjs"), "--help"], {
+      encoding: "utf8",
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /"ok":true/);
+    assert.match(result.stdout, /"providers":\["glm"\]/);
+  } finally {
+    rmSync(outRoot, { recursive: true, force: true });
+    rmSync(cacheRoot, { recursive: true, force: true });
   }
 });
 

--- a/tests/unit/relay-public-naming.test.mjs
+++ b/tests/unit/relay-public-naming.test.mjs
@@ -114,7 +114,7 @@ test("Claude relay marketplace exposes relay-for-claude suite over relay provide
     ],
   );
   assert.deepEqual(hiddenPlugins.map((plugin) => plugin.name), ["relay-api-reviewers"]);
-  assert.equal(hiddenPlugins[0].source, "../plugins/api-reviewers");
+  assert.equal(hiddenPlugins[0].source, "./relay-api-reviewers");
   assert.equal(publicPlugins.some((plugin) => plugin.name === "relay-claude"), false);
   for (const plugin of marketplace.plugins) {
     if (plugin.policy?.installation !== "HIDDEN") {


### PR DESCRIPTION
Summary:
- Package the hidden Claude direct-API runtime as a marketplace-local relay-api-reviewers symlink instead of an unsupported parent source.
- Add installed-cache runtime fallback for Claude GLM and DeepSeek wrapper shims.
- Cover the Claude marketplace source and installed runtime fallback with unit tests.

Tests:
- node --test tests/unit/relay-build-contracts.test.mjs tests/unit/relay-public-naming.test.mjs tests/unit/manifests.test.mjs
- npm run lint
- npm run lint:self-test
- npm test
- git diff --check
- claude plugin validate relay
- node relay/relay-glm/scripts/api-reviewer.mjs --help
- node relay/relay-deepseek/scripts/api-reviewer.mjs --help