### PR TITLE
fix: remove duplicate docs/*.md pattern in provider-parity-table.json

### DIFF
--- a/docs/provider-parity-table.json
+++ b/docs/provider-parity-table.json
@@ -301,7 +301,7 @@
     },
     {
       "name": "docs",
-      "module": "README.md, docs/*.md, docs/*.md",
+      "module": "README.md, docs/*.md",
       "interface": "operator runbooks and issue-fit evidence",
       "implementation": "Docs define #171 scope, use #170 as evidence only, and preserve no paid Grok API fallback language.",
       "adapters": [


### PR DESCRIPTION
Resolves [PR #205 discussion](https://github.com/seungpyoson/relay/pull/205#discussion_r3333063971).

One-line fix: `"README.md, docs/*.md, docs/*.md"` → `"README.md, docs/*.md"`