### PR TITLE
Add Grok oversized scope manifest

### DIFF
--- a/plugins/grok/scripts/grok-web-reviewer.mjs
+++ b/plugins/grok/scripts/grok-web-reviewer.mjs
@@ -59,6 +59,7 @@ const REVIEW_READINESS_PREFLIGHT_HEADER = "x-codex-grok-readiness-preflight";
 const REVIEW_READINESS_PREFLIGHT_PROMPT = "Return exactly: ok";
 const MAX_SCOPE_FILE_BYTES = 256 * 1024;
 const MAX_SCOPE_TOTAL_BYTES = 1024 * 1024;
+const SCOPE_TOTAL_MANIFEST_LIMIT = 5;
 const GIT_SHOW_MAX_BUFFER_BYTES = 16 * 1024 * 1024;
 const MAX_STATE_JOBS = 50;
 const STATE_LOCK_STALE_MS = 60 * 1000;
@@ -1047,9 +1048,24 @@ function addScopeFile(files, normalizedRel, text, totalBytes) {
   }
   totalBytes.value += bytes;
   if (totalBytes.value > MAX_SCOPE_TOTAL_BYTES) {
-    throw new Error(`scope_total_too_large:${totalBytes.value} bytes exceeds ${MAX_SCOPE_TOTAL_BYTES} byte limit`);
+    throw new Error(
+      `scope_total_too_large:${totalBytes.value} bytes exceeds ${MAX_SCOPE_TOTAL_BYTES} byte limit`
+      + scopeSizeManifest([...files, { path: normalizedRel, text }]),
+    );
   }
   files.push({ path: normalizedRel, text });
+}
+
+function scopeSizeManifest(files, limit = SCOPE_TOTAL_MANIFEST_LIMIT) {
+  const lines = files
+    .map((file) => ({
+      path: file.path,
+      bytes: Buffer.byteLength(file.text, "utf8"),
+    }))
+    .sort((a, b) => b.bytes - a.bytes || (a.path < b.path ? -1 : a.path > b.path ? 1 : 0))
+    .slice(0, limit)
+    .map((file) => `${file.bytes} ${file.path}`);
+  return lines.length > 0 ? `\nfiles:\n${lines.join("\n")}\n` : "";
 }
 
 async function readUtf8ScopeFileWithinLimit(filePath, normalizedRel, beforeOpen = null) {

--- a/plugins/grok/scripts/grok-web-reviewer.mjs
+++ b/plugins/grok/scripts/grok-web-reviewer.mjs
@@ -1047,21 +1047,19 @@ function addScopeFile(files, normalizedRel, text, totalBytes) {
     throw new Error(`scope_file_too_large:${normalizedRel}: ${bytes} bytes exceeds ${MAX_SCOPE_FILE_BYTES} byte limit`);
   }
   totalBytes.value += bytes;
+  const file = { path: normalizedRel, text, bytes };
   if (totalBytes.value > MAX_SCOPE_TOTAL_BYTES) {
     throw new Error(
       `scope_total_too_large:${totalBytes.value} bytes exceeds ${MAX_SCOPE_TOTAL_BYTES} byte limit`
-      + scopeSizeManifest([...files, { path: normalizedRel, text }]),
+      + scopeSizeManifest([...files, file]),
     );
   }
-  files.push({ path: normalizedRel, text });
+  files.push(file);
 }
 
-function scopeSizeManifest(files, limit = SCOPE_TOTAL_MANIFEST_LIMIT) {
+function scopeSizeManifest(files) {
+  const limit = SCOPE_TOTAL_MANIFEST_LIMIT;
   const lines = files
-    .map((file) => ({
-      path: file.path,
-      bytes: Buffer.byteLength(file.text, "utf8"),
-    }))
     .sort((a, b) => b.bytes - a.bytes || (a.path < b.path ? -1 : a.path > b.path ? 1 : 0))
     .slice(0, limit)
     .map((file) => `${file.bytes} ${file.path}`);

--- a/relay/relay-grok/scripts/grok-web-reviewer.mjs
+++ b/relay/relay-grok/scripts/grok-web-reviewer.mjs
@@ -59,6 +59,7 @@ const REVIEW_READINESS_PREFLIGHT_HEADER = "x-codex-grok-readiness-preflight";
 const REVIEW_READINESS_PREFLIGHT_PROMPT = "Return exactly: ok";
 const MAX_SCOPE_FILE_BYTES = 256 * 1024;
 const MAX_SCOPE_TOTAL_BYTES = 1024 * 1024;
+const SCOPE_TOTAL_MANIFEST_LIMIT = 5;
 const GIT_SHOW_MAX_BUFFER_BYTES = 16 * 1024 * 1024;
 const MAX_STATE_JOBS = 50;
 const STATE_LOCK_STALE_MS = 60 * 1000;
@@ -1047,9 +1048,24 @@ function addScopeFile(files, normalizedRel, text, totalBytes) {
   }
   totalBytes.value += bytes;
   if (totalBytes.value > MAX_SCOPE_TOTAL_BYTES) {
-    throw new Error(`scope_total_too_large:${totalBytes.value} bytes exceeds ${MAX_SCOPE_TOTAL_BYTES} byte limit`);
+    throw new Error(
+      `scope_total_too_large:${totalBytes.value} bytes exceeds ${MAX_SCOPE_TOTAL_BYTES} byte limit`
+      + scopeSizeManifest([...files, { path: normalizedRel, text }]),
+    );
   }
   files.push({ path: normalizedRel, text });
+}
+
+function scopeSizeManifest(files, limit = SCOPE_TOTAL_MANIFEST_LIMIT) {
+  const lines = files
+    .map((file) => ({
+      path: file.path,
+      bytes: Buffer.byteLength(file.text, "utf8"),
+    }))
+    .sort((a, b) => b.bytes - a.bytes || (a.path < b.path ? -1 : a.path > b.path ? 1 : 0))
+    .slice(0, limit)
+    .map((file) => `${file.bytes} ${file.path}`);
+  return lines.length > 0 ? `\nfiles:\n${lines.join("\n")}\n` : "";
 }
 
 async function readUtf8ScopeFileWithinLimit(filePath, normalizedRel, beforeOpen = null) {

--- a/relay/relay-grok/scripts/grok-web-reviewer.mjs
+++ b/relay/relay-grok/scripts/grok-web-reviewer.mjs
@@ -1047,21 +1047,19 @@ function addScopeFile(files, normalizedRel, text, totalBytes) {
     throw new Error(`scope_file_too_large:${normalizedRel}: ${bytes} bytes exceeds ${MAX_SCOPE_FILE_BYTES} byte limit`);
   }
   totalBytes.value += bytes;
+  const file = { path: normalizedRel, text, bytes };
   if (totalBytes.value > MAX_SCOPE_TOTAL_BYTES) {
     throw new Error(
       `scope_total_too_large:${totalBytes.value} bytes exceeds ${MAX_SCOPE_TOTAL_BYTES} byte limit`
-      + scopeSizeManifest([...files, { path: normalizedRel, text }]),
+      + scopeSizeManifest([...files, file]),
     );
   }
-  files.push({ path: normalizedRel, text });
+  files.push(file);
 }
 
-function scopeSizeManifest(files, limit = SCOPE_TOTAL_MANIFEST_LIMIT) {
+function scopeSizeManifest(files) {
+  const limit = SCOPE_TOTAL_MANIFEST_LIMIT;
   const lines = files
-    .map((file) => ({
-      path: file.path,
-      bytes: Buffer.byteLength(file.text, "utf8"),
-    }))
     .sort((a, b) => b.bytes - a.bytes || (a.path < b.path ? -1 : a.path > b.path ? 1 : 0))
     .slice(0, limit)
     .map((file) => `${file.bytes} ${file.path}`);

--- a/tests/smoke/grok-web.smoke.test.mjs
+++ b/tests/smoke/grok-web.smoke.test.mjs
@@ -5604,9 +5604,10 @@ test("custom-review rejects aggregate selected source that exceeds the prompt ca
   const fileSpecs = [
     ["third.js", 220],
     ["largest.js", 250],
-    ["fifth.js", 190],
     ["second.js", 230],
-    ["fourth.js", 210],
+    ["fifth.js", 190],
+    ["smaller.js", 100],
+    ["smallest.js", 60],
   ].map(([file, kib], index) => {
     const text = `export const value${index} = "${"x".repeat(kib * 1024)}";\n`;
     writeFileSync(path.join(cwd, file), text);
@@ -5640,11 +5641,13 @@ test("custom-review rejects aggregate selected source that exceeds the prompt ca
     .trim()
     .split("\n")
     .filter(Boolean);
-  const expectedManifest = fileSpecs
-    .toSorted((a, b) => b.bytes - a.bytes || a.file.localeCompare(b.file))
+  const expectedManifest = [...fileSpecs]
+    .sort((a, b) => b.bytes - a.bytes || (a.file < b.file ? -1 : a.file > b.file ? 1 : 0))
     .slice(0, 5)
     .map((item) => `${item.bytes} ${item.file}`);
   assert.deepEqual(manifest, expectedManifest);
+  assert.equal(manifest.length, 5);
+  assert.equal(manifest.some((line) => line.includes("smallest.js")), false);
   assert.equal(parseStdout(runOversizedScope()).error_message.split("\nfiles:\n")[1], `${manifest.join("\n")}\n`);
   assert.equal(record.external_review.source_content_transmission, "not_sent");
   assert.match(record.external_review.disclosure, /not sent/i);

--- a/tests/smoke/grok-web.smoke.test.mjs
+++ b/tests/smoke/grok-web.smoke.test.mjs
@@ -5601,14 +5601,20 @@ test("run rejects blank or valueless prompt flags before launch", () => {
 
 test("custom-review rejects aggregate selected source that exceeds the prompt cap before contacting the tunnel", () => {
   const cwd = mkdtempSync(path.join(tmpdir(), "grok-web-workspace-"));
-  const files = [];
-  for (let i = 0; i < 5; i += 1) {
-    const file = `large-${i}.js`;
-    files.push(file);
-    writeFileSync(path.join(cwd, file), `export const value${i} = "${"x".repeat(220 * 1024)}";\n`);
-  }
+  const fileSpecs = [
+    ["third.js", 220],
+    ["largest.js", 250],
+    ["fifth.js", 190],
+    ["second.js", 230],
+    ["fourth.js", 210],
+  ].map(([file, kib], index) => {
+    const text = `export const value${index} = "${"x".repeat(kib * 1024)}";\n`;
+    writeFileSync(path.join(cwd, file), text);
+    return { file, bytes: Buffer.byteLength(text, "utf8") };
+  });
+  const files = fileSpecs.map((item) => item.file);
 
-  const result = run([
+  const runOversizedScope = () => run([
     "run",
     "--mode", "custom-review",
     "--scope", "custom",
@@ -5621,12 +5627,25 @@ test("custom-review rejects aggregate selected source that exceeds the prompt ca
       GROK_WEB_BASE_URL: "http://127.0.0.1:9/api",
     },
   });
+  const result = runOversizedScope();
   const record = parseStdout(result);
 
   assert.equal(result.status, 1);
   assert.equal(record.status, "failed");
   assert.equal(record.error_code, "scope_failed");
   assert.match(record.error_message, /scope_total_too_large/);
+  assert.match(record.error_message, /\nfiles:\n/);
+  const manifest = record.error_message
+    .split("\nfiles:\n")[1]
+    .trim()
+    .split("\n")
+    .filter(Boolean);
+  const expectedManifest = fileSpecs
+    .toSorted((a, b) => b.bytes - a.bytes || a.file.localeCompare(b.file))
+    .slice(0, 5)
+    .map((item) => `${item.bytes} ${item.file}`);
+  assert.deepEqual(manifest, expectedManifest);
+  assert.equal(parseStdout(runOversizedScope()).error_message.split("\nfiles:\n")[1], `${manifest.join("\n")}\n`);
   assert.equal(record.external_review.source_content_transmission, "not_sent");
   assert.match(record.external_review.disclosure, /not sent/i);
 });


### PR DESCRIPTION
## Summary
- add a deterministic top-5 file-size manifest to Grok scope_total_too_large errors
- extend the Grok oversized custom-review smoke test to assert manifest order and stability
- regenerate the Claude relay Grok runtime copy

Closes #115

## Verification
- red focused Grok oversized-scope smoke test before implementation
- green focused Grok oversized-scope smoke test after implementation
- npm run smoke:grok
- npm run lint
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR attaches a deterministic top-5 file-size manifest to `scope_total_too_large` errors, making it easier to diagnose which files are consuming the scope budget. The smoke test is extended with named file specs, manifest-order assertions, and a stability re-run.

- `scopeSizeManifest` is a clean, self-contained helper that sorts accumulated files by size descending (with path as tiebreaker) and formats the top-5 entries. The constant is properly named and the manifest is appended directly to the existing error string.
- The smoke test creates exactly 5 files against a limit of 5, so the truncation behavior (`slice(0, 5)` dropping a 6th+ entry) is never exercised — a sixth small file that still triggers overflow, asserted to be absent from the manifest, would close this gap.
- `scopeSizeManifest` accepts a `limit` parameter that is never supplied by its sole call site, and recomputes byte lengths that `addScopeFile` already calculated; both are minor style nits on an error path.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the new error-enrichment path is additive and cannot affect normal (non-oversize) execution.

The implementation is correct and the existing assertions pass. The only gap is that the smoke test never triggers the top-5 truncation it claims to test, because it creates exactly as many files as the limit allows. Nothing in the changed code paths can break existing behaviour.

The smoke test in tests/smoke/grok-web.smoke.test.mjs would benefit from a sixth small file to actually exercise the manifest truncation logic.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| plugins/grok/scripts/grok-web-reviewer.mjs | Adds SCOPE_TOTAL_MANIFEST_LIMIT constant, scopeSizeManifest helper, and wires it into the scope_total_too_large error. Implementation is correct but recomputes byte sizes that were already calculated, and limit is an unused-in-practice parameter. |
| relay/relay-grok/scripts/grok-web-reviewer.mjs | Identical copy of the plugin change — regenerated relay runtime, mechanically identical diff. No independent issues. |
| tests/smoke/grok-web.smoke.test.mjs | Smoke test restructured to named file specs, adds manifest order and stability assertions. However, exactly 5 files are created with limit=5, so the slice never actually truncates — the top-5 cap is never exercised. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[addScopeFile called] --> B{file text empty?}
    B -- yes --> Z[return early]
    B -- no --> C[compute bytes via Buffer.byteLength]
    C --> D{bytes > MAX_SCOPE_FILE_BYTES?}
    D -- yes --> E[throw scope_file_too_large]
    D -- no --> F[totalBytes.value += bytes]
    F --> G{totalBytes.value > MAX_SCOPE_TOTAL_BYTES?}
    G -- yes --> H["build manifest: [...files, currentFile]"]
    H --> I["scopeSizeManifest: sort by size desc, slice top-5"]
    I --> J[throw scope_total_too_large + manifest string]
    G -- no --> K[files.push currentFile]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22seungpyoson%2Frelay%22%20on%20the%20existing%20branch%20%22codex%2Ffix-grok-scope-manifest%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ffix-grok-scope-manifest%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aplugins%2Fgrok%2Fscripts%2Fgrok-web-reviewer.mjs%3A1059%0AThe%20%60limit%60%20parameter%20on%20%60scopeSizeManifest%60%20is%20never%20supplied%20by%20its%20only%20call%20site%20%E2%80%94%20it%20always%20falls%20through%20to%20the%20default.%20Exposing%20it%20as%20a%20parameter%20adds%20API%20surface%20that%20implies%20external%20configurability%20without%20actually%20providing%20it.%20Using%20the%20constant%20directly%20keeps%20the%20interface%20honest%3B%20if%20you%20later%20need%20per-call%20overrides%2C%20the%20parameter%20can%20be%20re-added%20then.%0A%0A%60%60%60suggestion%0Afunction%20scopeSizeManifest%28files%29%20%7B%0A%20%20const%20limit%20%3D%20SCOPE_TOTAL_MANIFEST_LIMIT%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aplugins%2Fgrok%2Fscripts%2Fgrok-web-reviewer.mjs%3A1059-1069%0A%60scopeSizeManifest%60%20recomputes%20%60Buffer.byteLength%28file.text%2C%20%22utf8%22%29%60%20for%20every%20file%20in%20the%20manifest%2C%20even%20though%20%60addScopeFile%60%20already%20computed%20each%20file's%20byte%20length%20just%20before%20pushing%20it%20into%20%60files%60.%20On%20an%20error%20path%20this%20is%20harmless%2C%20but%20it%20means%20every%20kilobyte%20of%20accumulated%20scope%20content%20is%20re-scanned.%20Storing%20%60%7B%20path%2C%20text%2C%20bytes%20%7D%60%20in%20the%20%60files%60%20array%20would%20let%20the%20manifest%20reuse%20already-computed%20values.%0A%0A%23%23%23%20Issue%203%20of%203%0Atests%2Fsmoke%2Fgrok-web.smoke.test.mjs%3A5643-5646%0AThe%20test%20creates%20exactly%205%20files%20and%20asserts%20against%20%60.slice%280%2C%205%29%60%2C%20which%20means%20%60SCOPE_TOTAL_MANIFEST_LIMIT%60%20never%20actually%20truncates%20anything%20%E2%80%94%20all%205%20files%20fit%20within%20the%20limit.%20The%20key%20behavior%20%28that%20only%20the%20top-N%20largest%20appear%20when%20more%20than%20N%20files%20are%20in%20scope%29%20goes%20unverified.%20Adding%20a%206th%20small%20file%20that%20still%20causes%20overflow%2C%20then%20asserting%20it%20is%20absent%20from%20the%20manifest%2C%20would%20close%20this%20gap.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aplugins%2Fgrok%2Fscripts%2Fgrok-web-reviewer.mjs%3A1059%0AThe%20%60limit%60%20parameter%20on%20%60scopeSizeManifest%60%20is%20never%20supplied%20by%20its%20only%20call%20site%20%E2%80%94%20it%20always%20falls%20through%20to%20the%20default.%20Exposing%20it%20as%20a%20parameter%20adds%20API%20surface%20that%20implies%20external%20configurability%20without%20actually%20providing%20it.%20Using%20the%20constant%20directly%20keeps%20the%20interface%20honest%3B%20if%20you%20later%20need%20per-call%20overrides%2C%20the%20parameter%20can%20be%20re-added%20then.%0A%0A%60%60%60suggestion%0Afunction%20scopeSizeManifest%28files%29%20%7B%0A%20%20const%20limit%20%3D%20SCOPE_TOTAL_MANIFEST_LIMIT%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aplugins%2Fgrok%2Fscripts%2Fgrok-web-reviewer.mjs%3A1059-1069%0A%60scopeSizeManifest%60%20recomputes%20%60Buffer.byteLength%28file.text%2C%20%22utf8%22%29%60%20for%20every%20file%20in%20the%20manifest%2C%20even%20though%20%60addScopeFile%60%20already%20computed%20each%20file's%20byte%20length%20just%20before%20pushing%20it%20into%20%60files%60.%20On%20an%20error%20path%20this%20is%20harmless%2C%20but%20it%20means%20every%20kilobyte%20of%20accumulated%20scope%20content%20is%20re-scanned.%20Storing%20%60%7B%20path%2C%20text%2C%20bytes%20%7D%60%20in%20the%20%60files%60%20array%20would%20let%20the%20manifest%20reuse%20already-computed%20values.%0A%0A%23%23%23%20Issue%203%20of%203%0Atests%2Fsmoke%2Fgrok-web.smoke.test.mjs%3A5643-5646%0AThe%20test%20creates%20exactly%205%20files%20and%20asserts%20against%20%60.slice%280%2C%205%29%60%2C%20which%20means%20%60SCOPE_TOTAL_MANIFEST_LIMIT%60%20never%20actually%20truncates%20anything%20%E2%80%94%20all%205%20files%20fit%20within%20the%20limit.%20The%20key%20behavior%20%28that%20only%20the%20top-N%20largest%20appear%20when%20more%20than%20N%20files%20are%20in%20scope%29%20goes%20unverified.%20Adding%20a%206th%20small%20file%20that%20still%20causes%20overflow%2C%20then%20asserting%20it%20is%20absent%20from%20the%20manifest%2C%20would%20close%20this%20gap.%0A%0A&repo=seungpyoson%2Frelay&pr=202&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
plugins/grok/scripts/grok-web-reviewer.mjs:1059
The `limit` parameter on `scopeSizeManifest` is never supplied by its only call site — it always falls through to the default. Exposing it as a parameter adds API surface that implies external configurability without actually providing it. Using the constant directly keeps the interface honest; if you later need per-call overrides, the parameter can be re-added then.

```suggestion
function scopeSizeManifest(files) {
  const limit = SCOPE_TOTAL_MANIFEST_LIMIT;
```

### Issue 2 of 3
plugins/grok/scripts/grok-web-reviewer.mjs:1059-1069
`scopeSizeManifest` recomputes `Buffer.byteLength(file.text, "utf8")` for every file in the manifest, even though `addScopeFile` already computed each file's byte length just before pushing it into `files`. On an error path this is harmless, but it means every kilobyte of accumulated scope content is re-scanned. Storing `{ path, text, bytes }` in the `files` array would let the manifest reuse already-computed values.

### Issue 3 of 3
tests/smoke/grok-web.smoke.test.mjs:5643-5646
The test creates exactly 5 files and asserts against `.slice(0, 5)`, which means `SCOPE_TOTAL_MANIFEST_LIMIT` never actually truncates anything — all 5 files fit within the limit. The key behavior (that only the top-N largest appear when more than N files are in scope) goes unverified. Adding a 6th small file that still causes overflow, then asserting it is absent from the manifest, would close this gap.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add Grok oversized scope manifest"](https://github.com/seungpyoson/relay/commit/7f6dd9c50a4f64a2c223fc505958f23268588c3d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34850172)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->