### PR TITLE
Update README current relay state

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ npm run doctor:cache -- --second-codex-home "$HOME/.codex-second"
 ```
 
 The report compares both marketplace/plugin files and this repo's `plugins/`
-tree against `plugins/cache/relay-for-codex/<plugin>/0.1.0`, including
+tree against `plugins/cache/relay-for-codex/<plugin>/<version>`, including
 SHA-256 checks for bundled `commands/`, `skills/`, `scripts/`, and `config/`
 files. `relay-for-codex` is both the marketplace identifier and the Codex cache
 namespace used by installed plugin paths. The doctor also checks the
@@ -390,10 +390,10 @@ For local `relay/` marketplace installs, update the marketplace first:
 claude plugin marketplace update relay-for-claude
 ```
 
-Claude Code plugin versions are currently `0.1.0`. If `claude plugin update
-<plugin>@relay-for-claude` reports "already at the latest version" after a
-same-version local code change, refresh the installed cache by reinstalling the
-affected plugin while preserving its data:
+If `claude plugin update <plugin>@relay-for-claude` reports "already at the
+latest version" after a local code change that did not bump the plugin version,
+refresh the installed cache by reinstalling the affected plugin while
+preserving its data:
 
 ```bash
 claude plugin uninstall --keep-data -y relay-gemini@relay-for-claude
@@ -609,7 +609,10 @@ COVERAGE_ENFORCE_TARGET=1 npm run test:coverage
 ```
 
 For installed-host live error-case smoke tests, exercise the installed cache
-paths, not only repo source. The deterministic scope-error cases are:
+paths, not only repo source. The deterministic pre-source scope failures should
+remain distinguishable by these scope detail markers; direct API JobRecords may
+carry them under a generic `error_code: "scope_failed"` rather than as the
+top-level error code:
 
 - `custom-review --scope custom` without `--scope-paths` -> `scope_paths_required`
 - `branch-diff --scope-base refs/heads/does-not-exist` -> `scope_base_missing`
@@ -624,9 +627,9 @@ paths, not only repo source. The deterministic scope-error cases are:
 
 Each pre-source scope failure must report
 `source_content_transmission: "not_sent"`. For Codex, use scripts under
-`~/.codex/plugins/cache/relay-for-codex/relay-*/0.1.0/scripts/` and verify
+`~/.codex/plugins/cache/relay-for-codex/relay-*/*/scripts/` and verify
 cache freshness with `npm run doctor:cache`. For Claude Code, use scripts under
-`~/.claude/plugins/cache/relay-for-claude/relay-*/0.1.0/scripts/` after
+`~/.claude/plugins/cache/relay-for-claude/relay-*/*/scripts/` after
 refreshing the generated marketplace and reinstalling same-version changed
 plugins when needed.
 

--- a/README.md
+++ b/README.md
@@ -5,16 +5,20 @@ The Codex marketplace suite is `relay-for-codex` and exposes peer plugins for
 **Claude Code**, **Gemini CLI**, **Kimi Code CLI**, **Grok**, **DeepSeek**, and
 **GLM**. The generated Claude Code suite is `relay-for-claude` and exposes the
 non-self providers **Gemini**, **Kimi**, **Grok**, **DeepSeek**, and **GLM**.
+DeepSeek and GLM are provider-specific surfaces in both hosts; their shared
+direct-API implementation remains a hidden runtime package named
+`api-reviewers` in Codex and `relay-api-reviewers` in Claude Code.
 
 - **License:** AGPL-3.0-only. Commercial use is permitted under the AGPL, but
   modified versions distributed or offered over a network must provide
   corresponding source under the same license. Portions are ported from
   MIT-licensed upstream code; see `NOTICE`.
 - **State:** active development. Claude, Gemini, Kimi, Grok, DeepSeek, and GLM
-  flows are implemented and covered by mock smoke tests. Fresh-install
-  verification on Codex CLI
-  0.125.0 found that the marketplace installs successfully, but the TUI does
-  not register plugin command files as slash commands.
+  flows are implemented and covered by mock smoke tests. Current Codex
+  verification uses workflow skills or companion scripts because Codex CLI
+  0.125.0 installs the marketplace but does not register plugin command files
+  as TUI slash commands. Claude Code uses the generated `relay/` marketplace
+  directly and does expose its plugin command files.
 
 ## Requirements
 
@@ -279,14 +283,33 @@ the others. DeepSeek and GLM use a default-installed shared direct-API runtime
 package, so their provider plugins stay split without copying the same reviewer
 code twice.
 
-From Claude Code, the generated marketplace suite lives under `relay/`. Its
-marketplace name is `relay-for-claude`, and provider plugin sources stay under
-`relay/relay-*`. The suite/plugin pair is therefore
+From Claude Code, the generated marketplace suite lives under `relay/`. Add the
+local generated marketplace from the repo root:
+
+```bash
+claude plugin marketplace add ./relay
+```
+
+Its marketplace name is `relay-for-claude`, and provider plugin sources stay
+under `relay/relay-*`. The suite/plugin pair is therefore
 `relay-for-claude:relay-gemini` conceptually; Claude Code's install ref syntax
-is `relay-gemini@relay-for-claude`, `relay-grok@relay-for-claude`,
-`relay-kimi@relay-for-claude`, `relay-glm@relay-for-claude`, and
-`relay-deepseek@relay-for-claude`. Claude Code command namespaces are still
-plugin-scoped, such as `/relay-gemini:review`.
+is:
+
+```bash
+claude plugin install relay-gemini@relay-for-claude
+claude plugin install relay-grok@relay-for-claude
+claude plugin install relay-kimi@relay-for-claude
+claude plugin install relay-glm@relay-for-claude
+claude plugin install relay-deepseek@relay-for-claude
+```
+
+`relay-api-reviewers@relay-for-claude` is the hidden shared runtime for the
+DeepSeek and GLM Claude plugins. It is not a user-facing review surface. If it
+appears in `claude plugin list`, that is expected; review workflows should still
+use `relay-deepseek` or `relay-glm`.
+
+Claude Code command namespaces are plugin-scoped, such as
+`/relay-gemini:review`.
 
 ## Verify skill discovery after installation
 
@@ -358,6 +381,29 @@ reliably hot-reload plugin skill inventory. Verify the target profile with:
 ```bash
 codex debug prompt-input 'list skills'
 ```
+
+## Refresh Claude Code generated plugins
+
+For local `relay/` marketplace installs, update the marketplace first:
+
+```bash
+claude plugin marketplace update relay-for-claude
+```
+
+Claude Code plugin versions are currently `0.1.0`. If `claude plugin update
+<plugin>@relay-for-claude` reports "already at the latest version" after a
+same-version local code change, refresh the installed cache by reinstalling the
+affected plugin while preserving its data:
+
+```bash
+claude plugin uninstall --keep-data -y relay-gemini@relay-for-claude
+claude plugin install relay-gemini@relay-for-claude
+```
+
+Use the same uninstall/install shape for `relay-kimi`, `relay-grok`,
+`relay-glm`, `relay-deepseek`, and `relay-api-reviewers` when their generated
+files changed. Restart already-open Claude Code sessions after marketplace or
+plugin-cache changes.
 
 ## Current Codex 0.125.0 TUI limitation
 
@@ -562,6 +608,25 @@ npm run readiness:manifest -- --fixture-root <git-fixture> --evidence-dir <dir> 
 COVERAGE_ENFORCE_TARGET=1 npm run test:coverage
 ```
 
+For installed-host live error-case smoke tests, exercise the installed cache
+paths, not only repo source. The deterministic scope-error cases are:
+
+- `custom-review --scope custom` without `--scope-paths` -> `scope_paths_required`
+- `branch-diff --scope-base refs/heads/does-not-exist` -> `scope_base_missing`
+- `branch-diff --scope-base ../bad` -> `scope_base_invalid`
+- branch-diff with no selected files -> `scope_empty`
+- valid `custom-review --scope custom --scope-paths <file>` -> parser accepts
+  `--scope`, `--scope-paths`, and `--prompt-file`; auth/provider failures after
+  scope acceptance are classified separately
+
+Each pre-source scope failure must report
+`source_content_transmission: "not_sent"`. For Codex, use scripts under
+`~/.codex/plugins/cache/relay-for-codex/relay-*/0.1.0/scripts/` and verify
+cache freshness with `npm run doctor:cache`. For Claude Code, use scripts under
+`~/.claude/plugins/cache/relay-for-claude/relay-*/0.1.0/scripts/` after
+refreshing the generated marketplace and reinstalling same-version changed
+plugins when needed.
+
 `readiness:manifest` normalizes Claude, Gemini, Kimi, Grok, DeepSeek, and GLM
 doctor/review/approval artifacts into one readiness manifest. It classifies
 failures as `sandbox`, `auth`, `provider`, `tunnel`, `session_tokens`,
@@ -581,17 +646,18 @@ review/fix-loop issue is resolved.
 Repository layout:
 
 ```text
-relay/
-  .agents/plugins/marketplace.json
+.
+  .agents/plugins/marketplace.json  # Codex marketplace: relay-for-codex
   plugins/claude/
   plugins/gemini/
   plugins/kimi/
   plugins/grok/
-  plugins/api-reviewers/          # shared direct-API runtime
+  plugins/api-reviewers/           # hidden Codex direct-API runtime
   plugins/relay-deepseek/
   plugins/relay-glm/
-  relay/                         # generated Claude Code marketplace suite
+  relay/                           # generated Claude Code marketplace suite
     .claude-plugin/marketplace.json
+    relay-api-reviewers/           # hidden Claude direct-API runtime
     relay-deepseek/
     relay-gemini/
     relay-glm/

--- a/README.md
+++ b/README.md
@@ -613,7 +613,10 @@ paths, not only repo source. The deterministic scope-error cases are:
 
 - `custom-review --scope custom` without `--scope-paths` -> `scope_paths_required`
 - `branch-diff --scope-base refs/heads/does-not-exist` -> `scope_base_missing`
-- `branch-diff --scope-base ../bad` -> `scope_base_invalid`
+- `branch-diff --scope-base ../bad` -> `scope_base_missing` when the value is
+  path-like but not a valid ref
+- `branch-diff --scope-base=-x` -> `scope_base_invalid` for option-shaped unsafe
+  ref values
 - branch-diff with no selected files -> `scope_empty`
 - valid `custom-review --scope custom --scope-paths <file>` -> parser accepts
   `--scope`, `--scope-paths`, and `--prompt-file`; auth/provider failures after

--- a/scripts/ci/run-tests.mjs
+++ b/scripts/ci/run-tests.mjs
@@ -2,7 +2,7 @@
 // Unit-test runner. Discovers tests/unit/**/*.test.mjs and runs them via
 // `node --test`. Returns exit 0 with a notice when no tests exist yet.
 
-import { readdir, stat } from "node:fs/promises";
+import { readdir } from "node:fs/promises";
 import { spawnSync } from "node:child_process";
 import { resolve, dirname, relative } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -89,7 +89,7 @@ const cleanEnv = cleanGitEnv(process.env);
 
 const res = spawnSync(
   "node",
-  ["--test", "--test-reporter=spec", ...rel],
+  ["--test", "--test-concurrency", "1", "--test-reporter=spec", ...rel],
   { cwd: REPO_ROOT, stdio: "inherit", env: cleanEnv }
 );
 process.exit(res.status ?? 1);

--- a/tests/smoke/claude-companion.smoke.test.mjs
+++ b/tests/smoke/claude-companion.smoke.test.mjs
@@ -31,35 +31,34 @@ const COMPANION = path.join(REPO_ROOT, "plugins/claude/scripts/claude-companion.
 const MOCK = path.join(REPO_ROOT, "tests/smoke/claude-mock.mjs");
 const CLAUDE_SMOKE_POLL_TIMEOUT_MS = Number(process.env.CLAUDE_SMOKE_POLL_TIMEOUT_MS ?? 30000);
 
+function smokeEnv(dataDir, env = {}) {
+  const workloadLockDir = env.CODEX_PLUGIN_MULTI_PROVIDER_WORKLOAD_LOCK_DIR
+    ?? path.join(dataDir, "provider-workload");
+  return {
+    ...process.env,
+    CLAUDE_BINARY: MOCK,
+    CLAUDE_PLUGIN_DATA: dataDir,
+    CODEX_PLUGIN_MULTI_PROVIDER_WORKLOAD_LOCK_DIR: workloadLockDir,
+    ...env,
+  };
+}
+
 function runCompanion(args, { cwd, env = {}, dataDir = mkdtempSync(path.join(tmpdir(), "companion-smoke-")) } = {}) {
   // Point the companion at a fresh PLUGIN_DATA dir so tests don't step on
   // each other's state or on the user's real ~/.cache.
-  const workloadLockDir = env.CODEX_PLUGIN_MULTI_PROVIDER_WORKLOAD_LOCK_DIR
-    ?? path.join(dataDir, "provider-workload");
   const res = spawnSync("node", [COMPANION, ...args], {
     cwd,
-    env: {
-      ...process.env,
-      CLAUDE_BINARY: MOCK,
-      CLAUDE_PLUGIN_DATA: dataDir,
-      CODEX_PLUGIN_MULTI_PROVIDER_WORKLOAD_LOCK_DIR: workloadLockDir,
-      ...env,
-    },
+    env: smokeEnv(dataDir, env),
     encoding: "utf8",
   });
   return { ...res, dataDir };
 }
 
 function runCompanionWithPathBinary(args, { cwd, binDir, env = {}, dataDir = mkdtempSync(path.join(tmpdir(), "companion-smoke-")) } = {}) {
-  const workloadLockDir = env.CODEX_PLUGIN_MULTI_PROVIDER_WORKLOAD_LOCK_DIR
-    ?? path.join(dataDir, "provider-workload");
-  const childEnv = {
-    ...process.env,
-    CLAUDE_PLUGIN_DATA: dataDir,
-    CODEX_PLUGIN_MULTI_PROVIDER_WORKLOAD_LOCK_DIR: workloadLockDir,
+  const childEnv = smokeEnv(dataDir, {
     PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
     ...env,
-  };
+  });
   delete childEnv.CLAUDE_BINARY;
   const res = spawnSync("node", [COMPANION, ...args], {
     cwd,
@@ -2121,14 +2120,11 @@ test("continue --job: resumes a prior session via --resume", () => {
   const dataDir = mkdtempSync(path.join(tmpdir(), "continue-data-"));
   const sessionStore = path.join(dataDir, "mock-project-sessions");
   const priorTimeoutMs = 777777;
-  const env = {
-    ...process.env,
-    CLAUDE_BINARY: MOCK,
-    CLAUDE_PLUGIN_DATA: dataDir,
+  const env = smokeEnv(dataDir, {
     CLAUDE_REVIEW_TIMEOUT_MS: "",
     CLAUDE_MOCK_ENFORCE_PROJECT_SESSIONS: "1",
     CLAUDE_MOCK_PROJECT_SESSION_STORE: sessionStore,
-  };
+  });
   try {
     const runRes = spawnSync("node", [
       path.join(REPO_ROOT, "plugins/claude/scripts/claude-companion.mjs"),
@@ -2187,11 +2183,7 @@ test("continue --job from wrong cwd returns workspace retrieval guidance", () =>
   const wrongCwd = realpathSync(mkdtempSync(path.join(tmpdir(), "smoke-continue-wrong-cwd-")));
   writeFileSync(path.join(cwd, "seed.txt"), "continue wrong cwd seed\n");
   const dataDir = mkdtempSync(path.join(tmpdir(), "continue-wrong-cwd-data-"));
-  const env = {
-    ...process.env,
-    CLAUDE_BINARY: MOCK,
-    CLAUDE_PLUGIN_DATA: dataDir,
-  };
+  const env = smokeEnv(dataDir);
   try {
     const runRes = spawnSync("node", [
       path.join(REPO_ROOT, "plugins/claude/scripts/claude-companion.mjs"),
@@ -2364,7 +2356,7 @@ test("continue --job: --timeout-ms overrides prior timeout and env", () => {
       "--timeout-ms", "777777",
       "--cwd", cwd, "--", "seed",
     ], { cwd, encoding: "utf8",
-        env: { ...process.env, CLAUDE_BINARY: MOCK, CLAUDE_PLUGIN_DATA: dataDir, CLAUDE_REVIEW_TIMEOUT_MS: "" } });
+        env: smokeEnv(dataDir, { CLAUDE_REVIEW_TIMEOUT_MS: "" }) });
     assert.equal(runRes.status, 0, runRes.stderr);
     const { job_id } = JSON.parse(runRes.stdout);
     const contRes = spawnSync("node", [
@@ -2373,7 +2365,7 @@ test("continue --job: --timeout-ms overrides prior timeout and env", () => {
       "--timeout-ms", "555555",
       "--cwd", cwd, "--", "follow-up",
     ], { cwd, encoding: "utf8",
-        env: { ...process.env, CLAUDE_BINARY: MOCK, CLAUDE_PLUGIN_DATA: dataDir, CLAUDE_REVIEW_TIMEOUT_MS: "999999" } });
+        env: smokeEnv(dataDir, { CLAUDE_REVIEW_TIMEOUT_MS: "999999" }) });
     assert.equal(contRes.status, 0, contRes.stderr);
     const out = JSON.parse(contRes.stdout);
     assert.equal(out.review_metadata.audit_manifest.request.timeout_ms, 555555);

--- a/tests/unit/ci-workflow.test.mjs
+++ b/tests/unit/ci-workflow.test.mjs
@@ -99,6 +99,10 @@ test("full test runner has an explicit opt-in privacy matrix lane", () => {
   assert.match(pkg.scripts["test:privacy"] ?? "", /run-tests\.mjs/);
 });
 
+test("aggregate test runner serializes files to isolate smoke provider resources", () => {
+  assert.match(runTests, /"--test-concurrency",\s*"1"/);
+});
+
 test("manual external review relays are not merge gates", () => {
   assert.equal(existsSync(resolve(".github/workflows/manual-review-gate.yml")), false);
   assert.doesNotMatch(reviewEnforcementDocs, /manual-review-gate/);


### PR DESCRIPTION
## Summary
- document the current relay plugin package layout and installed surfaces
- clarify direct API approval/source behavior and provider reliability caveats
- align smoke-test error taxonomy for missing versus invalid custom-review bases

## Verification
- git diff --check HEAD~1..HEAD
- npm run lint
- npm run lint:self-test
- npm run doctor:cache

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates `README.md` to reflect the current state of the relay plugin system: documenting the hidden `api-reviewers`/`relay-api-reviewers` shared direct-API runtime packages, converting inline install-command prose to copyable bash blocks, adding a "Refresh Claude Code generated plugins" workflow, expanding the smoke-test error taxonomy, and correcting the repository layout diagram to root at `.` instead of `relay/`.

- Clarifies Claude Code plugin install/refresh commands and explains when same-version reinstalls are needed to bust the plugin cache.
- Documents the deterministic scope-error cases (`scope_paths_required`, `scope_base_missing`, `scope_base_invalid`, `scope_empty`) and the `source_content_transmission: "not_sent"` invariant that must hold for all pre-source failures.
- Updates the repo layout tree to correctly show `relay-api-reviewers/` as a sibling inside `relay/`.

<h3>Confidence Score: 4/5</h3>

Documentation-only change; safe to merge, with one path that will silently go stale when the plugin version bumps.

The change is entirely prose and code-block documentation — no executable logic is modified. The new "Refresh Claude Code generated plugins" section and the smoke-test cache paths both embed `0.1.0` as a literal, meaning any future version bump will leave those paths wrong for readers without any warning. Everything else — the install command blocks, error taxonomy, and layout diagram — is clear and internally consistent.

README.md lines 627–631 (hardcoded 0.1.0 in cache paths) and the "Refresh" section that also states the version inline.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Documentation update clarifying plugin layout, Claude Code install steps, refresh workflow, and smoke-test error taxonomy; hardcoded 0.1.0 version in cache paths may go stale |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Root[". (repo root)"]
    Root --> Codex[".agents/plugins/marketplace.json\nrelay-for-codex"]
    Root --> PluginsDir["plugins/"]
    Root --> RelayDir["relay/\nrelay-for-claude"]

    PluginsDir --> PC["plugins/claude/"]
    PluginsDir --> PG["plugins/gemini/"]
    PluginsDir --> PK["plugins/kimi/"]
    PluginsDir --> PGrok["plugins/grok/"]
    PluginsDir --> PAPI["plugins/api-reviewers/\nhidden Codex direct-API runtime"]
    PluginsDir --> PDS["plugins/relay-deepseek/"]
    PluginsDir --> PGLM["plugins/relay-glm/"]

    RelayDir --> RAPI["relay-api-reviewers/\nhidden Claude direct-API runtime"]
    RelayDir --> RDS["relay-deepseek/"]
    RelayDir --> RGem["relay-gemini/"]
    RelayDir --> RGLM["relay-glm/"]
    RelayDir --> RGrok["relay-grok/"]
    RelayDir --> RKimi["relay-kimi/"]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22seungpyoson%2Frelay%22%20on%20the%20existing%20branch%20%22codex%2Fupdate-readme-current-state%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fupdate-readme-current-state%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AREADME.md%3A627-631%0A**Hardcoded%20version%20in%20cache%20paths**%0A%0AThe%20plugin%20cache%20paths%20reference%20%600.1.0%60%20directly%20%28e.g.%2C%20%60relay-*%2F0.1.0%2Fscripts%2F%60%29.%20When%20the%20plugin%20version%20bumps%2C%20these%20paths%20will%20silently%20break%20for%20anyone%20following%20this%20guide%20%E2%80%94%20the%20glob%20%60relay-*%60%20covers%20the%20plugin%20name%20but%20the%20%600.1.0%60%20segment%20is%20a%20fixed%20literal.%20Consider%20using%20a%20glob%20wildcard%20for%20the%20version%20segment%20%28e.g.%2C%20%60relay-*%2F*%2Fscripts%2F%60%29%20or%20note%20that%20the%20version%20must%20be%20updated%20in%20tandem%20with%20the%20release.%20The%20same%20hardcoded%20version%20also%20appears%20in%20the%20%22Refresh%20Claude%20Code%20generated%20plugins%22%20section%20where%20the%20version%20is%20stated%20inline.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AREADME.md%3A627-631%0A**Hardcoded%20version%20in%20cache%20paths**%0A%0AThe%20plugin%20cache%20paths%20reference%20%600.1.0%60%20directly%20%28e.g.%2C%20%60relay-*%2F0.1.0%2Fscripts%2F%60%29.%20When%20the%20plugin%20version%20bumps%2C%20these%20paths%20will%20silently%20break%20for%20anyone%20following%20this%20guide%20%E2%80%94%20the%20glob%20%60relay-*%60%20covers%20the%20plugin%20name%20but%20the%20%600.1.0%60%20segment%20is%20a%20fixed%20literal.%20Consider%20using%20a%20glob%20wildcard%20for%20the%20version%20segment%20%28e.g.%2C%20%60relay-*%2F*%2Fscripts%2F%60%29%20or%20note%20that%20the%20version%20must%20be%20updated%20in%20tandem%20with%20the%20release.%20The%20same%20hardcoded%20version%20also%20appears%20in%20the%20%22Refresh%20Claude%20Code%20generated%20plugins%22%20section%20where%20the%20version%20is%20stated%20inline.%0A%0A&repo=seungpyoson%2Frelay&pr=201&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
README.md:627-631
**Hardcoded version in cache paths**

The plugin cache paths reference `0.1.0` directly (e.g., `relay-*/0.1.0/scripts/`). When the plugin version bumps, these paths will silently break for anyone following this guide — the glob `relay-*` covers the plugin name but the `0.1.0` segment is a fixed literal. Consider using a glob wildcard for the version segment (e.g., `relay-*/*/scripts/`) or note that the version must be updated in tandem with the release. The same hardcoded version also appears in the "Refresh Claude Code generated plugins" section where the version is stated inline.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: align smoke error taxonomy"](https://github.com/seungpyoson/relay/commit/1430a5d322879731251ade48f730fc98b8ff0a3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34846836)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->