### PR TITLE
[codex] Resolve kimi-cli as Kimi fallback binary

### DIFF
--- a/plugins/kimi/scripts/kimi-companion.mjs
+++ b/plugins/kimi/scripts/kimi-companion.mjs
@@ -21,6 +21,7 @@ import { reconcileActiveJobs } from "./lib/reconcile.mjs";
 import { cleanGitEnv } from "./lib/git-env.mjs";
 import { gitEnv, isGitBinaryPolicyError, resolveGitBinary } from "./lib/git-binary.mjs";
 import { spawnKimi } from "./lib/kimi.mjs";
+import { binaryAvailable } from "./lib/process.mjs";
 import {
   latestSourcePacketPreviousAttempt,
   selectProviderRoute,
@@ -703,6 +704,16 @@ function readOnlyLaunchInputs(launchFiles) {
   };
 }
 
+function resolveKimiBinary(options = {}) {
+  if (typeof options.binary === "string" && options.binary.length > 0) return options.binary;
+  if (typeof process.env.KIMI_BINARY === "string" && process.env.KIMI_BINARY.length > 0) {
+    return process.env.KIMI_BINARY;
+  }
+  if (binaryAvailable("kimi", ["--version"]).available) return "kimi";
+  if (binaryAvailable("kimi-cli", ["--version"]).available) return "kimi-cli";
+  return "kimi";
+}
+
 async function kimiReadinessPreflight(invocation, profile) {
   const readinessProfile = resolveProfile("ping");
   const candidates = modelCandidatesForInvocation(profile, invocation);
@@ -1163,7 +1174,7 @@ async function cmdRun(rest) {
     review_prompt_contract_version: profile.name === "rescue" ? null : REVIEW_PROMPT_CONTRACT_VERSION,
     review_prompt_provider: profile.name === "rescue" ? null : "Kimi",
     schema_spec: null,
-    binary: options.binary ?? process.env.KIMI_BINARY ?? "kimi",
+    binary: resolveKimiBinary(options),
     run_kind: options.background ? "background" : "foreground",
     timeout_ms: timeoutMs,
     max_steps_per_turn: maxStepsPerTurn,
@@ -1797,7 +1808,7 @@ async function cmdContinue(rest) {
     review_prompt_contract_version: priorProfile.name === "rescue" ? null : REVIEW_PROMPT_CONTRACT_VERSION,
     review_prompt_provider: priorProfile.name === "rescue" ? null : "Kimi",
     schema_spec: prior.schema_spec ?? null,
-    binary: options.binary ?? process.env.KIMI_BINARY ?? "kimi",
+    binary: resolveKimiBinary(options),
     run_kind: options.background ? "background" : "foreground",
     timeout_ms: timeoutMs,
     max_steps_per_turn: maxStepsPerTurn,
@@ -2071,7 +2082,7 @@ async function cmdPing(rest, { readinessProfileName = "ping" } = {}) {
         model: selectedModel,
         promptText: PING_PROMPT,
         cwd: pingCwd,
-        binary: options.binary ?? process.env.KIMI_BINARY ?? "kimi",
+        binary: resolveKimiBinary(options),
         timeoutMs,
         ...readOnlyLaunchInputs(launchFiles),
       });

--- a/relay/relay-kimi/scripts/kimi-companion.mjs
+++ b/relay/relay-kimi/scripts/kimi-companion.mjs
@@ -21,6 +21,7 @@ import { reconcileActiveJobs } from "./lib/reconcile.mjs";
 import { cleanGitEnv } from "./lib/git-env.mjs";
 import { gitEnv, isGitBinaryPolicyError, resolveGitBinary } from "./lib/git-binary.mjs";
 import { spawnKimi } from "./lib/kimi.mjs";
+import { binaryAvailable } from "./lib/process.mjs";
 import {
   latestSourcePacketPreviousAttempt,
   selectProviderRoute,
@@ -703,6 +704,16 @@ function readOnlyLaunchInputs(launchFiles) {
   };
 }
 
+function resolveKimiBinary(options = {}) {
+  if (typeof options.binary === "string" && options.binary.length > 0) return options.binary;
+  if (typeof process.env.KIMI_BINARY === "string" && process.env.KIMI_BINARY.length > 0) {
+    return process.env.KIMI_BINARY;
+  }
+  if (binaryAvailable("kimi", ["--version"]).available) return "kimi";
+  if (binaryAvailable("kimi-cli", ["--version"]).available) return "kimi-cli";
+  return "kimi";
+}
+
 async function kimiReadinessPreflight(invocation, profile) {
   const readinessProfile = resolveProfile("ping");
   const candidates = modelCandidatesForInvocation(profile, invocation);
@@ -1163,7 +1174,7 @@ async function cmdRun(rest) {
     review_prompt_contract_version: profile.name === "rescue" ? null : REVIEW_PROMPT_CONTRACT_VERSION,
     review_prompt_provider: profile.name === "rescue" ? null : "Kimi",
     schema_spec: null,
-    binary: options.binary ?? process.env.KIMI_BINARY ?? "kimi",
+    binary: resolveKimiBinary(options),
     run_kind: options.background ? "background" : "foreground",
     timeout_ms: timeoutMs,
     max_steps_per_turn: maxStepsPerTurn,
@@ -1797,7 +1808,7 @@ async function cmdContinue(rest) {
     review_prompt_contract_version: priorProfile.name === "rescue" ? null : REVIEW_PROMPT_CONTRACT_VERSION,
     review_prompt_provider: priorProfile.name === "rescue" ? null : "Kimi",
     schema_spec: prior.schema_spec ?? null,
-    binary: options.binary ?? process.env.KIMI_BINARY ?? "kimi",
+    binary: resolveKimiBinary(options),
     run_kind: options.background ? "background" : "foreground",
     timeout_ms: timeoutMs,
     max_steps_per_turn: maxStepsPerTurn,
@@ -2071,7 +2082,7 @@ async function cmdPing(rest, { readinessProfileName = "ping" } = {}) {
         model: selectedModel,
         promptText: PING_PROMPT,
         cwd: pingCwd,
-        binary: options.binary ?? process.env.KIMI_BINARY ?? "kimi",
+        binary: resolveKimiBinary(options),
         timeoutMs,
         ...readOnlyLaunchInputs(launchFiles),
       });

--- a/tests/smoke/kimi-companion.smoke.test.mjs
+++ b/tests/smoke/kimi-companion.smoke.test.mjs
@@ -337,6 +337,41 @@ test("kimi doctor probes configured review model, not only native auth", () => {
   }
 });
 
+test("kimi doctor defaults to kimi-cli when kimi is absent from PATH", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "kimi-doctor-kimi-cli-cwd-"));
+  const binDir = mkdtempSync(path.join(tmpdir(), "kimi-doctor-kimi-cli-bin-"));
+  const dataDir = mkdtempSync(path.join(tmpdir(), "kimi-doctor-kimi-cli-data-"));
+  const binary = path.join(binDir, "kimi-cli");
+  writeFileSync(binary, [
+    "#!/bin/sh",
+    `exec ${JSON.stringify(process.execPath)} ${JSON.stringify(MOCK)} "$@"`,
+    "",
+  ].join("\n"));
+  chmodSync(binary, 0o755);
+  const baseEnv = { ...process.env };
+  delete baseEnv.KIMI_BINARY;
+  try {
+    const result = spawnSync(process.execPath, [COMPANION, "doctor"], {
+      cwd,
+      encoding: "utf8",
+      env: {
+        ...baseEnv,
+        PATH: binDir,
+        KIMI_PLUGIN_DATA: dataDir,
+      },
+    });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const parsed = parseJson(result.stdout);
+    assert.equal(parsed.status, "ok");
+    assert.equal(parsed.ready, true);
+    assert.equal(parsed.model, "kimi-code/kimi-for-coding");
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(binDir, { recursive: true, force: true });
+    rmSync(dataDir, { recursive: true, force: true });
+  }
+});
+
 test("kimi doctor default timeout allows slow review-model startup", { timeout: 70000 }, () => {
   const cwd = mkdtempSync(path.join(tmpdir(), "kimi-doctor-slow-review-model-"));
   try {


### PR DESCRIPTION
## Summary
- Resolve Kimi's default binary as `kimi-cli` when `kimi` is absent from PATH and no explicit `--binary`/`KIMI_BINARY` override is set.
- Apply the same fallback in both the Codex plugin copy and the relay package copy.
- Add smoke coverage for the observed install shape where only `kimi-cli` is available.

## Root Cause
The Kimi companion defaulted to a binary named `kimi`. Current Kimi CLI installs may expose `/Users/.../.local/bin/kimi-cli` instead, so setup reported Kimi as unavailable even though the CLI and first-party auth were working.

## Validation
- Red test first failed with `not_found` when only `kimi-cli` was on PATH.
- `node --test --test-name-pattern "kimi doctor defaults to kimi-cli|kimi ping classifies missing binary" tests/smoke/kimi-companion.smoke.test.mjs`
- `node --test tests/smoke/kimi-companion.smoke.test.mjs`
- `npm run lint`
- Live source-free doctor: `node plugins/kimi/scripts/kimi-companion.mjs doctor --cwd /Users/spson/Projects/Claude/relay/.worktrees/fix-kimi-binary-detection`