### PR TITLE
Fix custom review scope parsing for Gemini and Kimi

### DIFF
--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -1197,7 +1197,7 @@ async function cmdApprovalRequest(rest) {
 async function cmdRun(rest) {
   const { options, positionals } = parseArgs(rest, {
     valueOptions: [
-      "mode", "model", "cwd", "binary", "scope-base", "scope-paths",
+      "mode", "model", "cwd", "binary", "scope", "scope-base", "scope-paths",
       "override-dispose", "auth-mode", "timeout-ms", "lifecycle-events",
       "approval-token", "approval-scope",
       "review-slot-disposition", "review-slot-waiver-artifact", "review-slot-override-artifact",

--- a/plugins/kimi/scripts/kimi-companion.mjs
+++ b/plugins/kimi/scripts/kimi-companion.mjs
@@ -1096,7 +1096,7 @@ function cmdPreflight(rest) {
 async function cmdRun(rest) {
   const { options, positionals } = parseArgs(rest, {
     valueOptions: [
-      "mode", "model", "cwd", "binary", "scope-base", "scope-paths",
+      "mode", "model", "cwd", "binary", "scope", "scope-base", "scope-paths",
       "override-dispose", "timeout-ms", "max-steps-per-turn", "lifecycle-events", "auth-mode",
       "review-slot-disposition", "review-slot-waiver-artifact", "review-slot-override-artifact",
       "prompt-file",

--- a/relay/relay-gemini/scripts/gemini-companion.mjs
+++ b/relay/relay-gemini/scripts/gemini-companion.mjs
@@ -1197,7 +1197,7 @@ async function cmdApprovalRequest(rest) {
 async function cmdRun(rest) {
   const { options, positionals } = parseArgs(rest, {
     valueOptions: [
-      "mode", "model", "cwd", "binary", "scope-base", "scope-paths",
+      "mode", "model", "cwd", "binary", "scope", "scope-base", "scope-paths",
       "override-dispose", "auth-mode", "timeout-ms", "lifecycle-events",
       "approval-token", "approval-scope",
       "review-slot-disposition", "review-slot-waiver-artifact", "review-slot-override-artifact",

--- a/relay/relay-kimi/scripts/kimi-companion.mjs
+++ b/relay/relay-kimi/scripts/kimi-companion.mjs
@@ -1096,7 +1096,7 @@ function cmdPreflight(rest) {
 async function cmdRun(rest) {
   const { options, positionals } = parseArgs(rest, {
     valueOptions: [
-      "mode", "model", "cwd", "binary", "scope-base", "scope-paths",
+      "mode", "model", "cwd", "binary", "scope", "scope-base", "scope-paths",
       "override-dispose", "timeout-ms", "max-steps-per-turn", "lifecycle-events", "auth-mode",
       "review-slot-disposition", "review-slot-waiver-artifact", "review-slot-override-artifact",
       "prompt-file",

--- a/tests/smoke/gemini-companion.smoke.test.mjs
+++ b/tests/smoke/gemini-companion.smoke.test.mjs
@@ -1899,6 +1899,37 @@ test("gemini custom-review prompt includes selected source content", () => {
   }
 });
 
+test("gemini custom-review accepts documented --scope custom with prompt file", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "gemini-custom-review-prompt-file-cwd-"));
+  let dataDir = null;
+  try {
+    fixtureSeedRepo(cwd, {
+      fileName: "seed.txt",
+      fileContents: "gemini documented custom source sentinel\n",
+    });
+    const promptFile = path.join(cwd, "prompt.txt");
+    writeFileSync(promptFile, "review: documented custom prompt\n", { mode: 0o600 });
+    const result = runCompanion(
+      [
+        "run", "--mode=custom-review", "--scope", "custom", "--foreground", "--cwd", cwd,
+        "--scope-paths", "seed.txt", "--prompt-file", promptFile,
+      ],
+      { cwd, env: {
+        CODEX_SANDBOX: "seatbelt",
+        GEMINI_MOCK_ASSERT_PROMPT_INCLUDES: "gemini documented custom source sentinel",
+      } },
+    );
+    dataDir = result.dataDir;
+    assert.equal(result.status, 0, `exit ${result.status}: ${result.stderr}; stdout=${result.stdout}`);
+    const record = JSON.parse(result.stdout);
+    assert.equal(record.status, "completed");
+    assert.equal(record.external_review.source_content_transmission, "sent");
+  } finally {
+    if (dataDir) rmTree(dataDir);
+    rmTree(cwd);
+  }
+});
+
 test("gemini custom-review rejects over-budget source packets before Gemini launch", () => {
   const cwd = mkdtempSync(path.join(tmpdir(), "gemini-source-packet-cwd-"));
   seedMinimalRepo(cwd);

--- a/tests/smoke/kimi-companion.smoke.test.mjs
+++ b/tests/smoke/kimi-companion.smoke.test.mjs
@@ -721,6 +721,46 @@ test("kimi custom-review prompt includes selected source content", () => {
   }
 });
 
+test("kimi custom-review accepts documented --scope custom with prompt file", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "kimi-custom-review-prompt-file-cwd-"));
+  let dataDir = null;
+  try {
+    fixtureSeedRepo(cwd, {
+      fileName: "seed.txt",
+      fileContents: "kimi documented custom source sentinel\n",
+    });
+    const promptFile = path.join(cwd, "prompt.txt");
+    writeFileSync(promptFile, "review: documented custom prompt\n", { mode: 0o600 });
+    const result = runCompanion([
+      "run",
+      "--mode",
+      "custom-review",
+      "--scope",
+      "custom",
+      "--cwd",
+      cwd,
+      "--scope-paths",
+      "seed.txt",
+      "--foreground",
+      "--prompt-file",
+      promptFile,
+    ], {
+      cwd,
+      env: {
+        KIMI_MOCK_ASSERT_PROMPT_INCLUDES: "kimi documented custom source sentinel",
+      },
+    });
+    dataDir = result.dataDir;
+    assert.equal(result.status, 0, result.stderr);
+    const record = parseJson(result.stdout);
+    assert.equal(record.status, "completed");
+    assert.equal(record.external_review.source_content_transmission, "sent");
+  } finally {
+    if (dataDir) rmSync(dataDir, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test("kimi custom-review maps held workload lease to provider_workload_blocked without spawn", () => {
   const cwd = mkdtempSync(path.join(tmpdir(), "kimi-workload-block-cwd-"));
   const dataDir = mkdtempSync(path.join(tmpdir(), "kimi-workload-block-data-"));


### PR DESCRIPTION
## Summary
- Fix Gemini and Kimi run argument parsing so documented custom-review invocations treat --scope custom as an option value, not as a positional prompt.
- Regenerate the Claude relay Gemini/Kimi copies so relay-for-claude gets the same runtime behavior.
- Add smoke regressions for the exact documented command shape with --scope custom, --scope-paths, and --prompt-file.

## Verification
- node --test --test-name-pattern "gemini custom-review accepts documented --scope custom with prompt file" tests/smoke/gemini-companion.smoke.test.mjs
- node --test --test-name-pattern "kimi custom-review accepts documented --scope custom with prompt file" tests/smoke/kimi-companion.smoke.test.mjs
- node scripts/build-relay-plugin.mjs
- node --test tests/unit/relay-build-contracts.test.mjs
- node --test --test-name-pattern "custom-review accepts documented --scope custom with prompt file" tests/smoke/gemini-companion.smoke.test.mjs tests/smoke/kimi-companion.smoke.test.mjs
- node --test tests/smoke/gemini-companion.smoke.test.mjs tests/smoke/kimi-companion.smoke.test.mjs
- env CODEX_PLUGIN_SKIP_SMOKE=1 npm test
- npm run lint
- git diff --check

Note: plain npm test was attempted, but Claude smoke tests failed closed because another active Claude source-bearing job held the provider workload lock in a separate bolt-v2 worktree. The changed Gemini/Kimi smoke files and non-smoke suite passed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a `parseArgs` configuration bug where `--scope` was absent from `valueOptions` in `cmdRun` for both Gemini and Kimi companions, causing the word `custom` (and the `--scope` token itself) to land in `positionals` and be injected into the LLM prompt. Relay copies are regenerated and smoke tests are added to cover the documented command shape.

- **Core fix**: adds `\"scope\"` to `cmdRun`'s `valueOptions` in four files (plugin + relay for Gemini and Kimi), preventing positional contamination. The parsed `options[\"scope\"]` value is not read back — scope is determined by the mode-profile — but absorbing the token is sufficient to correct the prompt.
- **`cmdApprovalRequest`** (Gemini, same file) calls `promptFromOptions` after its own `parseArgs` and still lacks `\"scope\"` in its `valueOptions`, leaving an identical latent bug unfixed.
- **Gemini smoke test** places `runCompanion` outside the try block; if it throws, `dataDir` is undefined in the `finally` cleanup — the kimi test in the same PR uses the safer guarded pattern.

<h3>Confidence Score: 4/5</h3>

The fix is narrowly targeted and correct; the relay copies are properly regenerated and smoke tests exercise the exact documented invocation shape.

The `cmdRun` change achieves its goal — `--scope custom` no longer contaminates the prompt in either companion. The `cmdApprovalRequest` function in the Gemini files has the same structural gap (no `"scope"` in its `valueOptions` despite calling `promptFromOptions`), and the Gemini smoke test leaves a temp-dir cleanup gap if `runCompanion` throws. Neither blocks the documented use case, but they are incomplete given the stated intent to make `--scope` handling consistent.

The `cmdApprovalRequest` section of `plugins/gemini/scripts/gemini-companion.mjs` (and its relay copy) deserves a second look to decide if `"scope"` belongs in its `valueOptions` too.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| plugins/gemini/scripts/gemini-companion.mjs | Adds `"scope"` to `cmdRun`'s `valueOptions` so `--scope custom` is consumed as a named option instead of landing in `positionals`; `cmdApprovalRequest` (same file) still lacks `"scope"` in its `valueOptions`. |
| plugins/kimi/scripts/kimi-companion.mjs | Same single-line `valueOptions` fix applied to Kimi's `cmdRun`; mirrors the Gemini change exactly. |
| relay/relay-gemini/scripts/gemini-companion.mjs | Relay copy regenerated from the plugin source; diff is byte-identical to the plugin change. |
| relay/relay-kimi/scripts/kimi-companion.mjs | Relay copy regenerated from the plugin source; diff is byte-identical to the plugin change. |
| tests/smoke/gemini-companion.smoke.test.mjs | New smoke test for the documented `--scope custom` shape; `runCompanion` is called outside the try block, so a throw there leaves `dataDir` undefined in the finally cleanup — inconsistent with the kimi test's safer pattern. |
| tests/smoke/kimi-companion.smoke.test.mjs | New smoke test correctly guards `dataDir` with `let dataDir = null` and a conditional cleanup — the safer pattern of the two. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["CLI invocation\nrun --mode=custom-review --scope custom …"] --> B["parseArgs(rest, { valueOptions: [...] })"]
    B --> C{"Is 'scope' in\nvalueOptions?"}
    C -- "Before fix: NO" --> D["--scope pushed to positionals\ncustom pushed to positionals"]
    C -- "After fix: YES" --> E["options['scope'] = 'custom'\npositionals = []"]
    D --> F["promptFromOptions(positionals, options)\n→ prompt includes '--scope custom'"]
    E --> G["promptFromOptions(positionals, options)\n→ prompt is clean"]
    F --> H["❌ Prompt contaminated\nwith '--scope custom' text"]
    G --> I["effectiveProfileForOptions\n→ profile.scope = 'custom' (from mode-profile)"]
    I --> J["✅ invocation.scope = 'custom'\nCorrect review scope"]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `plugins/gemini/scripts/gemini-companion.mjs`, line 1066-1072 ([link](https://github.com/seungpyoson/relay/blob/d995947a1366b6db430e60de34895d8b7da53212/plugins/gemini/scripts/gemini-companion.mjs#L1066-L1072)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`cmdApprovalRequest` has the same missing `"scope"` valueOption**

   `cmdApprovalRequest` calls `promptFromOptions(positionals, options)` after parsing, but `"scope"` is absent from its `valueOptions`. Per `args.mjs` lines 47–49, an unrecognised `--` flag is pushed verbatim into `positionals`, so calling `approval-request … --scope custom` would push both `"--scope"` and `"custom"` into positionals and inject them into the prompt text — the same bug this PR fixes for `cmdRun`. The same gap exists in `relay/relay-gemini/scripts/gemini-companion.mjs`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: plugins/gemini/scripts/gemini-companion.mjs
   Line: 1066-1072

   Comment:
   **`cmdApprovalRequest` has the same missing `"scope"` valueOption**

   `cmdApprovalRequest` calls `promptFromOptions(positionals, options)` after parsing, but `"scope"` is absent from its `valueOptions`. Per `args.mjs` lines 47–49, an unrecognised `--` flag is pushed verbatim into `positionals`, so calling `approval-request … --scope custom` would push both `"--scope"` and `"custom"` into positionals and inject them into the prompt text — the same bug this PR fixes for `cmdRun`. The same gap exists in `relay/relay-gemini/scripts/gemini-companion.mjs`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22seungpyoson%2Frelay%22%20on%20the%20existing%20branch%20%22codex%2Ffix-claude-custom-review-scope%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ffix-claude-custom-review-scope%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20plugins%2Fgemini%2Fscripts%2Fgemini-companion.mjs%0ALine%3A%201066-1072%0A%0AComment%3A%0A**%60cmdApprovalRequest%60%20has%20the%20same%20missing%20%60%22scope%22%60%20valueOption**%0A%0A%60cmdApprovalRequest%60%20calls%20%60promptFromOptions%28positionals%2C%20options%29%60%20after%20parsing%2C%20but%20%60%22scope%22%60%20is%20absent%20from%20its%20%60valueOptions%60.%20Per%20%60args.mjs%60%20lines%2047%E2%80%9349%2C%20an%20unrecognised%20%60--%60%20flag%20is%20pushed%20verbatim%20into%20%60positionals%60%2C%20so%20calling%20%60approval-request%20%E2%80%A6%20--scope%20custom%60%20would%20push%20both%20%60%22--scope%22%60%20and%20%60%22custom%22%60%20into%20positionals%20and%20inject%20them%20into%20the%20prompt%20text%20%E2%80%94%20the%20same%20bug%20this%20PR%20fixes%20for%20%60cmdRun%60.%20The%20same%20gap%20exists%20in%20%60relay%2Frelay-gemini%2Fscripts%2Fgemini-companion.mjs%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20plugins%2Fgemini%2Fscripts%2Fgemini-companion.mjs%0ALine%3A%201066-1072%0A%0AComment%3A%0A**%60cmdApprovalRequest%60%20has%20the%20same%20missing%20%60%22scope%22%60%20valueOption**%0A%0A%60cmdApprovalRequest%60%20calls%20%60promptFromOptions%28positionals%2C%20options%29%60%20after%20parsing%2C%20but%20%60%22scope%22%60%20is%20absent%20from%20its%20%60valueOptions%60.%20Per%20%60args.mjs%60%20lines%2047%E2%80%9349%2C%20an%20unrecognised%20%60--%60%20flag%20is%20pushed%20verbatim%20into%20%60positionals%60%2C%20so%20calling%20%60approval-request%20%E2%80%A6%20--scope%20custom%60%20would%20push%20both%20%60%22--scope%22%60%20and%20%60%22custom%22%60%20into%20positionals%20and%20inject%20them%20into%20the%20prompt%20text%20%E2%80%94%20the%20same%20bug%20this%20PR%20fixes%20for%20%60cmdRun%60.%20The%20same%20gap%20exists%20in%20%60relay%2Frelay-gemini%2Fscripts%2Fgemini-companion.mjs%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=seungpyoson%2Frelay&pr=200&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22seungpyoson%2Frelay%22%20on%20the%20existing%20branch%20%22codex%2Ffix-claude-custom-review-scope%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ffix-claude-custom-review-scope%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aplugins%2Fgemini%2Fscripts%2Fgemini-companion.mjs%3A1066-1072%0A**%60cmdApprovalRequest%60%20has%20the%20same%20missing%20%60%22scope%22%60%20valueOption**%0A%0A%60cmdApprovalRequest%60%20calls%20%60promptFromOptions%28positionals%2C%20options%29%60%20after%20parsing%2C%20but%20%60%22scope%22%60%20is%20absent%20from%20its%20%60valueOptions%60.%20Per%20%60args.mjs%60%20lines%2047%E2%80%9349%2C%20an%20unrecognised%20%60--%60%20flag%20is%20pushed%20verbatim%20into%20%60positionals%60%2C%20so%20calling%20%60approval-request%20%E2%80%A6%20--scope%20custom%60%20would%20push%20both%20%60%22--scope%22%60%20and%20%60%22custom%22%60%20into%20positionals%20and%20inject%20them%20into%20the%20prompt%20text%20%E2%80%94%20the%20same%20bug%20this%20PR%20fixes%20for%20%60cmdRun%60.%20The%20same%20gap%20exists%20in%20%60relay%2Frelay-gemini%2Fscripts%2Fgemini-companion.mjs%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Atests%2Fsmoke%2Fgemini-companion.smoke.test.mjs%3A1909-1930%0A**%60runCompanion%60%20outside%20the%20try%20block%20leaves%20temp%20dir%20unreachable%20on%20failure**%0A%0A%60runCompanion%28%E2%80%A6%29%60%20is%20called%20before%20the%20%60try%60%20block%2C%20so%20if%20it%20throws%20%28e.g.%2C%20spawn%20failure%29%2C%20the%20%60finally%60%20block%20still%20executes%20%60rmTree%28dataDir%29%60%20with%20%60dataDir%60%20being%20undefined.%20The%20companion%20kimi%20test%20%28added%20in%20the%20same%20PR%29%20correctly%20uses%20%60let%20dataDir%20%3D%20null%60%20inside%20the%20try%20block%20and%20guards%20with%20%60if%20%28dataDir%29%60%20before%20cleanup%20%E2%80%94%20prefer%20that%20pattern%20here%20for%20consistency%20and%20safety.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aplugins%2Fgemini%2Fscripts%2Fgemini-companion.mjs%3A1066-1072%0A**%60cmdApprovalRequest%60%20has%20the%20same%20missing%20%60%22scope%22%60%20valueOption**%0A%0A%60cmdApprovalRequest%60%20calls%20%60promptFromOptions%28positionals%2C%20options%29%60%20after%20parsing%2C%20but%20%60%22scope%22%60%20is%20absent%20from%20its%20%60valueOptions%60.%20Per%20%60args.mjs%60%20lines%2047%E2%80%9349%2C%20an%20unrecognised%20%60--%60%20flag%20is%20pushed%20verbatim%20into%20%60positionals%60%2C%20so%20calling%20%60approval-request%20%E2%80%A6%20--scope%20custom%60%20would%20push%20both%20%60%22--scope%22%60%20and%20%60%22custom%22%60%20into%20positionals%20and%20inject%20them%20into%20the%20prompt%20text%20%E2%80%94%20the%20same%20bug%20this%20PR%20fixes%20for%20%60cmdRun%60.%20The%20same%20gap%20exists%20in%20%60relay%2Frelay-gemini%2Fscripts%2Fgemini-companion.mjs%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Atests%2Fsmoke%2Fgemini-companion.smoke.test.mjs%3A1909-1930%0A**%60runCompanion%60%20outside%20the%20try%20block%20leaves%20temp%20dir%20unreachable%20on%20failure**%0A%0A%60runCompanion%28%E2%80%A6%29%60%20is%20called%20before%20the%20%60try%60%20block%2C%20so%20if%20it%20throws%20%28e.g.%2C%20spawn%20failure%29%2C%20the%20%60finally%60%20block%20still%20executes%20%60rmTree%28dataDir%29%60%20with%20%60dataDir%60%20being%20undefined.%20The%20companion%20kimi%20test%20%28added%20in%20the%20same%20PR%29%20correctly%20uses%20%60let%20dataDir%20%3D%20null%60%20inside%20the%20try%20block%20and%20guards%20with%20%60if%20%28dataDir%29%60%20before%20cleanup%20%E2%80%94%20prefer%20that%20pattern%20here%20for%20consistency%20and%20safety.%0A%0A&repo=seungpyoson%2Frelay&pr=200&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
plugins/gemini/scripts/gemini-companion.mjs:1066-1072
**`cmdApprovalRequest` has the same missing `"scope"` valueOption**

`cmdApprovalRequest` calls `promptFromOptions(positionals, options)` after parsing, but `"scope"` is absent from its `valueOptions`. Per `args.mjs` lines 47–49, an unrecognised `--` flag is pushed verbatim into `positionals`, so calling `approval-request … --scope custom` would push both `"--scope"` and `"custom"` into positionals and inject them into the prompt text — the same bug this PR fixes for `cmdRun`. The same gap exists in `relay/relay-gemini/scripts/gemini-companion.mjs`.

### Issue 2 of 2
tests/smoke/gemini-companion.smoke.test.mjs:1909-1930
**`runCompanion` outside the try block leaves temp dir unreachable on failure**

`runCompanion(…)` is called before the `try` block, so if it throws (e.g., spawn failure), the `finally` block still executes `rmTree(dataDir)` with `dataDir` being undefined. The companion kimi test (added in the same PR) correctly uses `let dataDir = null` inside the try block and guards with `if (dataDir)` before cleanup — prefer that pattern here for consistency and safety.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix custom review scope parsing for Gemi..."](https://github.com/seungpyoson/relay/commit/d995947a1366b6db430e60de34895d8b7da53212) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34839570)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->