### PR TITLE
#223: readiness verdicts trust live signals, fail clean on drift

### DIFF
--- a/plugins/claude/scripts/claude-companion.mjs
+++ b/plugins/claude/scripts/claude-companion.mjs
@@ -42,6 +42,7 @@ import { setupContainment } from "./lib/containment.mjs";
 import { populateScope } from "./lib/scope.mjs";
 import { newJobId, verifyPidInfo } from "./lib/identity.mjs";
 import { buildJobRecord, classifyExecution, externalReviewForInvocation, isOAuthInferenceRejected } from "./lib/job-record.mjs";
+import { probeWithReprobe } from "./lib/companion-readiness-probe.mjs";
 import { sourceContentTransmissionForExecution } from "./lib/external-review.mjs";
 import { reconcileActiveJobs } from "./lib/reconcile.mjs";
 import { cleanGitEnv } from "./lib/git-env.mjs";
@@ -1883,15 +1884,23 @@ async function claudeOAuthInferencePreflight(invocation, authSelection, { allowA
   const profile = resolveProfile("ping");
   let execution;
   try {
-    execution = await spawnClaude(profile, {
-      model: invocation.model,
-      promptText: PING_PROMPT,
-      sessionId: newJobId(),
-      cwd: tmpdir(),
-      binary: resolveCliBinary(invocation.cwd, invocation.binary),
-      timeoutMs: Math.min(Number(invocation.timeout_ms ?? DEFAULT_CLAUDE_PING_TIMEOUT_MS), DEFAULT_CLAUDE_PING_TIMEOUT_MS),
-      sessionPersistence: false,
-      authSelection,
+    // Bounded same-path re-probe (#223): a transient mid-OAuth-refresh 401 must
+    // not terminally block a source-bearing review. Re-probe the SAME OAuth path
+    // once; a reproduced rejection falls through to terminal classification below.
+    execution = await probeWithReprobe({
+      attempt: () => spawnClaude(profile, {
+        model: invocation.model,
+        promptText: PING_PROMPT,
+        sessionId: newJobId(),
+        cwd: tmpdir(),
+        binary: resolveCliBinary(invocation.cwd, invocation.binary),
+        timeoutMs: Math.min(Number(invocation.timeout_ms ?? DEFAULT_CLAUDE_PING_TIMEOUT_MS), DEFAULT_CLAUDE_PING_TIMEOUT_MS),
+        sessionPersistence: false,
+        authSelection,
+      }),
+      isTransientFailure: (ex) =>
+        authSelection.selected_auth_path === "subscription_oauth"
+        && isOAuthInferenceRejected(ex, invocation),
     });
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
@@ -2892,7 +2901,15 @@ async function cmdPing(rest, { readinessProfileName = "ping" } = {}) {
       binary,
       timeoutMs,
     };
-    execution = await runClaudePingAttempt({ ...pingInputs, authSelection });
+    // Bounded same-path re-probe (#223): a transient mid-OAuth-refresh 401 can
+    // clear on an immediate retry. Re-probe the SAME subscription path once
+    // before any auth-path fallback; a reproduced rejection stays terminal.
+    execution = await probeWithReprobe({
+      attempt: () => runClaudePingAttempt({ ...pingInputs, authSelection }),
+      isTransientFailure: (ex) =>
+        ex.exitCode !== 0
+        && isOAuthInferenceRejected(ex, authSelectionClassifierContext(authSelection)),
+    });
     if (execution.exitCode !== 0) {
       const fallbackReason = pingApiFallbackReason(execution, authSelection);
       const fallbackSelection = fallbackReason

--- a/plugins/claude/scripts/lib/companion-readiness-probe.mjs
+++ b/plugins/claude/scripts/lib/companion-readiness-probe.mjs
@@ -1,0 +1,55 @@
+// Bounded same-path re-probe for readiness checks (#223).
+//
+// A readiness probe spawns the provider CLI once and classifies the result.
+// A *transient* failure — e.g. an HTTP 401 returned to a non-interactive
+// `claude -p` while the Claude CLI is mid-OAuth-token-refresh — would be
+// hard-classified terminal by a single-shot probe, even though an immediate
+// retry on the SAME auth path would succeed. This helper re-runs the identical
+// attempt closure once (after a short backoff) when the first result is
+// classified transient, and lets a *reproduced* failure stand as terminal.
+//
+// It never mutates auth state, credentials, or arguments between attempts —
+// that is what distinguishes it from an auth-PATH fallback (which switches
+// credentials, e.g. OAuth -> api_key_env). A persistent bad credential fails
+// both attempts and remains terminal (fail-closed preserved); a transient
+// mid-refresh rejection clears on the second attempt.
+
+const DEFAULT_MAX_ATTEMPTS = 2; // exactly one re-probe
+const DEFAULT_BACKOFF_MS = 250;
+
+function defaultSleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * @param {object}   opts
+ * @param {() => Promise<any>} opts.attempt            Runs one probe; returns the execution result.
+ * @param {(execution:any) => boolean} opts.isTransientFailure  True iff the result is a retryable transient.
+ * @param {number}   [opts.maxAttempts]  Total attempts including the first (>=1). Default 2 (one re-probe).
+ * @param {number}   [opts.backoffMs]    Delay before the re-probe. Default 250ms.
+ * @param {(ms:number) => Promise<void>} [opts.sleep]  Injectable for tests.
+ * @returns {Promise<any>} The last execution result (success, or the reproduced/terminal failure).
+ */
+export async function probeWithReprobe({
+  attempt,
+  isTransientFailure,
+  maxAttempts = DEFAULT_MAX_ATTEMPTS,
+  backoffMs = DEFAULT_BACKOFF_MS,
+  sleep = defaultSleep,
+} = {}) {
+  if (typeof attempt !== "function") {
+    throw new Error("probeWithReprobe: attempt must be a function");
+  }
+  if (typeof isTransientFailure !== "function") {
+    throw new Error("probeWithReprobe: isTransientFailure must be a function");
+  }
+  const total = Number.isInteger(maxAttempts) && maxAttempts >= 1 ? maxAttempts : DEFAULT_MAX_ATTEMPTS;
+  let execution;
+  for (let i = 1; i <= total; i++) {
+    execution = await attempt();
+    if (i >= total) break;
+    if (!isTransientFailure(execution)) break;
+    if (backoffMs > 0) await sleep(backoffMs);
+  }
+  return execution;
+}

--- a/plugins/grok/scripts/grok-web-reviewer.mjs
+++ b/plugins/grok/scripts/grok-web-reviewer.mjs
@@ -2014,7 +2014,15 @@ async function grokCliReadinessPreflight(cfg, env = process.env) {
   }
   const modelsInfo = parseGrokCliModels(models.stdout, cfg);
   const ignoredEnvCredentials = ignoredGrokDirectApiEnvKeys(cfg, env);
-  if (authFreshness.status === "expired") {
+  // Precedence: the live `grok models` result is authoritative over the cached
+  // access-token expiry snapshot taken above (before `grok models` ran). The
+  // bounded `grok models` call triggers the Grok CLI's own silent token refresh,
+  // so a stale cached `exp` alone does NOT mean the session is dead. Only fail
+  // fast on expired auth when the live result ALSO fails to confirm a working
+  // session (not logged in, or model not ready). This leans entirely on the
+  // CLI's refresh — it reads no refresh_token and makes no auth-file schema
+  // assumptions (see #190, #223).
+  if (authFreshness.status === "expired" && !(modelsInfo.logged_in && modelsInfo.model_ready)) {
     return providerFailureWithDiagnostic(
       "grok_cli_auth_expired",
       grokCliAuthExpiredMessage(cfg, env),
@@ -2079,6 +2087,13 @@ async function grokCliReadinessPreflight(cfg, env = process.env) {
   const sourceFree = await callGrokCli(cfg, REVIEW_READINESS_PREFLIGHT_PROMPT, {
     sourceBearing: false,
     env,
+    // If we proceeded past an expired cached access-token exp (because the live
+    // `grok models` confirmed logged_in/model_ready), bound this refresh probe
+    // so a session that still stalls on interactive OAuth fails fast instead of
+    // waiting out the full review timeout (#187 hang regression guard; #190, #223).
+    timeoutMs: authFreshness.status === "expired"
+      ? Math.min(cfg.timeout_ms, cfg.refresh_probe_timeout_ms)
+      : cfg.timeout_ms,
     baseDiagnostics: {
       grok_version: versionText,
       default_model: modelsInfo.default_model,
@@ -2128,7 +2143,7 @@ async function grokCliReadinessPreflight(cfg, env = process.env) {
   };
 }
 
-async function callGrokCli(cfg, prompt, { sourceBearing = true, baseDiagnostics = {}, env = process.env } = {}) {
+async function callGrokCli(cfg, prompt, { sourceBearing = true, baseDiagnostics = {}, env = process.env, timeoutMs = cfg.timeout_ms } = {}) {
   const neutralCwd = resolve(tmpdir(), `grok-cli-cwd-${randomUUID()}`);
   let promptDir = null;
   let promptFile = null;
@@ -2158,7 +2173,7 @@ async function callGrokCli(cfg, prompt, { sourceBearing = true, baseDiagnostics 
     ];
     result = await runGrokCliCommandAsync(cfg, args, {
       cwd: neutralCwd,
-      timeoutMs: cfg.timeout_ms,
+      timeoutMs,
       env: {
         GROK_HOME: runtimeHome.dir,
         GROK_MEMORY: "0",

--- a/plugins/grok/scripts/lib/grok-transport-adapters.mjs
+++ b/plugins/grok/scripts/lib/grok-transport-adapters.mjs
@@ -6,6 +6,12 @@ const DEFAULT_GROK2API_ADMIN_KEY = "grok2api";
 const DEFAULT_WEB_MODEL = "grok-4.20-fast";
 const DEFAULT_CLI_MODEL = "grok-build";
 const DEFAULT_TIMEOUT_MS = 900000;
+// Short bound for the source-free readiness probe we run when persisted auth
+// shows an expired cached access-token exp but the live `grok models` confirmed
+// a working session. It must stay far below the full review timeout (900s) so a
+// session that nonetheless stalls on interactive OAuth fails fast rather than
+// reintroducing the multi-minute hang #187 eliminated (see #190, #223).
+const DEFAULT_REFRESH_PROBE_TIMEOUT_MS = 30000;
 const DEFAULT_DOCTOR_TIMEOUT_MS = 2000;
 const DEFAULT_CHAT_DOCTOR_TIMEOUT_MS = 10000;
 const DEFAULT_TUNNEL_START_TIMEOUT_MS = 8000;
@@ -80,11 +86,13 @@ function cliConfig(options = {}, env = process.env) {
     base_url: null,
     model: env.GROK_CLI_MODEL || DEFAULT_CLI_MODEL,
     timeout_ms: parsePositiveIntegerEnv(env, "GROK_CLI_TIMEOUT_MS", DEFAULT_TIMEOUT_MS),
+    refresh_probe_timeout_ms: parsePositiveIntegerEnv(env, "GROK_CLI_REFRESH_PROBE_TIMEOUT_MS", DEFAULT_REFRESH_PROBE_TIMEOUT_MS),
     max_prompt_chars: parsePositiveIntegerEnv(env, "GROK_CLI_MAX_PROMPT_CHARS", DEFAULT_MAX_PROMPT_CHARS, "character count"),
     max_turns: parsePositiveIntegerEnv(env, "GROK_CLI_MAX_TURNS", DEFAULT_CLI_MAX_TURNS, "turn count"),
     prompt_budget_env: "GROK_CLI_MAX_PROMPT_CHARS",
     default_model_env: "GROK_CLI_MODEL",
     timeout_env: "GROK_CLI_TIMEOUT_MS",
+    refresh_probe_timeout_env: "GROK_CLI_REFRESH_PROBE_TIMEOUT_MS",
     legacy: false,
     credential_ref: null,
     credential_value: null,
@@ -95,6 +103,7 @@ function cliConfig(options = {}, env = process.env) {
 function cliFallbackConfig(options = {}, env = process.env) {
   return cliConfig(options, envWithoutKeys(env, [
     "GROK_CLI_TIMEOUT_MS",
+    "GROK_CLI_REFRESH_PROBE_TIMEOUT_MS",
     "GROK_CLI_MAX_PROMPT_CHARS",
     "GROK_CLI_MAX_TURNS",
   ]));

--- a/plugins/kimi/scripts/kimi-companion.mjs
+++ b/plugins/kimi/scripts/kimi-companion.mjs
@@ -21,6 +21,7 @@ import { reconcileActiveJobs } from "./lib/reconcile.mjs";
 import { cleanGitEnv } from "./lib/git-env.mjs";
 import { gitEnv, isGitBinaryPolicyError, resolveGitBinary } from "./lib/git-binary.mjs";
 import { spawnKimi } from "./lib/kimi.mjs";
+import { KimiContractMismatchError } from "./lib/kimi-capabilities.mjs";
 import {
   latestSourcePacketPreviousAttempt,
   selectProviderRoute,
@@ -1996,6 +1997,14 @@ function pingErrorFields() {
   };
 }
 
+function pingContractMismatchFields() {
+  return {
+    ready: false,
+    summary: "Installed Kimi CLI is incompatible with relay's Kimi adapter (command-surface mismatch).",
+    next_action: "Relay targets the legacy kimi-cli flag surface; the installed kimi-code CLI uses a different command contract. Adapter migration is tracked in #222.",
+  };
+}
+
 function pingSandboxBlockedFields() {
   return {
     ready: false,
@@ -2127,6 +2136,13 @@ async function cmdPing(rest, { readinessProfileName = "ping" } = {}) {
     printJson({ status: "error", ...pingErrorFields(), ...pingRouteAuthFields(), exit_code: execution.exitCode, detail });
     process.exit(2);
   } catch (e) {
+    if (e instanceof KimiContractMismatchError) {
+      printJson({ status: "cli_contract_mismatch", ...pingContractMismatchFields(), ...pingRouteAuthFields(),
+        detail: e.message,
+        missing_flags: e.missingFlags ?? [],
+        detected_version: e.detectedVersion ?? null });
+      process.exit(2);
+    }
     if (e.code === "ENOENT") {
       printJson({ status: "not_found", ...pingNotFoundFields(),
         ...pingRouteAuthFields(),

--- a/plugins/kimi/scripts/lib/kimi-capabilities.mjs
+++ b/plugins/kimi/scripts/lib/kimi-capabilities.mjs
@@ -1,0 +1,92 @@
+// Kimi CLI capability detection + command-surface contract guard (#222, #223).
+//
+// Relay's `buildKimiArgs` emits the legacy `kimi-cli` flag surface (e.g.
+// `--print`, `--input-format`, `--max-steps-per-turn`). The rewritten
+// `kimi-code` CLI uses a different contract (e.g. `-p/--prompt`, no
+// `--input-format`), so spawning it with the legacy flags dies on the first
+// unknown option with a cryptic "unknown option" error before auth is ever
+// reached. Rather than hardcode either generation's flag spellings, we read the
+// installed CLI's own `--help` and fail with a clear, terminal
+// `cli_contract_mismatch` when relay's emitted flags are not supported.
+//
+// Detection is FAIL-OPEN: when we cannot confidently read the CLI's contract
+// (e.g. `--help` errors, or its output is unrecognizable) we report ok:false and
+// callers SKIP the guard, so a CLI we could not probe is never wrongly blocked.
+
+import { runCommand } from "./process.mjs";
+
+export class KimiContractMismatchError extends Error {
+  constructor(message, { missingFlags = [], detectedVersion = null } = {}) {
+    super(message);
+    this.name = "KimiContractMismatchError";
+    this.code = "cli_contract_mismatch";
+    this.missingFlags = missingFlags;
+    this.detectedVersion = detectedVersion;
+  }
+}
+
+// Parse the option flag tokens advertised by a CLI --help screen. Only lines
+// that look like an option entry (leading whitespace + a dash) are scanned, so
+// prose, usage examples, and command descriptions don't introduce phantom flags.
+export function parseKimiHelpFlags(helpText) {
+  const flags = new Set();
+  const tokenRe = /(--[a-zA-Z0-9][a-zA-Z0-9-]*|-[a-zA-Z])(?=[\s,=]|$)/g;
+  for (const line of String(helpText ?? "").split("\n")) {
+    if (!/^\s+-/.test(line)) continue;
+    let m;
+    while ((m = tokenRe.exec(line)) !== null) flags.add(m[1]);
+  }
+  return flags;
+}
+
+// Probe the installed Kimi CLI's supported flags via `--help`. Returns
+// { ok, supportedFlags:Set, version, detail }. ok is true ONLY when --help
+// clearly produced an options screen (exit 0 AND it lists its own --help/-h).
+export function detectKimiCapabilities(binary, { env = process.env, runImpl = runCommand } = {}) {
+  const help = runImpl(binary, ["--help"], { env });
+  if (help.error || help.status !== 0) {
+    return {
+      ok: false,
+      supportedFlags: new Set(),
+      version: null,
+      detail: String(help.stderr || help.error?.message || "kimi --help exited non-zero").trim().slice(0, 400),
+    };
+  }
+  const supportedFlags = parseKimiHelpFlags(help.stdout);
+  if (!supportedFlags.has("--help") && !supportedFlags.has("-h")) {
+    // Output did not look like a genuine options screen — do not trust it.
+    return { ok: false, supportedFlags: new Set(), version: null, detail: "kimi --help output not recognized" };
+  }
+  let version = null;
+  const ver = runImpl(binary, ["--version"], { env });
+  if (!ver.error && ver.status === 0) {
+    version = String(ver.stdout ?? "").trim().split("\n")[0] || null;
+  }
+  return { ok: true, supportedFlags, version, detail: null };
+}
+
+// The distinct flag tokens an argv array uses (entries starting with "-").
+export function argFlags(args) {
+  return [...new Set((args ?? []).filter((a) => typeof a === "string" && a.startsWith("-")))];
+}
+
+// Flags the built argv uses that the installed CLI does not advertise. Empty
+// when capabilities are unknown (detection failed) — never a false positive.
+export function missingKimiFlags(args, capabilities) {
+  if (!capabilities?.ok) return [];
+  return argFlags(args).filter((f) => !capabilities.supportedFlags.has(f));
+}
+
+// Throw a typed contract-mismatch error when the installed CLI does not support
+// the flag surface relay is about to emit. No-op when capabilities are unknown.
+export function assertKimiContract(args, capabilities) {
+  const missing = missingKimiFlags(args, capabilities);
+  if (missing.length === 0) return;
+  const ver = capabilities.version ? ` ${capabilities.version}` : "";
+  throw new KimiContractMismatchError(
+    `cli_contract_mismatch: installed Kimi CLI${ver} does not support ${missing.join(", ")}. ` +
+    "Relay's adapter targets the legacy kimi-cli flag surface; the installed CLI uses a different " +
+    "command contract (e.g. -p/--prompt instead of --print). Adapter migration tracked in #222.",
+    { missingFlags: missing, detectedVersion: capabilities.version },
+  );
+}

--- a/plugins/kimi/scripts/lib/kimi.mjs
+++ b/plugins/kimi/scripts/lib/kimi.mjs
@@ -3,6 +3,7 @@ import { spawn } from "node:child_process";
 import { attachPidCapture } from "./identity.mjs";
 import { sanitizeTargetEnv } from "./provider-env.mjs";
 import { usageLimitMessage } from "./usage-limit.mjs";
+import { detectKimiCapabilities, assertKimiContract } from "./kimi-capabilities.mjs";
 
 function assertProfile(profile) {
   if (!profile || typeof profile !== "object") {
@@ -230,6 +231,11 @@ export async function spawnKimi(profile, runtimeInputs = {}) {
     mcpConfigFile,
     skillsDir,
   });
+  // Fail fast with a clear cli_contract_mismatch if the installed CLI does not
+  // support the flag surface we are about to emit, instead of dying on a cryptic
+  // "unknown option" before auth (#222, #223). No-op when the contract cannot be
+  // probed (fail-open).
+  assertKimiContract(args, detectKimiCapabilities(binary, { env }));
   const targetEnv = sanitizeTargetEnv(env);
 
   return new Promise((resolve, reject) => {

--- a/relay/relay-grok/scripts/grok-web-reviewer.mjs
+++ b/relay/relay-grok/scripts/grok-web-reviewer.mjs
@@ -2014,7 +2014,15 @@ async function grokCliReadinessPreflight(cfg, env = process.env) {
   }
   const modelsInfo = parseGrokCliModels(models.stdout, cfg);
   const ignoredEnvCredentials = ignoredGrokDirectApiEnvKeys(cfg, env);
-  if (authFreshness.status === "expired") {
+  // Precedence: the live `grok models` result is authoritative over the cached
+  // access-token expiry snapshot taken above (before `grok models` ran). The
+  // bounded `grok models` call triggers the Grok CLI's own silent token refresh,
+  // so a stale cached `exp` alone does NOT mean the session is dead. Only fail
+  // fast on expired auth when the live result ALSO fails to confirm a working
+  // session (not logged in, or model not ready). This leans entirely on the
+  // CLI's refresh — it reads no refresh_token and makes no auth-file schema
+  // assumptions (see #190, #223).
+  if (authFreshness.status === "expired" && !(modelsInfo.logged_in && modelsInfo.model_ready)) {
     return providerFailureWithDiagnostic(
       "grok_cli_auth_expired",
       grokCliAuthExpiredMessage(cfg, env),
@@ -2079,6 +2087,13 @@ async function grokCliReadinessPreflight(cfg, env = process.env) {
   const sourceFree = await callGrokCli(cfg, REVIEW_READINESS_PREFLIGHT_PROMPT, {
     sourceBearing: false,
     env,
+    // If we proceeded past an expired cached access-token exp (because the live
+    // `grok models` confirmed logged_in/model_ready), bound this refresh probe
+    // so a session that still stalls on interactive OAuth fails fast instead of
+    // waiting out the full review timeout (#187 hang regression guard; #190, #223).
+    timeoutMs: authFreshness.status === "expired"
+      ? Math.min(cfg.timeout_ms, cfg.refresh_probe_timeout_ms)
+      : cfg.timeout_ms,
     baseDiagnostics: {
       grok_version: versionText,
       default_model: modelsInfo.default_model,
@@ -2128,7 +2143,7 @@ async function grokCliReadinessPreflight(cfg, env = process.env) {
   };
 }
 
-async function callGrokCli(cfg, prompt, { sourceBearing = true, baseDiagnostics = {}, env = process.env } = {}) {
+async function callGrokCli(cfg, prompt, { sourceBearing = true, baseDiagnostics = {}, env = process.env, timeoutMs = cfg.timeout_ms } = {}) {
   const neutralCwd = resolve(tmpdir(), `grok-cli-cwd-${randomUUID()}`);
   let promptDir = null;
   let promptFile = null;
@@ -2158,7 +2173,7 @@ async function callGrokCli(cfg, prompt, { sourceBearing = true, baseDiagnostics 
     ];
     result = await runGrokCliCommandAsync(cfg, args, {
       cwd: neutralCwd,
-      timeoutMs: cfg.timeout_ms,
+      timeoutMs,
       env: {
         GROK_HOME: runtimeHome.dir,
         GROK_MEMORY: "0",

--- a/relay/relay-grok/scripts/lib/grok-transport-adapters.mjs
+++ b/relay/relay-grok/scripts/lib/grok-transport-adapters.mjs
@@ -6,6 +6,12 @@ const DEFAULT_GROK2API_ADMIN_KEY = "grok2api";
 const DEFAULT_WEB_MODEL = "grok-4.20-fast";
 const DEFAULT_CLI_MODEL = "grok-build";
 const DEFAULT_TIMEOUT_MS = 900000;
+// Short bound for the source-free readiness probe we run when persisted auth
+// shows an expired cached access-token exp but the live `grok models` confirmed
+// a working session. It must stay far below the full review timeout (900s) so a
+// session that nonetheless stalls on interactive OAuth fails fast rather than
+// reintroducing the multi-minute hang #187 eliminated (see #190, #223).
+const DEFAULT_REFRESH_PROBE_TIMEOUT_MS = 30000;
 const DEFAULT_DOCTOR_TIMEOUT_MS = 2000;
 const DEFAULT_CHAT_DOCTOR_TIMEOUT_MS = 10000;
 const DEFAULT_TUNNEL_START_TIMEOUT_MS = 8000;
@@ -80,11 +86,13 @@ function cliConfig(options = {}, env = process.env) {
     base_url: null,
     model: env.GROK_CLI_MODEL || DEFAULT_CLI_MODEL,
     timeout_ms: parsePositiveIntegerEnv(env, "GROK_CLI_TIMEOUT_MS", DEFAULT_TIMEOUT_MS),
+    refresh_probe_timeout_ms: parsePositiveIntegerEnv(env, "GROK_CLI_REFRESH_PROBE_TIMEOUT_MS", DEFAULT_REFRESH_PROBE_TIMEOUT_MS),
     max_prompt_chars: parsePositiveIntegerEnv(env, "GROK_CLI_MAX_PROMPT_CHARS", DEFAULT_MAX_PROMPT_CHARS, "character count"),
     max_turns: parsePositiveIntegerEnv(env, "GROK_CLI_MAX_TURNS", DEFAULT_CLI_MAX_TURNS, "turn count"),
     prompt_budget_env: "GROK_CLI_MAX_PROMPT_CHARS",
     default_model_env: "GROK_CLI_MODEL",
     timeout_env: "GROK_CLI_TIMEOUT_MS",
+    refresh_probe_timeout_env: "GROK_CLI_REFRESH_PROBE_TIMEOUT_MS",
     legacy: false,
     credential_ref: null,
     credential_value: null,
@@ -95,6 +103,7 @@ function cliConfig(options = {}, env = process.env) {
 function cliFallbackConfig(options = {}, env = process.env) {
   return cliConfig(options, envWithoutKeys(env, [
     "GROK_CLI_TIMEOUT_MS",
+    "GROK_CLI_REFRESH_PROBE_TIMEOUT_MS",
     "GROK_CLI_MAX_PROMPT_CHARS",
     "GROK_CLI_MAX_TURNS",
   ]));

--- a/relay/relay-kimi/scripts/kimi-companion.mjs
+++ b/relay/relay-kimi/scripts/kimi-companion.mjs
@@ -21,6 +21,7 @@ import { reconcileActiveJobs } from "./lib/reconcile.mjs";
 import { cleanGitEnv } from "./lib/git-env.mjs";
 import { gitEnv, isGitBinaryPolicyError, resolveGitBinary } from "./lib/git-binary.mjs";
 import { spawnKimi } from "./lib/kimi.mjs";
+import { KimiContractMismatchError } from "./lib/kimi-capabilities.mjs";
 import {
   latestSourcePacketPreviousAttempt,
   selectProviderRoute,
@@ -1996,6 +1997,14 @@ function pingErrorFields() {
   };
 }
 
+function pingContractMismatchFields() {
+  return {
+    ready: false,
+    summary: "Installed Kimi CLI is incompatible with relay's Kimi adapter (command-surface mismatch).",
+    next_action: "Relay targets the legacy kimi-cli flag surface; the installed kimi-code CLI uses a different command contract. Adapter migration is tracked in #222.",
+  };
+}
+
 function pingSandboxBlockedFields() {
   return {
     ready: false,
@@ -2127,6 +2136,13 @@ async function cmdPing(rest, { readinessProfileName = "ping" } = {}) {
     printJson({ status: "error", ...pingErrorFields(), ...pingRouteAuthFields(), exit_code: execution.exitCode, detail });
     process.exit(2);
   } catch (e) {
+    if (e instanceof KimiContractMismatchError) {
+      printJson({ status: "cli_contract_mismatch", ...pingContractMismatchFields(), ...pingRouteAuthFields(),
+        detail: e.message,
+        missing_flags: e.missingFlags ?? [],
+        detected_version: e.detectedVersion ?? null });
+      process.exit(2);
+    }
     if (e.code === "ENOENT") {
       printJson({ status: "not_found", ...pingNotFoundFields(),
         ...pingRouteAuthFields(),

--- a/relay/relay-kimi/scripts/lib/kimi-capabilities.mjs
+++ b/relay/relay-kimi/scripts/lib/kimi-capabilities.mjs
@@ -1,0 +1,92 @@
+// Kimi CLI capability detection + command-surface contract guard (#222, #223).
+//
+// Relay's `buildKimiArgs` emits the legacy `kimi-cli` flag surface (e.g.
+// `--print`, `--input-format`, `--max-steps-per-turn`). The rewritten
+// `kimi-code` CLI uses a different contract (e.g. `-p/--prompt`, no
+// `--input-format`), so spawning it with the legacy flags dies on the first
+// unknown option with a cryptic "unknown option" error before auth is ever
+// reached. Rather than hardcode either generation's flag spellings, we read the
+// installed CLI's own `--help` and fail with a clear, terminal
+// `cli_contract_mismatch` when relay's emitted flags are not supported.
+//
+// Detection is FAIL-OPEN: when we cannot confidently read the CLI's contract
+// (e.g. `--help` errors, or its output is unrecognizable) we report ok:false and
+// callers SKIP the guard, so a CLI we could not probe is never wrongly blocked.
+
+import { runCommand } from "./process.mjs";
+
+export class KimiContractMismatchError extends Error {
+  constructor(message, { missingFlags = [], detectedVersion = null } = {}) {
+    super(message);
+    this.name = "KimiContractMismatchError";
+    this.code = "cli_contract_mismatch";
+    this.missingFlags = missingFlags;
+    this.detectedVersion = detectedVersion;
+  }
+}
+
+// Parse the option flag tokens advertised by a CLI --help screen. Only lines
+// that look like an option entry (leading whitespace + a dash) are scanned, so
+// prose, usage examples, and command descriptions don't introduce phantom flags.
+export function parseKimiHelpFlags(helpText) {
+  const flags = new Set();
+  const tokenRe = /(--[a-zA-Z0-9][a-zA-Z0-9-]*|-[a-zA-Z])(?=[\s,=]|$)/g;
+  for (const line of String(helpText ?? "").split("\n")) {
+    if (!/^\s+-/.test(line)) continue;
+    let m;
+    while ((m = tokenRe.exec(line)) !== null) flags.add(m[1]);
+  }
+  return flags;
+}
+
+// Probe the installed Kimi CLI's supported flags via `--help`. Returns
+// { ok, supportedFlags:Set, version, detail }. ok is true ONLY when --help
+// clearly produced an options screen (exit 0 AND it lists its own --help/-h).
+export function detectKimiCapabilities(binary, { env = process.env, runImpl = runCommand } = {}) {
+  const help = runImpl(binary, ["--help"], { env });
+  if (help.error || help.status !== 0) {
+    return {
+      ok: false,
+      supportedFlags: new Set(),
+      version: null,
+      detail: String(help.stderr || help.error?.message || "kimi --help exited non-zero").trim().slice(0, 400),
+    };
+  }
+  const supportedFlags = parseKimiHelpFlags(help.stdout);
+  if (!supportedFlags.has("--help") && !supportedFlags.has("-h")) {
+    // Output did not look like a genuine options screen — do not trust it.
+    return { ok: false, supportedFlags: new Set(), version: null, detail: "kimi --help output not recognized" };
+  }
+  let version = null;
+  const ver = runImpl(binary, ["--version"], { env });
+  if (!ver.error && ver.status === 0) {
+    version = String(ver.stdout ?? "").trim().split("\n")[0] || null;
+  }
+  return { ok: true, supportedFlags, version, detail: null };
+}
+
+// The distinct flag tokens an argv array uses (entries starting with "-").
+export function argFlags(args) {
+  return [...new Set((args ?? []).filter((a) => typeof a === "string" && a.startsWith("-")))];
+}
+
+// Flags the built argv uses that the installed CLI does not advertise. Empty
+// when capabilities are unknown (detection failed) — never a false positive.
+export function missingKimiFlags(args, capabilities) {
+  if (!capabilities?.ok) return [];
+  return argFlags(args).filter((f) => !capabilities.supportedFlags.has(f));
+}
+
+// Throw a typed contract-mismatch error when the installed CLI does not support
+// the flag surface relay is about to emit. No-op when capabilities are unknown.
+export function assertKimiContract(args, capabilities) {
+  const missing = missingKimiFlags(args, capabilities);
+  if (missing.length === 0) return;
+  const ver = capabilities.version ? ` ${capabilities.version}` : "";
+  throw new KimiContractMismatchError(
+    `cli_contract_mismatch: installed Kimi CLI${ver} does not support ${missing.join(", ")}. ` +
+    "Relay's adapter targets the legacy kimi-cli flag surface; the installed CLI uses a different " +
+    "command contract (e.g. -p/--prompt instead of --print). Adapter migration tracked in #222.",
+    { missingFlags: missing, detectedVersion: capabilities.version },
+  );
+}

--- a/relay/relay-kimi/scripts/lib/kimi.mjs
+++ b/relay/relay-kimi/scripts/lib/kimi.mjs
@@ -3,6 +3,7 @@ import { spawn } from "node:child_process";
 import { attachPidCapture } from "./identity.mjs";
 import { sanitizeTargetEnv } from "./provider-env.mjs";
 import { usageLimitMessage } from "./usage-limit.mjs";
+import { detectKimiCapabilities, assertKimiContract } from "./kimi-capabilities.mjs";
 
 function assertProfile(profile) {
   if (!profile || typeof profile !== "object") {
@@ -230,6 +231,11 @@ export async function spawnKimi(profile, runtimeInputs = {}) {
     mcpConfigFile,
     skillsDir,
   });
+  // Fail fast with a clear cli_contract_mismatch if the installed CLI does not
+  // support the flag surface we are about to emit, instead of dying on a cryptic
+  // "unknown option" before auth (#222, #223). No-op when the contract cannot be
+  // probed (fail-open).
+  assertKimiContract(args, detectKimiCapabilities(binary, { env }));
   const targetEnv = sanitizeTargetEnv(env);
 
   return new Promise((resolve, reject) => {

--- a/scripts/ci/coverage-baseline.json
+++ b/scripts/ci/coverage-baseline.json
@@ -140,6 +140,11 @@
       "branches": 73.68,
       "functions": 92.86
     },
+    "plugins/claude/scripts/lib/companion-readiness-probe.mjs": {
+      "lines": 95,
+      "branches": 88,
+      "functions": 100
+    },
     "plugins/claude/scripts/lib/containment.mjs": {
       "lines": 96.55,
       "branches": 88.89,
@@ -574,6 +579,11 @@
       "lines": 44.97,
       "branches": 66.67,
       "functions": 85.71
+    },
+    "plugins/kimi/scripts/lib/kimi-capabilities.mjs": {
+      "lines": 96,
+      "branches": 78,
+      "functions": 100
     },
     "plugins/kimi/scripts/lib/kimi.mjs": {
       "lines": 53.81,

--- a/tests/smoke/claude-companion.smoke.test.mjs
+++ b/tests/smoke/claude-companion.smoke.test.mjs
@@ -3675,6 +3675,67 @@ process.exit(1);
   }
 });
 
+test("doctor: a transient OAuth 401 clears on the bounded same-path re-probe and reports ready (#223)", () => {
+  const tmp = mkdtempSync(path.join(tmpdir(), "claude-doctor-oauth-transient-401-"));
+  const countPath = path.join(tmp, "infer-count.txt");
+  const binary = writeExecutable(tmp, "claude-oauth-transient-401", `#!/usr/bin/env node
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+const args = process.argv.slice(2);
+if (args[0] === "auth" && args[1] === "status") {
+  process.stdout.write(JSON.stringify({
+    loggedIn: true,
+    authMethod: "claude.ai",
+    apiProvider: "firstParty",
+    subscriptionType: "max"
+  }) + "\\n");
+  process.exit(0);
+}
+const countPath = ${JSON.stringify(countPath)};
+const n = existsSync(countPath) ? Number(readFileSync(countPath, "utf8")) : 0;
+writeFileSync(countPath, String(n + 1), "utf8");
+if (n === 0) {
+  // First inference attempt: a transient mid-OAuth-refresh 401 on the SAME auth path.
+  process.stdout.write(JSON.stringify({
+    type: "result",
+    is_error: true,
+    api_error_status: 401,
+    result: "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+    session_id: "33333333-3333-4333-8333-333333333333",
+    usage: { input_tokens: 0, output_tokens: 0 }
+  }) + "\\n");
+  process.exit(1);
+}
+// Second attempt: the refresh has completed; the identical OAuth call now succeeds.
+process.stdout.write(JSON.stringify({
+  type: "result",
+  is_error: false,
+  result: "ok",
+  session_id: "33333333-3333-4333-8333-333333333333",
+  usage: { input_tokens: 1, output_tokens: 1 }
+}) + "\\n");
+process.exit(0);
+`);
+  const { stdout, status, dataDir } = runCompanion(
+    ["doctor", "--binary", binary, "--model", "claude-haiku-4-5-20251001", "--auth-mode", "subscription"],
+    { cwd: tmpdir(), env: { ANTHROPIC_API_KEY: "", CLAUDE_API_KEY: "" } },
+  );
+  try {
+    assert.equal(status, 0, stdout);
+    const result = JSON.parse(stdout);
+    assert.equal(result.status, "ok");
+    assert.equal(result.ready, true);
+    // Recovered on the SAME subscription path — not via the api-key fallback.
+    assert.equal(result.selected_auth_path, "subscription_oauth");
+    assert.equal(result.auth_fallback, undefined);
+    // The re-probe ran the inference exactly twice: transient 401, then success.
+    assert.equal(Number(readFileSync(countPath, "utf8")), 2);
+    assert.doesNotMatch(stdout, /invalid authentication credentials/i);
+  } finally {
+    cleanup(dataDir);
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test("doctor: OAuth inference rejection falls back to API key for source-free readiness", () => {
   const tmp = mkdtempSync(path.join(tmpdir(), "claude-doctor-oauth-api-fallback-"));
   const binary = writeExecutable(tmp, "claude-oauth-api-fallback", `#!/usr/bin/env node
@@ -3960,15 +4021,22 @@ process.exit(1);
 
 test("doctor: OAuth status missing binary after ping reports not found", () => {
   const tmp = mkdtempSync(path.join(tmpdir(), "claude-doctor-oauth-status-enoent-"));
+  const countPath = path.join(tmp, "infer-count.txt");
   const binary = writeExecutable(tmp, "claude-oauth-status-enoent", `#!/usr/bin/env node
-const { unlinkSync } = require("node:fs");
+const { existsSync, readFileSync, writeFileSync, unlinkSync } = require("node:fs");
 const self = process.argv[1];
+const countPath = ${JSON.stringify(countPath)};
 const args = process.argv.slice(2);
 if (args[0] === "auth" && args[1] === "status") {
   process.stdout.write("unexpected auth status execution\\n");
   process.exit(0);
 }
-unlinkSync(self);
+const n = (existsSync(countPath) ? Number(readFileSync(countPath, "utf8")) : 0) + 1;
+writeFileSync(countPath, String(n), "utf8");
+// Self-delete only after the bounded re-probe's final attempt (maxAttempts=2),
+// so the missing-binary condition is observed by the subsequent auth-status
+// check rather than by the re-probe spawn itself (#223).
+if (n >= 2) unlinkSync(self);
 process.stdout.write(JSON.stringify({
   type: "result",
   is_error: true,
@@ -4445,8 +4513,16 @@ if (args[0] === "auth" && args[1] === "status") {
   }) + "\\n");
   process.exit(0);
 }
-const count = existsSync(countPath) ? Number(readFileSync(countPath, "utf8")) : 0;
-writeFileSync(countPath, String(count + 1), "utf8");
+// Distinguish the source-free preflight ping from an actual source-bearing
+// review by inspecting the prompt (delivered on stdin). Only real review
+// launches are counted, so the bounded preflight re-probe (#223) — which
+// reuses the ping prompt — is never mistaken for a review launch.
+let prompt = "";
+try { prompt = readFileSync(0, "utf8"); } catch {}
+if (!prompt.includes("reply with exactly: pong")) {
+  const count = existsSync(countPath) ? Number(readFileSync(countPath, "utf8")) : 0;
+  writeFileSync(countPath, String(count + 1), "utf8");
+}
 process.stdout.write(JSON.stringify({
   type: "result",
   is_error: true,
@@ -4476,7 +4552,10 @@ process.exit(1);
     assert.equal(record.external_review.source_content_transmission, "not_sent");
     assert.equal(record.review_metadata.audit_manifest.error_code, "oauth_inference_rejected");
     assert.equal(record.review_metadata.audit_manifest.review_quality.failed_review_slot, false);
-    assert.equal(readFileSync(countPath, "utf8"), "1", "target review must not launch after preflight rejection");
+    // The preflight (including its one bounded re-probe) uses only the source-free
+    // ping prompt; the source-bearing review must never launch after rejection.
+    const reviewLaunches = existsSync(countPath) ? readFileSync(countPath, "utf8") : "0";
+    assert.equal(reviewLaunches, "0", "source-bearing review must not launch after preflight rejection");
   } finally {
     cleanup(dataDir);
     cleanupDir(cwd);

--- a/tests/smoke/grok-web.smoke.test.mjs
+++ b/tests/smoke/grok-web.smoke.test.mjs
@@ -371,6 +371,7 @@ function makeFakeGrokCli({
   ignoreSourceBearingSigterm = false,
   mutateAuthOnSource = false,
   mutateAuthOnSourceFree = false,
+  sourceFreeHangMs = 0,
 } = {}) {
   const binDir = mkdtempSync(path.join(tmpdir(), "fake-grok-cli-bin-"));
   const logPath = path.join(binDir, "grok-log.jsonl");
@@ -391,6 +392,7 @@ const modelsStderr = ${JSON.stringify(modelsStderr)};
 const sourceFreeAuthStderr = ${JSON.stringify(sourceFreeAuthStderr)};
 const mutateAuthOnSource = ${JSON.stringify(mutateAuthOnSource)};
 const mutateAuthOnSourceFree = ${JSON.stringify(mutateAuthOnSourceFree)};
+const sourceFreeHangMs = ${JSON.stringify(sourceFreeHangMs)};
 const args = process.argv.slice(2);
 const apiEnvKeys = ["GROK_API_KEY", "XAI_API_KEY", "XAI_KEY"].filter((key) => Object.prototype.hasOwnProperty.call(process.env, key));
 const sensitiveEnvKeys = ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "AWS_ACCESS_KEY_ID", "GITHUB_TOKEN", "GH_TOKEN"].filter((key) => Object.prototype.hasOwnProperty.call(process.env, key));
@@ -471,6 +473,11 @@ if (failSourceBearing && prompt.includes("CLI_SOURCE_SECRET")) {
 if (sourceFreeAuthStderr && !prompt.includes("CLI_SOURCE_SECRET")) {
   process.stderr.write(sourceFreeAuthStderr);
   process.exit(1);
+}
+if (sourceFreeHangMs > 0 && !prompt.includes("CLI_SOURCE_SECRET")) {
+  // Silent stall on the source-free probe (no OAuth stderr): forces the parent
+  // to enforce its own timeout bound rather than the child exiting on its own.
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, sourceFreeHangMs);
 }
 if (ignoreSourceBearingSigterm && prompt.includes("CLI_SOURCE_SECRET")) {
   process.on("SIGTERM", () => {});
@@ -1177,7 +1184,7 @@ test("custom-review fails fast on expired Grok CLI auth without starting OAuth p
   }
 });
 
-test("custom-review fails fast when Grok CLI reports logged in but persisted auth is expired", () => {
+test("custom-review defers to the live Grok CLI session over an expired cached exp, then fails closed (bounded) when the source-free probe stalls on OAuth", () => {
   const cwd = realpathSync(mkdtempSync(path.join(tmpdir(), "grok-cli-logged-in-expired-auth-workspace-")));
   const dataDir = mkdtempSync(path.join(tmpdir(), "grok-cli-logged-in-expired-auth-data-"));
   const authHome = mkdtempSync(path.join(tmpdir(), "grok-cli-logged-in-expired-auth-home-"));
@@ -1209,22 +1216,122 @@ test("custom-review fails fast when Grok CLI reports logged in but persisted aut
     assert.equal(result.status, 1, result.stdout);
     const record = parseStdout(result);
     assert.equal(record.status, "failed");
-    assert.equal(record.error_code, "grok_cli_auth_expired");
+    // Precedence fix (#190, #223): a stale cached access-token exp no longer
+    // pre-empts the authoritative live `grok models` result. We proceed to the
+    // bounded, source-free refresh probe; only when THAT fails — here the CLI
+    // stalls on interactive OAuth — do we fail closed, now as grok_cli_auth_timeout
+    // rather than the old pre-judged grok_cli_auth_expired. Source is never sent.
+    assert.equal(record.error_code, "grok_cli_auth_timeout");
     assert.equal(record.error_cause, "grok_cli");
+    assert.equal(record.auth_mode, "subscription_cli");
     assert.equal(record.external_review.source_content_transmission, "not_sent");
     assert.equal(record.runtime_diagnostics.cli_request.logged_in, true);
     assert.equal(record.runtime_diagnostics.cli_request.model_ready, true);
     assert.equal(record.runtime_diagnostics.cli_request.auth_freshness.status, "expired");
+    assert.equal(record.runtime_diagnostics.cli_request.exit_status, 1);
+    assert.match(record.runtime_diagnostics.cli_request.stderr_head, /OSStatus error -10661/);
+    assert.equal(record.runtime_diagnostics.cli_request.source_free_prompt_cleanup, "deleted");
     assert.equal(record.runtime_diagnostics.cli_request.prompt_cleanup, null);
     assert.equal(record.runtime_diagnostics.cli_request.grok_home_cleanup, null);
-    assert.match(record.suggested_action, /grok login/i);
-    assert.doesNotMatch(JSON.stringify(record), /CLI_SOURCE_SECRET|OSStatus error -10661|Login timed out/);
+    assert.match(record.suggested_action, /grok login|auth/i);
+    assert.doesNotMatch(JSON.stringify(record), /CLI_SOURCE_SECRET/);
 
+    // The source-free probe DID run (third invocation), carrying no selected source.
     const logLines = readGrokCliLog(logPath);
     assert.deepEqual(logLines.filter((line) => Array.isArray(line.args)).map((line) => line.args[0]), [
-      "--version", "models",
+      "--version", "models", "--prompt-file",
     ]);
-    assert.equal(logLines.some((line) => line.promptPath), false);
+    const promptInvocations = logLines.filter((line) => line.promptPath);
+    assert.equal(promptInvocations.length, 1);
+    assert.equal(promptInvocations[0].promptHasSource, false);
+  } finally {
+    rmTree(authHome);
+    rmTree(cwd);
+    rmTree(dataDir);
+  }
+});
+
+test("doctor treats an expired cached exp as ready when the live Grok CLI session works", () => {
+  const dataDir = mkdtempSync(path.join(tmpdir(), "grok-cli-expired-recovered-doctor-data-"));
+  const authHome = mkdtempSync(path.join(tmpdir(), "grok-cli-expired-recovered-doctor-auth-home-"));
+  // No sourceFreeAuthStderr -> the source-free probe succeeds, proving the live session works.
+  const { binDir, grokPath, logPath } = makeFakeGrokCli();
+  writeExpiredGrokCliAuthFixture(authHome);
+
+  try {
+    const result = run(["doctor"], {
+      defaultTransport: false,
+      env: {
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        GROK_CLI_BINARY: grokPath,
+        GROK_CLI_AUTH_HOME: authHome,
+        GROK_PLUGIN_DATA: dataDir,
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const parsed = parseStdout(result);
+    // The cached exp is expired, but the live `grok models` + source-free probe
+    // prove the session works -> readiness must be true. Before #190/#223 this was
+    // a false negative (grok_cli_auth_expired, ready:false).
+    assert.equal(parsed.ready, true);
+    assert.equal(parsed.transport, "cli");
+    assert.equal(parsed.logged_in, true);
+    assert.equal(parsed.model_ready, true);
+    assert.equal(parsed.readiness_layers.cli_login.status, "ready");
+    assert.equal(parsed.readiness_layers.source_free_prompt.status, "ready");
+
+    const logLines = readGrokCliLog(logPath);
+    const promptInvocations = logLines.filter((line) => line.promptPath);
+    assert.equal(promptInvocations.length, 1);
+    assert.equal(promptInvocations[0].promptHasSource, false);
+  } finally {
+    rmTree(authHome);
+    rmTree(dataDir);
+  }
+});
+
+test("the expired-recovery source-free probe is bounded by refresh_probe_timeout_ms, not the full review timeout", () => {
+  const cwd = realpathSync(mkdtempSync(path.join(tmpdir(), "grok-cli-refresh-bound-workspace-")));
+  const dataDir = mkdtempSync(path.join(tmpdir(), "grok-cli-refresh-bound-data-"));
+  const authHome = mkdtempSync(path.join(tmpdir(), "grok-cli-refresh-bound-auth-home-"));
+  // Source-free probe silently stalls for 5s (no OAuth stderr); only the parent's
+  // own timeout can end it.
+  const { binDir, grokPath } = makeFakeGrokCli({ sourceFreeHangMs: 5000 });
+  writeFileSync(path.join(cwd, "review.js"), "export const marker = 'CLI_SOURCE_SECRET';\n");
+  writeExpiredGrokCliAuthFixture(authHome);
+
+  try {
+    const result = run([
+      "run",
+      "--mode", "custom-review",
+      "--scope", "custom",
+      "--scope-paths", "review.js",
+      "--foreground",
+      "--prompt", "Review selected source.",
+    ], {
+      cwd,
+      defaultTransport: false,
+      env: {
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        GROK_CLI_BINARY: grokPath,
+        GROK_CLI_AUTH_HOME: authHome,
+        GROK_PLUGIN_DATA: dataDir,
+        // Generous full review timeout, tiny refresh-probe bound. If the bound
+        // governs, the 5s stall is aborted at ~300ms and the run fails closed —
+        // it never reaches the success the child would have produced post-hang.
+        GROK_CLI_TIMEOUT_MS: "60000",
+        GROK_CLI_REFRESH_PROBE_TIMEOUT_MS: "300",
+      },
+    });
+
+    assert.equal(result.status, 1, result.stdout);
+    const record = parseStdout(result);
+    assert.equal(record.status, "failed");
+    assert.equal(record.external_review.source_content_transmission, "not_sent");
+    assert.equal(record.runtime_diagnostics.cli_request.logged_in, true);
+    assert.equal(record.runtime_diagnostics.cli_request.auth_freshness.status, "expired");
+    assert.doesNotMatch(JSON.stringify(record), /CLI_SOURCE_SECRET/);
   } finally {
     rmTree(authHome);
     rmTree(cwd);

--- a/tests/smoke/kimi-companion.smoke.test.mjs
+++ b/tests/smoke/kimi-companion.smoke.test.mjs
@@ -397,6 +397,59 @@ test("kimi ping classifies timeout as transient latency", () => {
   }
 });
 
+test("kimi doctor reports cli_contract_mismatch when the installed CLI is kimi-code (no legacy --print) (#222, #223)", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "kimi-doctor-contract-mismatch-"));
+  const bin = path.join(cwd, "kimi-code");
+  writeFileSync(bin, `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args.includes("--version") || args.includes("-V")) {
+  process.stdout.write("0.18.0\\n");
+  process.exit(0);
+}
+if (args.includes("--help") || args.includes("-h")) {
+  process.stdout.write([
+    "Usage: kimi [options] [command]",
+    "",
+    "Options:",
+    "  -V, --version              output the version number",
+    "  -S, --session [id]         Resume a session.",
+    "  -m, --model <model>        LLM model alias.",
+    "  -p, --prompt <prompt>      Run one prompt non-interactively.",
+    "  --output-format <format>   Output format. (choices: text, stream-json)",
+    "  --skills-dir <dir>         Load skills from this directory.",
+    "  --plan                     Start in plan mode.",
+    "  -h, --help                 Show help.",
+    "",
+    "Commands:",
+    "  doctor                     Validate Kimi Code configuration files.",
+    "",
+  ].join("\\n"));
+  process.exit(0);
+}
+// Must never be reached: relay must fail the contract check before spawning,
+// instead of dying here on the legacy --print flag.
+process.stderr.write("error: unknown option '--print'\\n");
+process.exit(1);
+`, "utf8");
+  chmodSync(bin, 0o755);
+  try {
+    const result = runCompanion(["doctor", "--binary", bin], { cwd });
+    assert.equal(result.status, 2, result.stderr || result.stdout);
+    const parsed = parseJson(result.stdout);
+    assert.equal(parsed.status, "cli_contract_mismatch");
+    assert.equal(parsed.ready, false);
+    assert.ok(Array.isArray(parsed.missing_flags));
+    assert.ok(parsed.missing_flags.includes("--print"), result.stdout);
+    assert.equal(parsed.detected_version, "0.18.0");
+    assert.match(parsed.detail, /#222/);
+    assert.match(parsed.next_action, /#222/);
+    // The cryptic "unknown option" path must NOT be what the operator sees.
+    assert.doesNotMatch(parsed.summary, /unknown option/);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test("kimi ping classifies Codex sandbox denial for Kimi state as sandbox_blocked", () => {
   const cwd = mkdtempSync(path.join(tmpdir(), "kimi-ping-sandbox-denied-"));
   const bin = path.join(cwd, "kimi-denied");

--- a/tests/unit/companion-readiness-probe.test.mjs
+++ b/tests/unit/companion-readiness-probe.test.mjs
@@ -1,0 +1,111 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { probeWithReprobe } from "../../plugins/claude/scripts/lib/companion-readiness-probe.mjs";
+
+// Drives a scripted sequence of attempt results and records how many times the
+// attempt closure ran. The last scripted result repeats if more attempts occur.
+function scriptedAttempts(results) {
+  let i = 0;
+  const calls = [];
+  return {
+    calls,
+    attempt: async () => {
+      const r = results[Math.min(i, results.length - 1)];
+      i += 1;
+      calls.push(r);
+      return r;
+    },
+  };
+}
+
+test("re-probes once and returns success when a transient clears on the second attempt", async () => {
+  const { attempt, calls } = scriptedAttempts([
+    { exitCode: 1, transient: true },
+    { exitCode: 0, transient: false },
+  ]);
+  const sleeps = [];
+  const result = await probeWithReprobe({
+    attempt,
+    isTransientFailure: (ex) => ex.transient === true,
+    sleep: async (ms) => { sleeps.push(ms); },
+  });
+  assert.equal(result.exitCode, 0);
+  assert.equal(calls.length, 2);
+  assert.deepEqual(sleeps, [250]); // exactly one backoff before the single re-probe
+});
+
+test("a reproduced transient becomes terminal after exactly one re-probe (bounded)", async () => {
+  const { attempt, calls } = scriptedAttempts([
+    { exitCode: 1, transient: true },
+    { exitCode: 1, transient: true },
+    { exitCode: 1, transient: true },
+  ]);
+  let sleepCount = 0;
+  const result = await probeWithReprobe({
+    attempt,
+    isTransientFailure: (ex) => ex.transient === true,
+    sleep: async () => { sleepCount += 1; },
+  });
+  assert.equal(result.exitCode, 1);
+  assert.equal(calls.length, 2); // never exceeds maxAttempts even when always transient
+  assert.equal(sleepCount, 1);
+});
+
+test("a terminal (non-transient) failure is never retried — fail-closed preserved", async () => {
+  const { attempt, calls } = scriptedAttempts([
+    { exitCode: 1, transient: false },
+    { exitCode: 0, transient: false },
+  ]);
+  let sleepCount = 0;
+  const result = await probeWithReprobe({
+    attempt,
+    isTransientFailure: (ex) => ex.transient === true,
+    sleep: async () => { sleepCount += 1; },
+  });
+  assert.equal(result.exitCode, 1);
+  assert.equal(calls.length, 1);
+  assert.equal(sleepCount, 0);
+});
+
+test("a first-attempt success neither retries nor sleeps", async () => {
+  const { attempt, calls } = scriptedAttempts([{ exitCode: 0, transient: false }]);
+  let sleepCount = 0;
+  const result = await probeWithReprobe({
+    attempt,
+    // Realistic predicate: only a non-zero exit can be transient. A success is
+    // therefore never re-probed regardless of other fields.
+    isTransientFailure: (ex) => ex.exitCode !== 0,
+    sleep: async () => { sleepCount += 1; },
+  });
+  assert.equal(result.exitCode, 0);
+  assert.equal(calls.length, 1);
+  assert.equal(sleepCount, 0);
+});
+
+test("honors a custom maxAttempts while staying bounded", async () => {
+  const { attempt, calls } = scriptedAttempts([
+    { exitCode: 1, transient: true },
+    { exitCode: 1, transient: true },
+    { exitCode: 0, transient: false },
+  ]);
+  const result = await probeWithReprobe({
+    attempt,
+    isTransientFailure: (ex) => ex.transient === true,
+    maxAttempts: 3,
+    sleep: async () => {},
+  });
+  assert.equal(result.exitCode, 0);
+  assert.equal(calls.length, 3);
+});
+
+test("validates its callbacks", async () => {
+  await assert.rejects(
+    () => probeWithReprobe({ isTransientFailure: () => false }),
+    /attempt must be a function/,
+  );
+  await assert.rejects(
+    () => probeWithReprobe({ attempt: async () => ({}) }),
+    /isTransientFailure must be a function/,
+  );
+});

--- a/tests/unit/kimi-capabilities.test.mjs
+++ b/tests/unit/kimi-capabilities.test.mjs
@@ -1,0 +1,134 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  parseKimiHelpFlags,
+  detectKimiCapabilities,
+  missingKimiFlags,
+  assertKimiContract,
+  KimiContractMismatchError,
+} from "../../plugins/kimi/scripts/lib/kimi-capabilities.mjs";
+
+// Abridged real kimi-code 0.18.0 --help (the installed contract).
+const KIMI_CODE_HELP = `Usage: kimi [options] [command]
+
+The Starting Point for Next-Gen Agents
+
+Options:
+  -V, --version                 output the version number
+  -S, --session [id]            Resume a session.
+  -y, --yolo                    Automatically approve all actions.
+  -m, --model <model>           LLM model alias to use for this invocation.
+  -p, --prompt <prompt>         Run one prompt non-interactively and print the response.
+  --output-format <format>      Output format for prompt mode. (choices: "text", "stream-json")
+  --skills-dir <dir>            Load skills from this directory.
+  --plan                        Start in plan mode.
+  -h, --help                    Show help.
+
+Commands:
+  doctor                        Validate Kimi Code configuration files.
+`;
+
+// Legacy kimi-cli help (the surface relay's buildKimiArgs targets).
+const LEGACY_HELP = `Usage: kimi [options]
+
+Options:
+  --print                       Print mode.
+  --final-message-only          Only the final message.
+  --input-format <fmt>          Input format.
+  --output-format <fmt>         Output format.
+  --max-steps-per-turn <n>      Max steps per turn.
+  -m, --model <model>           Model.
+  --thinking                    Thinking.
+  --agent-file <path>           Agent file.
+  --mcp-config-file <path>      MCP config file.
+  --skills-dir <dir>            Skills dir.
+  -h, --help                    Show help.
+`;
+
+function fakeRun(map) {
+  return (_binary, args) => map[args.join(" ")] ?? { status: 1, stdout: "", stderr: "unknown", error: null };
+}
+
+test("parseKimiHelpFlags extracts option tokens from option lines only", () => {
+  const flags = parseKimiHelpFlags(KIMI_CODE_HELP);
+  assert.ok(flags.has("-p"));
+  assert.ok(flags.has("--prompt"));
+  assert.ok(flags.has("--output-format"));
+  assert.ok(flags.has("--help"));
+  assert.ok(!flags.has("--print")); // not advertised by kimi-code
+  assert.ok(!flags.has("doctor")); // command/prose lines do not leak tokens
+});
+
+test("detectKimiCapabilities reports ok with parsed flags + version on a real help screen", () => {
+  const caps = detectKimiCapabilities("kimi", {
+    runImpl: fakeRun({
+      "--help": { status: 0, stdout: KIMI_CODE_HELP, stderr: "" },
+      "--version": { status: 0, stdout: "0.18.0\n", stderr: "" },
+    }),
+  });
+  assert.equal(caps.ok, true);
+  assert.equal(caps.version, "0.18.0");
+  assert.ok(caps.supportedFlags.has("--prompt"));
+});
+
+test("detectKimiCapabilities is fail-open (ok:false) when --help errors", () => {
+  const caps = detectKimiCapabilities("kimi", {
+    runImpl: fakeRun({ "--help": { status: 1, stdout: "", stderr: "unknown flag --help" } }),
+  });
+  assert.equal(caps.ok, false);
+  assert.equal(caps.supportedFlags.size, 0);
+});
+
+test("detectKimiCapabilities is fail-open when --help output is unrecognizable", () => {
+  const caps = detectKimiCapabilities("kimi", {
+    runImpl: fakeRun({ "--help": { status: 0, stdout: "not a help screen", stderr: "" } }),
+  });
+  assert.equal(caps.ok, false);
+});
+
+test("missingKimiFlags returns the legacy flags kimi-code does not advertise", () => {
+  const caps = detectKimiCapabilities("kimi", {
+    runImpl: fakeRun({
+      "--help": { status: 0, stdout: KIMI_CODE_HELP, stderr: "" },
+      "--version": { status: 0, stdout: "0.18.0" },
+    }),
+  });
+  const legacyArgs = ["--print", "--final-message-only", "--output-format", "stream-json",
+    "--input-format", "text", "-m", "kimi-x"];
+  assert.deepEqual(
+    missingKimiFlags(legacyArgs, caps).sort(),
+    ["--final-message-only", "--input-format", "--print"].sort(),
+  );
+});
+
+test("assertKimiContract throws a typed cli_contract_mismatch naming the missing flags", () => {
+  const caps = detectKimiCapabilities("kimi", {
+    runImpl: fakeRun({
+      "--help": { status: 0, stdout: KIMI_CODE_HELP, stderr: "" },
+      "--version": { status: 0, stdout: "0.18.0" },
+    }),
+  });
+  assert.throws(
+    () => assertKimiContract(["--print", "--output-format", "stream-json"], caps),
+    (e) => e instanceof KimiContractMismatchError
+      && e.code === "cli_contract_mismatch"
+      && e.missingFlags.includes("--print")
+      && /#222/.test(e.message),
+  );
+});
+
+test("assertKimiContract is a no-op when the legacy surface IS supported", () => {
+  const caps = detectKimiCapabilities("kimi", {
+    runImpl: fakeRun({
+      "--help": { status: 0, stdout: LEGACY_HELP, stderr: "" },
+      "--version": { status: 0, stdout: "1.41.0" },
+    }),
+  });
+  assert.doesNotThrow(() =>
+    assertKimiContract(["--print", "--output-format", "x", "--input-format", "text", "-m", "y"], caps));
+});
+
+test("assertKimiContract is fail-open (no-op) when capabilities are unknown", () => {
+  assert.doesNotThrow(() => assertKimiContract(["--print"], { ok: false, supportedFlags: new Set() }));
+});


### PR DESCRIPTION
Provider-readiness hardening. Three independent false-negative classes in the readiness doctor (`cmdPing`), each fixed at the class level — **no per-provider hardcoded patches**.

## Grok — trust the live `grok models` result over a stale cached expiry (Refs #190)
The doctor read a cached access-token `exp` snapshot taken *before* the `grok models` call that itself refreshes the session. An expired-but-refreshable token was reported as a hard `grok_cli_auth_expired` failure even though the live `grok models` probe showed `logged_in && model_ready`.
- Precedence fix: an `expired` cached snapshot no longer overrides a live "logged in + ready" signal.
- Added bounded `refresh_probe_timeout_ms` (`GROK_CLI_REFRESH_PROBE_TIMEOUT_MS`, default 30s) so the expired-recovery source-free probe can't hang (guards the #187 fast-fail intent).
- Still never falls back to paid xAI API billing; `XAI_API_KEY` stays ignored.

## Kimi — detect the CLI command-surface, fail with a clear contract verdict (Refs #222)
kimi-code 0.18.0 dropped the legacy flag surface relay's `buildKimiArgs` targets, so spawns failed opaquely.
- New `kimi-capabilities.mjs`: parses `kimi --help`, compares emitted flags against the advertised surface, and (fail-open if unknown) throws a typed `KimiContractMismatchError`.
- `cmdPing` now reports a terminal `status: cli_contract_mismatch` naming the missing flags + detected version, instead of a vague spawn error.
- Full kimi-code adapter migration (stdin→`-p/--prompt`) tracked as **#222**.

## Claude — bounded same-path re-probe for transient OAuth rejections (Refs #223, #224)
- New `companion-readiness-probe.mjs`: `probeWithReprobe` retries the same auth path once (250ms backoff) when and only when the failure classifies as a transient OAuth inference rejection.
- Note: this does **not** cover the separate ~17-min generic-`error` Claude outage observed via live sampling — that is tracked under **#224** (still undiagnosed, awaiting full `detail` capture).

## Tests & coverage
- New unit suites: `companion-readiness-probe.test.mjs`, `kimi-capabilities.test.mjs`.
- Smoke additions across grok/claude/kimi (expired-recovery, bounded-probe, 401-transient-clears, contract-mismatch).
- Coverage baseline updated for the two new lib files (honest measured values, non-regression-safe).
- `relay/relay-*` generated artifacts regenerated and in sync (`npm run lint:sync`).
- Gates green: `npm run lint`, `npm test` (2533/0), `npm run test:coverage` (0 regressions).

## Relations
Refs #190, #222, #223, #224. Issue closure intentionally left to the `/done` QA gate (commits use `Refs`, not `Closes`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)