### PR TITLE
AGY: omit misleading disclosure on read-command errors (#240)

### DIFF
--- a/plugins/agy/scripts/agy-companion.mjs
+++ b/plugins/agy/scripts/agy-companion.mjs
@@ -78,6 +78,25 @@ const LARGE_SOURCE_PACKET_FLAG = "--allow-large-source-packet";
 // to main().catch. One CLI invocation per process, so a set-once latch is sufficient.
 let sourceSentToTarget = false;
 
+// Read/query commands (status/result/cancel) inspect an existing job's persisted state — they
+// spawn no target and transmit nothing, so a bare top-level "not_sent" on their error envelopes
+// is misleading (the job's real disclosure is nested at external_review.source_content_transmission
+// on the record). They omit the field (#240). EVERY other command keeps disclosing: run carries
+// the honest sent/not_sent, and continue/resume fail-closes with "not_sent" to assert that no
+// source was resent. Fail-safe — the default is to DISCLOSE; only this explicit read set omits.
+const DISCLOSURE_OMITTING_COMMANDS = new Set(["status", "result", "cancel"]);
+let commandOmitsErrorDisclosure = false;
+
+// Disclosure field for the top-level error sinks (fail / main().catch). Omitted only for the
+// read/query commands above; the latch overrides so a genuinely-sent source is ALWAYS disclosed
+// (never the dangerous under-warning direction).
+function errorSinkDisclosure() {
+  if (commandOmitsErrorDisclosure && !sourceSentToTarget) {
+    return {};
+  }
+  return { source_content_transmission: sourceSentToTarget ? "sent" : "not_sent" };
+}
+
 const ROUTE_CAPABILITIES = Object.freeze({
   source_packet: Object.freeze({
     max_bytes: AGY_SOURCE_PACKET_MAX_BYTES,
@@ -1488,7 +1507,8 @@ function fail(code, message, details = {}) {
     error_message: message,
     // Honor whether the target already received the source (see sourceSentToTarget):
     // a post-spawn failure reaching this generic sink must not falsely report not_sent.
-    source_content_transmission: sourceSentToTarget ? "sent" : "not_sent",
+    // Read/query commands omit the field entirely (errorSinkDisclosure, #240).
+    ...errorSinkDisclosure(),
     ...details,
   });
   process.exit(1);
@@ -1611,6 +1631,8 @@ function cancel(rest) {
 
 async function main() {
   const [command, ...rest] = process.argv.slice(2);
+  // Read/query commands omit the error-envelope disclosure; every other command discloses (#240).
+  commandOmitsErrorDisclosure = DISCLOSURE_OMITTING_COMMANDS.has(command);
   if (command === "doctor" || command === "setup") {
     doctor(rest);
     return;
@@ -1652,7 +1674,8 @@ main().catch((error) => {
     status: "failed",
     error_code: "agy_companion_error",
     error_message: error.message,
-    source_content_transmission: sourceSentToTarget ? "sent" : "not_sent",
+    // See fail()/errorSinkDisclosure: read/query commands omit; the latch overrides (#240).
+    ...errorSinkDisclosure(),
   });
   process.exit(1);
 });

--- a/plugins/agy/scripts/agy-companion.mjs
+++ b/plugins/agy/scripts/agy-companion.mjs
@@ -96,6 +96,12 @@ function errorSinkDisclosure() {
   return resolveErrorSinkDisclosure({ commandOmitsErrorDisclosure, sourceSentToTarget });
 }
 
+// Diagnostic commands (doctor / preflight) invoke AGY for readiness or run a local scope dry-run
+// only — they NEVER spawn the review target with the source packet, so their disclosure is a
+// structural constant, NOT the latch-aware error-sink decision (resolveErrorSinkDisclosure). One
+// home for that constant so the invariant ("this command transmits no source") cannot drift.
+const NON_TRANSMITTING_DISCLOSURE = Object.freeze({ source_content_transmission: "not_sent" });
+
 const ROUTE_CAPABILITIES = Object.freeze({
   source_packet: Object.freeze({
     max_bytes: AGY_SOURCE_PACKET_MAX_BYTES,
@@ -163,7 +169,7 @@ function doctor(rest) {
       ready: false,
       error_code: "not_found",
       error_message: result.error.message,
-      source_content_transmission: "not_sent",
+      ...NON_TRANSMITTING_DISCLOSURE,
     });
     process.exit(1);
   }
@@ -173,7 +179,7 @@ function doctor(rest) {
       ready: false,
       error_code: "not_ready",
       error_message: String(result.stderr ?? "").trim() || "agy models failed",
-      source_content_transmission: "not_sent",
+      ...NON_TRANSMITTING_DISCLOSURE,
     });
     process.exit(1);
   }
@@ -183,7 +189,7 @@ function doctor(rest) {
     ready: true,
     status: "ok",
     models,
-    source_content_transmission: "not_sent",
+    ...NON_TRANSMITTING_DISCLOSURE,
   });
 }
 
@@ -945,7 +951,6 @@ function cmdPreflight(rest) {
       target: "agy",
       mode: mode ?? null,
       cwd,
-      source_content_transmission: "not_sent",
       ...preflightSafetyFields(),
       disclosure_note: preflightDisclosure(PROVIDER_DISPLAY),
     });
@@ -987,7 +992,7 @@ function cmdPreflight(rest) {
       scope: profile.scope,
       scope_base: resolvedScopeBase,
       scope_paths: resolvedScopePaths,
-      source_content_transmission: "not_sent",
+      ...NON_TRANSMITTING_DISCLOSURE,
       ...summary,
       ...preflightSafetyFields(),
       disclosure_note: preflightDisclosure(PROVIDER_DISPLAY),
@@ -1006,7 +1011,7 @@ function cmdPreflight(rest) {
       scope: profile.scope,
       scope_base: resolvedScopeBase,
       scope_paths: resolvedScopePaths,
-      source_content_transmission: "not_sent",
+      ...NON_TRANSMITTING_DISCLOSURE,
       error,
       error_message: e.message,
       ...preflightSafetyFields(),
@@ -1030,7 +1035,7 @@ async function run(rest) {
   });
   const mode = options.mode;
   if (!["review", "adversarial-review", "custom-review"].includes(mode)) {
-    printJson({ target: "agy", status: "failed", error_code: "bad_mode", source_content_transmission: "not_sent" });
+    printJson({ target: "agy", status: "failed", error_code: "bad_mode", ...errorSinkDisclosure() });
     process.exit(1);
   }
   if (options.background) {
@@ -1504,11 +1509,13 @@ function fail(code, message, details = {}) {
     error_code: code,
     message,
     error_message: message,
+    ...details,
     // Honor whether the target already received the source (see sourceSentToTarget):
     // a post-spawn failure reaching this generic sink must not falsely report not_sent.
-    // Read/query commands omit the field entirely (errorSinkDisclosure, #240).
+    // Read/query commands omit the field entirely (errorSinkDisclosure, #240). Spread LAST so the
+    // latch-driven decision is authoritative — a stray source_content_transmission in details can
+    // never override it (never the dangerous under-warning direction).
     ...errorSinkDisclosure(),
-    ...details,
   });
   process.exit(1);
 }

--- a/plugins/agy/scripts/agy-companion.mjs
+++ b/plugins/agy/scripts/agy-companion.mjs
@@ -29,7 +29,7 @@ import { diffSourceFiles } from "./lib/diff-source.mjs";
 import { cleanGitEnv } from "./lib/git-env.mjs";
 import { gitEnv, isGitBinaryPolicyError, resolveGitBinary } from "./lib/git-binary.mjs";
 import { verifyPidInfo } from "./lib/identity.mjs";
-import { buildJobRecord, externalReviewForInvocation } from "./lib/job-record.mjs";
+import { buildJobRecord, externalReviewForInvocation, resolveErrorSinkDisclosure } from "./lib/job-record.mjs";
 import { sourceContentTransmissionForExecution } from "./lib/external-review.mjs";
 import { sanitizeTargetEnv } from "./lib/provider-env.mjs";
 import {
@@ -87,14 +87,13 @@ let sourceSentToTarget = false;
 const DISCLOSURE_OMITTING_COMMANDS = new Set(["status", "result", "cancel"]);
 let commandOmitsErrorDisclosure = false;
 
-// Disclosure field for the top-level error sinks (fail / main().catch). Omitted only for the
-// read/query commands above; the latch overrides so a genuinely-sent source is ALWAYS disclosed
-// (never the dangerous under-warning direction).
+// Disclosure field for the top-level error sinks (fail / main().catch). The decision (and its
+// full truth table / rationale) is the single-source resolveErrorSinkDisclosure in lib/job-record.mjs,
+// beside classifyExecution; this just feeds it the two runtime flags so the fail() and main().catch
+// sinks cannot drift. Read/query commands omit; the latch overrides so a genuinely-sent source is
+// ALWAYS disclosed (never the dangerous under-warning direction).
 function errorSinkDisclosure() {
-  if (commandOmitsErrorDisclosure && !sourceSentToTarget) {
-    return {};
-  }
-  return { source_content_transmission: sourceSentToTarget ? "sent" : "not_sent" };
+  return resolveErrorSinkDisclosure({ commandOmitsErrorDisclosure, sourceSentToTarget });
 }
 
 const ROUTE_CAPABILITIES = Object.freeze({

--- a/plugins/agy/scripts/lib/job-record.mjs
+++ b/plugins/agy/scripts/lib/job-record.mjs
@@ -295,6 +295,29 @@ export function classifyExecution(execution) {
   });
 }
 
+// Disclosure object for AGY's top-level error sinks (fail() / main().catch). The job's REAL
+// disclosure lives nested on the persisted record (classifyExecution / externalReviewForInvocation);
+// this governs only the bare top-level field on the *error envelope*. Inputs:
+//   commandOmitsErrorDisclosure  true for read/query commands (status/result/cancel) that spawn no
+//                                target and transmit nothing — a bare top-level "not_sent" on their
+//                                error envelopes is misleading, so they omit the field (#240).
+//   sourceSentToTarget           the run-path latch (set at execve). It OVERRIDES the omit: a
+//                                genuinely-sent source is ALWAYS disclosed "sent", never omitted —
+//                                fail-safe toward over-disclosure, never the dangerous under-warning.
+// Truth table (the contract this enforces):
+//   (omit=false, latch=false) -> { source_content_transmission: "not_sent" }  run pre-spawn / continue
+//   (omit=false, latch=true)  -> { source_content_transmission: "sent" }      run post-spawn -> generic sink
+//   (omit=true,  latch=false) -> { }                                          read/query: omit (#240)
+//   (omit=true,  latch=true)  -> { source_content_transmission: "sent" }      defense-in-depth override
+// This is the single source of truth for that decision; the companion only holds the runtime flags
+// and delegates here, so the rule cannot drift between the fail() and main().catch sinks.
+export function resolveErrorSinkDisclosure({ commandOmitsErrorDisclosure, sourceSentToTarget }) {
+  if (commandOmitsErrorDisclosure && !sourceSentToTarget) {
+    return {};
+  }
+  return { source_content_transmission: sourceSentToTarget ? "sent" : "not_sent" };
+}
+
 function classifyProviderParsedFailure({ execution, parsed }) {
   if (
     parsed?.reason === "prompt_sidecar_failed"

--- a/relay/relay-agy/scripts/agy-companion.mjs
+++ b/relay/relay-agy/scripts/agy-companion.mjs
@@ -78,6 +78,25 @@ const LARGE_SOURCE_PACKET_FLAG = "--allow-large-source-packet";
 // to main().catch. One CLI invocation per process, so a set-once latch is sufficient.
 let sourceSentToTarget = false;
 
+// Read/query commands (status/result/cancel) inspect an existing job's persisted state — they
+// spawn no target and transmit nothing, so a bare top-level "not_sent" on their error envelopes
+// is misleading (the job's real disclosure is nested at external_review.source_content_transmission
+// on the record). They omit the field (#240). EVERY other command keeps disclosing: run carries
+// the honest sent/not_sent, and continue/resume fail-closes with "not_sent" to assert that no
+// source was resent. Fail-safe — the default is to DISCLOSE; only this explicit read set omits.
+const DISCLOSURE_OMITTING_COMMANDS = new Set(["status", "result", "cancel"]);
+let commandOmitsErrorDisclosure = false;
+
+// Disclosure field for the top-level error sinks (fail / main().catch). Omitted only for the
+// read/query commands above; the latch overrides so a genuinely-sent source is ALWAYS disclosed
+// (never the dangerous under-warning direction).
+function errorSinkDisclosure() {
+  if (commandOmitsErrorDisclosure && !sourceSentToTarget) {
+    return {};
+  }
+  return { source_content_transmission: sourceSentToTarget ? "sent" : "not_sent" };
+}
+
 const ROUTE_CAPABILITIES = Object.freeze({
   source_packet: Object.freeze({
     max_bytes: AGY_SOURCE_PACKET_MAX_BYTES,
@@ -1488,7 +1507,8 @@ function fail(code, message, details = {}) {
     error_message: message,
     // Honor whether the target already received the source (see sourceSentToTarget):
     // a post-spawn failure reaching this generic sink must not falsely report not_sent.
-    source_content_transmission: sourceSentToTarget ? "sent" : "not_sent",
+    // Read/query commands omit the field entirely (errorSinkDisclosure, #240).
+    ...errorSinkDisclosure(),
     ...details,
   });
   process.exit(1);
@@ -1611,6 +1631,8 @@ function cancel(rest) {
 
 async function main() {
   const [command, ...rest] = process.argv.slice(2);
+  // Read/query commands omit the error-envelope disclosure; every other command discloses (#240).
+  commandOmitsErrorDisclosure = DISCLOSURE_OMITTING_COMMANDS.has(command);
   if (command === "doctor" || command === "setup") {
     doctor(rest);
     return;
@@ -1652,7 +1674,8 @@ main().catch((error) => {
     status: "failed",
     error_code: "agy_companion_error",
     error_message: error.message,
-    source_content_transmission: sourceSentToTarget ? "sent" : "not_sent",
+    // See fail()/errorSinkDisclosure: read/query commands omit; the latch overrides (#240).
+    ...errorSinkDisclosure(),
   });
   process.exit(1);
 });

--- a/relay/relay-agy/scripts/agy-companion.mjs
+++ b/relay/relay-agy/scripts/agy-companion.mjs
@@ -96,6 +96,12 @@ function errorSinkDisclosure() {
   return resolveErrorSinkDisclosure({ commandOmitsErrorDisclosure, sourceSentToTarget });
 }
 
+// Diagnostic commands (doctor / preflight) invoke AGY for readiness or run a local scope dry-run
+// only — they NEVER spawn the review target with the source packet, so their disclosure is a
+// structural constant, NOT the latch-aware error-sink decision (resolveErrorSinkDisclosure). One
+// home for that constant so the invariant ("this command transmits no source") cannot drift.
+const NON_TRANSMITTING_DISCLOSURE = Object.freeze({ source_content_transmission: "not_sent" });
+
 const ROUTE_CAPABILITIES = Object.freeze({
   source_packet: Object.freeze({
     max_bytes: AGY_SOURCE_PACKET_MAX_BYTES,
@@ -163,7 +169,7 @@ function doctor(rest) {
       ready: false,
       error_code: "not_found",
       error_message: result.error.message,
-      source_content_transmission: "not_sent",
+      ...NON_TRANSMITTING_DISCLOSURE,
     });
     process.exit(1);
   }
@@ -173,7 +179,7 @@ function doctor(rest) {
       ready: false,
       error_code: "not_ready",
       error_message: String(result.stderr ?? "").trim() || "agy models failed",
-      source_content_transmission: "not_sent",
+      ...NON_TRANSMITTING_DISCLOSURE,
     });
     process.exit(1);
   }
@@ -183,7 +189,7 @@ function doctor(rest) {
     ready: true,
     status: "ok",
     models,
-    source_content_transmission: "not_sent",
+    ...NON_TRANSMITTING_DISCLOSURE,
   });
 }
 
@@ -945,7 +951,6 @@ function cmdPreflight(rest) {
       target: "agy",
       mode: mode ?? null,
       cwd,
-      source_content_transmission: "not_sent",
       ...preflightSafetyFields(),
       disclosure_note: preflightDisclosure(PROVIDER_DISPLAY),
     });
@@ -987,7 +992,7 @@ function cmdPreflight(rest) {
       scope: profile.scope,
       scope_base: resolvedScopeBase,
       scope_paths: resolvedScopePaths,
-      source_content_transmission: "not_sent",
+      ...NON_TRANSMITTING_DISCLOSURE,
       ...summary,
       ...preflightSafetyFields(),
       disclosure_note: preflightDisclosure(PROVIDER_DISPLAY),
@@ -1006,7 +1011,7 @@ function cmdPreflight(rest) {
       scope: profile.scope,
       scope_base: resolvedScopeBase,
       scope_paths: resolvedScopePaths,
-      source_content_transmission: "not_sent",
+      ...NON_TRANSMITTING_DISCLOSURE,
       error,
       error_message: e.message,
       ...preflightSafetyFields(),
@@ -1030,7 +1035,7 @@ async function run(rest) {
   });
   const mode = options.mode;
   if (!["review", "adversarial-review", "custom-review"].includes(mode)) {
-    printJson({ target: "agy", status: "failed", error_code: "bad_mode", source_content_transmission: "not_sent" });
+    printJson({ target: "agy", status: "failed", error_code: "bad_mode", ...errorSinkDisclosure() });
     process.exit(1);
   }
   if (options.background) {
@@ -1504,11 +1509,13 @@ function fail(code, message, details = {}) {
     error_code: code,
     message,
     error_message: message,
+    ...details,
     // Honor whether the target already received the source (see sourceSentToTarget):
     // a post-spawn failure reaching this generic sink must not falsely report not_sent.
-    // Read/query commands omit the field entirely (errorSinkDisclosure, #240).
+    // Read/query commands omit the field entirely (errorSinkDisclosure, #240). Spread LAST so the
+    // latch-driven decision is authoritative — a stray source_content_transmission in details can
+    // never override it (never the dangerous under-warning direction).
     ...errorSinkDisclosure(),
-    ...details,
   });
   process.exit(1);
 }

--- a/relay/relay-agy/scripts/agy-companion.mjs
+++ b/relay/relay-agy/scripts/agy-companion.mjs
@@ -29,7 +29,7 @@ import { diffSourceFiles } from "./lib/diff-source.mjs";
 import { cleanGitEnv } from "./lib/git-env.mjs";
 import { gitEnv, isGitBinaryPolicyError, resolveGitBinary } from "./lib/git-binary.mjs";
 import { verifyPidInfo } from "./lib/identity.mjs";
-import { buildJobRecord, externalReviewForInvocation } from "./lib/job-record.mjs";
+import { buildJobRecord, externalReviewForInvocation, resolveErrorSinkDisclosure } from "./lib/job-record.mjs";
 import { sourceContentTransmissionForExecution } from "./lib/external-review.mjs";
 import { sanitizeTargetEnv } from "./lib/provider-env.mjs";
 import {
@@ -87,14 +87,13 @@ let sourceSentToTarget = false;
 const DISCLOSURE_OMITTING_COMMANDS = new Set(["status", "result", "cancel"]);
 let commandOmitsErrorDisclosure = false;
 
-// Disclosure field for the top-level error sinks (fail / main().catch). Omitted only for the
-// read/query commands above; the latch overrides so a genuinely-sent source is ALWAYS disclosed
-// (never the dangerous under-warning direction).
+// Disclosure field for the top-level error sinks (fail / main().catch). The decision (and its
+// full truth table / rationale) is the single-source resolveErrorSinkDisclosure in lib/job-record.mjs,
+// beside classifyExecution; this just feeds it the two runtime flags so the fail() and main().catch
+// sinks cannot drift. Read/query commands omit; the latch overrides so a genuinely-sent source is
+// ALWAYS disclosed (never the dangerous under-warning direction).
 function errorSinkDisclosure() {
-  if (commandOmitsErrorDisclosure && !sourceSentToTarget) {
-    return {};
-  }
-  return { source_content_transmission: sourceSentToTarget ? "sent" : "not_sent" };
+  return resolveErrorSinkDisclosure({ commandOmitsErrorDisclosure, sourceSentToTarget });
 }
 
 const ROUTE_CAPABILITIES = Object.freeze({

--- a/relay/relay-agy/scripts/lib/job-record.mjs
+++ b/relay/relay-agy/scripts/lib/job-record.mjs
@@ -295,6 +295,29 @@ export function classifyExecution(execution) {
   });
 }
 
+// Disclosure object for AGY's top-level error sinks (fail() / main().catch). The job's REAL
+// disclosure lives nested on the persisted record (classifyExecution / externalReviewForInvocation);
+// this governs only the bare top-level field on the *error envelope*. Inputs:
+//   commandOmitsErrorDisclosure  true for read/query commands (status/result/cancel) that spawn no
+//                                target and transmit nothing — a bare top-level "not_sent" on their
+//                                error envelopes is misleading, so they omit the field (#240).
+//   sourceSentToTarget           the run-path latch (set at execve). It OVERRIDES the omit: a
+//                                genuinely-sent source is ALWAYS disclosed "sent", never omitted —
+//                                fail-safe toward over-disclosure, never the dangerous under-warning.
+// Truth table (the contract this enforces):
+//   (omit=false, latch=false) -> { source_content_transmission: "not_sent" }  run pre-spawn / continue
+//   (omit=false, latch=true)  -> { source_content_transmission: "sent" }      run post-spawn -> generic sink
+//   (omit=true,  latch=false) -> { }                                          read/query: omit (#240)
+//   (omit=true,  latch=true)  -> { source_content_transmission: "sent" }      defense-in-depth override
+// This is the single source of truth for that decision; the companion only holds the runtime flags
+// and delegates here, so the rule cannot drift between the fail() and main().catch sinks.
+export function resolveErrorSinkDisclosure({ commandOmitsErrorDisclosure, sourceSentToTarget }) {
+  if (commandOmitsErrorDisclosure && !sourceSentToTarget) {
+    return {};
+  }
+  return { source_content_transmission: sourceSentToTarget ? "sent" : "not_sent" };
+}
+
 function classifyProviderParsedFailure({ execution, parsed }) {
   if (
     parsed?.reason === "prompt_sidecar_failed"

--- a/tests/unit/agy-command-disclosure-surface.test.mjs
+++ b/tests/unit/agy-command-disclosure-surface.test.mjs
@@ -1,0 +1,118 @@
+// PR #218 follow-up #240 — single-source-of-truth for AGY's error/output disclosure surface.
+//
+// Round-2 review (Kimi) flagged that, although resolveErrorSinkDisclosure centralizes the generic
+// error-sink decision (fail() / main().catch), three other envelope paths hard-coded
+// source_content_transmission directly, bypassing the central decision — and fail() spread
+// ...errorSinkDisclosure() BEFORE ...details, so a detail could override the latch-driven decision
+// (defeating the "a sent source is ALWAYS disclosed" safety net).
+//
+// Resolution:
+//   - run() bad_mode (a generic-sink-SHAPED envelope) now routes through errorSinkDisclosure().
+//   - preflight bad_args no longer carries the field in fail() details (errorSinkDisclosure owns it),
+//     and fail() spreads ...errorSinkDisclosure() LAST so details can never override it.
+//   - doctor / preflight (non-transmitting diagnostic commands) disclose via a single named constant
+//     NON_TRANSMITTING_DISCLOSURE — their not_sent is a structural invariant, not the latch decision.
+//
+// These tests lock (a) the observable contract on every changed path and (b) the single-source
+// invariant itself: no bare source_content_transmission literal may reappear in the companion.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..", "..");
+const COMPANION = path.join(REPO_ROOT, "plugins/agy/scripts/agy-companion.mjs");
+const MISSING_JOB = "00000000-0000-0000-0000-000000000000";
+
+function gitRepo(cwd) {
+  const env = {
+    ...process.env,
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_AUTHOR_NAME: "t", GIT_AUTHOR_EMAIL: "t@t",
+    GIT_COMMITTER_NAME: "t", GIT_COMMITTER_EMAIL: "t@t",
+  };
+  const git = (args) => spawnSync("git", ["-C", cwd, "-c", "core.hooksPath=/dev/null", ...args], { cwd, encoding: "utf8", env });
+  git(["init", "-q", "-b", "main"]);
+  writeFileSync(path.join(cwd, "a.md"), "x\n"); git(["add", "."]); git(["commit", "-q", "-m", "m"]);
+}
+
+// printJson pretty-prints a single multi-line object per envelope; grab the last balanced object.
+function lastEnvelope(run) {
+  const raw = String(run.stdout ?? "");
+  let depth = 0, start = -1, inStr = false, esc = false, last = null;
+  for (let i = 0; i < raw.length; i += 1) {
+    const c = raw[i];
+    if (inStr) { if (esc) esc = false; else if (c === "\\") esc = true; else if (c === "\"") inStr = false; continue; }
+    if (c === "\"") inStr = true;
+    else if (c === "{") { if (depth === 0) start = i; depth += 1; }
+    else if (c === "}") { depth -= 1; if (depth === 0 && start >= 0) { try { last = JSON.parse(raw.slice(start, i + 1)); } catch { /* skip */ } start = -1; } }
+  }
+  return last ?? {};
+}
+
+function companion(args, cwd, env = {}) {
+  return lastEnvelope(spawnSync(process.execPath, [COMPANION, ...args], { cwd, encoding: "utf8", env: { ...process.env, ...env } }));
+}
+
+test("doctor error envelope discloses not_sent (NON_TRANSMITTING_DISCLOSURE)", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "agy-cds-doctor-"));
+  try {
+    gitRepo(cwd);
+    const env = { AGY_PLUGIN_DATA: path.join(cwd, "data") };
+    const env1 = companion(["doctor", "--binary", "/nonexistent/agy", "--cwd", cwd], cwd, env);
+    assert.equal(env1.ready, false, `doctor should report not ready: ${JSON.stringify(env1)}`);
+    assert.equal(env1.source_content_transmission, "not_sent", "doctor never transmits source");
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("preflight bad_args discloses not_sent AND keeps its disclosure_note contract", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "agy-cds-preflight-"));
+  try {
+    gitRepo(cwd);
+    const env = { AGY_PLUGIN_DATA: path.join(cwd, "data") };
+    const out = companion(["preflight", "--mode", "invalid", "--cwd", cwd], cwd, env);
+    assert.equal(out.error_code, "bad_args", `expected bad_args: ${JSON.stringify(out)}`);
+    // Field is now provided by errorSinkDisclosure (preflight is not a read/query command and is
+    // pre-spawn), not a hard-coded detail — so it must still be present and honest.
+    assert.equal(out.source_content_transmission, "not_sent", "preflight transmits no source");
+    assert.ok(out.disclosure_note, "preflight's deliberate disclosure_note contract must survive");
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("run bad_mode (generic-sink-shaped) discloses not_sent via the central decision", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "agy-cds-badmode-"));
+  try {
+    gitRepo(cwd);
+    const env = { AGY_PLUGIN_DATA: path.join(cwd, "data") };
+    const out = companion(["run", "--mode", "invalid", "--cwd", cwd], cwd, env);
+    assert.equal(out.error_code, "bad_mode", `expected bad_mode: ${JSON.stringify(out)}`);
+    assert.equal(out.status, "failed");
+    // Pre-spawn run error: run is not a read/query command and the latch is unset -> not_sent.
+    assert.equal(out.source_content_transmission, "not_sent", "pre-spawn run bad_mode honestly discloses not_sent");
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("single-source invariant: no bare source_content_transmission literal in the companion", () => {
+  // Every disclosure must flow from resolveErrorSinkDisclosure (lib) or NON_TRANSMITTING_DISCLOSURE.
+  // A hard-coded `source_content_transmission: "sent"|"not_sent"` reappearing anywhere else is the
+  // exact class of bypass this round closed. Comments are ignored; the lone allowed value literal is
+  // the NON_TRANSMITTING_DISCLOSURE definition.
+  const src = readFileSync(COMPANION, "utf8").split(/\r?\n/);
+  const offenders = [];
+  for (let i = 0; i < src.length; i += 1) {
+    const line = src[i];
+    const code = line.replace(/\/\/.*$/, ""); // strip line comments
+    if (!/source_content_transmission\s*:\s*"(sent|not_sent)"/.test(code)) continue;
+    if (/const NON_TRANSMITTING_DISCLOSURE\s*=\s*Object\.freeze/.test(code)) continue; // the one home
+    offenders.push(`${i + 1}: ${line.trim()}`);
+  }
+  assert.deepEqual(offenders, [], `bare source_content_transmission literals must not bypass the single source:\n${offenders.join("\n")}`);
+});

--- a/tests/unit/agy-command-disclosure-surface.test.mjs
+++ b/tests/unit/agy-command-disclosure-surface.test.mjs
@@ -21,8 +21,9 @@ import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..", "..");
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
 const COMPANION = path.join(REPO_ROOT, "plugins/agy/scripts/agy-companion.mjs");
 const MISSING_JOB = "00000000-0000-0000-0000-000000000000";
 

--- a/tests/unit/agy-error-sink-disclosure.test.mjs
+++ b/tests/unit/agy-error-sink-disclosure.test.mjs
@@ -1,0 +1,59 @@
+// PR #218 follow-up #240 (item 1) — decision-level lock for the AGY error-sink disclosure.
+//
+// agy-read-command-disclosure.test.mjs exercises the gate end-to-end through the CLI, but only the
+// pre-spawn / read-command rows are reachable that way: the source-bearing SENT direction
+// (latch=true) is produced post-spawn, and round-3's run() finalizer (finalizeRunGitPolicyEscape)
+// intercepts the normal post-spawn escape and discloses via classifyExecution — so the generic
+// error sinks' latch-override branch is only reachable in the doubly-degraded / non-policy-escape
+// corner, which no CI-safe integration path can hit deterministically (a chmod-based wedge does not
+// fail as root, the common CI uid). That left the safety-critical row — "a genuinely-sent source is
+// ALWAYS disclosed, never omitted or under-warned" — unlocked by any always-run test.
+//
+// resolveErrorSinkDisclosure is the single source of truth for that decision (lib/job-record.mjs,
+// beside classifyExecution); the companion only holds the runtime flags and delegates. These tests
+// pin its full truth table directly: deterministic, root-safe, and non-vacuous against any revert of
+// the omit rule OR the latch override. They fail if the omit branch widens to swallow a sent source,
+// if the latch override is dropped, or if the disclosed value flips.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { resolveErrorSinkDisclosure } from "../../plugins/agy/scripts/lib/job-record.mjs";
+
+const FIELD = "source_content_transmission";
+
+test("resolveErrorSinkDisclosure: non-read command, pre-spawn -> discloses not_sent", () => {
+  // run pre-spawn and continue/resume: no source left the process, but the field must be present
+  // and honest (continue fail-closes on this to assert no source was resent).
+  const out = resolveErrorSinkDisclosure({ commandOmitsErrorDisclosure: false, sourceSentToTarget: false });
+  assert.deepEqual(out, { [FIELD]: "not_sent" });
+});
+
+test("resolveErrorSinkDisclosure: non-read command, post-spawn -> discloses sent (the unlocked SENT direction)", () => {
+  // run post-spawn reaching the generic sink (fail() doubly-degraded, or main().catch on a
+  // non-policy escape): the source already reached the target, so the sink must disclose sent.
+  const out = resolveErrorSinkDisclosure({ commandOmitsErrorDisclosure: false, sourceSentToTarget: true });
+  assert.deepEqual(out, { [FIELD]: "sent" });
+});
+
+test("resolveErrorSinkDisclosure: read/query command, pre-spawn -> omits the field (#240)", () => {
+  // status/result/cancel inspect persisted state and transmit nothing; a bare top-level not_sent is
+  // misleading, so the field is omitted entirely (the job's real disclosure is nested on the record).
+  const out = resolveErrorSinkDisclosure({ commandOmitsErrorDisclosure: true, sourceSentToTarget: false });
+  assert.deepEqual(out, {});
+  assert.equal(FIELD in out, false, "read-command disclosure must omit the field, not set it to undefined/null");
+});
+
+test("resolveErrorSinkDisclosure: latch overrides the omit -> a sent source is ALWAYS disclosed", () => {
+  // Defense-in-depth: read commands never set the latch today, but the omit must NEVER swallow a
+  // genuinely-sent source. The latch wins over the omit so the failure mode is over-disclosure,
+  // never the dangerous under-warning. This row is unreachable via the CLI, so this is its only lock.
+  const out = resolveErrorSinkDisclosure({ commandOmitsErrorDisclosure: true, sourceSentToTarget: true });
+  assert.deepEqual(out, { [FIELD]: "sent" });
+});
+
+test("resolveErrorSinkDisclosure: returns a fresh object each call (no shared mutable singleton)", () => {
+  const a = resolveErrorSinkDisclosure({ commandOmitsErrorDisclosure: false, sourceSentToTarget: true });
+  const b = resolveErrorSinkDisclosure({ commandOmitsErrorDisclosure: false, sourceSentToTarget: true });
+  assert.notEqual(a, b, "each call must return a new object so a caller spreading it cannot mutate shared state");
+  assert.deepEqual(a, b);
+});

--- a/tests/unit/agy-read-command-disclosure.test.mjs
+++ b/tests/unit/agy-read-command-disclosure.test.mjs
@@ -19,8 +19,9 @@ import { spawnSync } from "node:child_process";
 import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..", "..");
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
 const COMPANION = path.join(REPO_ROOT, "plugins/agy/scripts/agy-companion.mjs");
 const MISSING_JOB = "00000000-0000-0000-0000-000000000000";
 

--- a/tests/unit/agy-read-command-disclosure.test.mjs
+++ b/tests/unit/agy-read-command-disclosure.test.mjs
@@ -1,0 +1,168 @@
+// PR #218 follow-up #240 (item 1) — read-command error envelopes must not carry a bare
+// top-level source_content_transmission.
+//
+// The AGY top-level error sinks (fail() / main().catch) used to stamp
+//   source_content_transmission: sourceSentToTarget ? "sent" : "not_sent"
+// on EVERY command's error envelope. For the read commands (status / result / cancel) — which
+// spawn no target and transmit no source — the latch is always false, so they emitted a bare
+// top-level "not_sent". That is misleading: a consumer keying on the top-level field could read
+// it as "the job's source was not sent", when the job's real disclosure lives nested at
+// external_review.source_content_transmission on the persisted record (and stays correct).
+//
+// The fix gates the field behind errorSinkDisclosure(): only source-bearing commands (run — the
+// only command that spawns the AGY target) disclose, and the latch overrides so a genuinely-sent
+// source is ALWAYS disclosed (never the dangerous under-warning direction). Read commands omit
+// the field. These tests fail if the gate is reverted (read-command fail() re-emits "not_sent").
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..", "..");
+const COMPANION = path.join(REPO_ROOT, "plugins/agy/scripts/agy-companion.mjs");
+const MISSING_JOB = "00000000-0000-0000-0000-000000000000";
+
+function rmTree(target) {
+  rmSync(target, { recursive: true, force: true });
+}
+
+function resolveRealGit() {
+  const which = spawnSync(process.platform === "win32" ? "where" : "which", ["git"], { encoding: "utf8" });
+  return String(which.stdout ?? "").trim().split(/\r?\n/).filter(Boolean)[0] ?? "";
+}
+
+// Minimal brace-matching JSON-stream parser — printJson()/fail() pretty-print multi-line objects.
+function parseJsonStream(raw) {
+  const objs = [];
+  let depth = 0, start = -1, inStr = false, esc = false;
+  for (let i = 0; i < raw.length; i += 1) {
+    const c = raw[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (c === "\\") esc = true;
+      else if (c === "\"") inStr = false;
+      continue;
+    }
+    if (c === "\"") inStr = true;
+    else if (c === "{") { if (depth === 0) start = i; depth += 1; }
+    else if (c === "}") {
+      depth -= 1;
+      if (depth === 0 && start >= 0) { try { objs.push(JSON.parse(raw.slice(start, i + 1))); } catch { /* skip */ } start = -1; }
+    }
+  }
+  return objs;
+}
+
+function gitRepo(cwd) {
+  const real = resolveRealGit();
+  assert.ok(real, "a real git binary must be resolvable for this test");
+  const env = {
+    ...process.env,
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_AUTHOR_NAME: "t", GIT_AUTHOR_EMAIL: "t@t",
+    GIT_COMMITTER_NAME: "t", GIT_COMMITTER_EMAIL: "t@t",
+  };
+  const git = (args) => spawnSync("git", ["-C", cwd, "-c", "core.hooksPath=/dev/null", ...args], { cwd, encoding: "utf8", env });
+  git(["init", "-q", "-b", "main"]);
+  writeFileSync(path.join(cwd, "old.md"), "old\n"); git(["add", "old.md"]); git(["commit", "-q", "-m", "main"]);
+  const base = git(["rev-parse", "HEAD"]).stdout.trim();
+  git(["checkout", "-qb", "feature"]);
+  writeFileSync(path.join(cwd, "foo.md"), "body\n"); git(["add", "foo.md"]); git(["commit", "-q", "-m", "feature"]);
+  return { real, base };
+}
+
+function lastEnvelope(run) {
+  const objs = parseJsonStream(run.stdout);
+  return objs.at(-1) ?? {};
+}
+
+function companion(args, cwd, env = {}) {
+  return spawnSync(process.execPath, [COMPANION, ...args], { cwd, encoding: "utf8", env: { ...process.env, ...env } });
+}
+
+test("agy read-command error envelopes omit the top-level source_content_transmission (#240)", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "agy-readdisc-"));
+  const cwd = path.join(root, "ws");
+  mkdirSync(cwd);
+  const dataDir = mkdtempSync(path.join(tmpdir(), "agy-readdisc-data-"));
+  try {
+    gitRepo(cwd);
+    const env = { AGY_PLUGIN_DATA: dataDir };
+    // status / result / cancel for a non-existent job all route through fail("not_found").
+    for (const cmd of ["status", "result", "cancel"]) {
+      const envelope = lastEnvelope(companion([cmd, "--cwd", cwd, "--job", MISSING_JOB], cwd, env));
+      assert.equal(envelope.ok, false, `${cmd}: expected an error envelope, got ${JSON.stringify(envelope)}`);
+      assert.equal(envelope.error_code, "not_found", `${cmd}: expected not_found`);
+      assert.equal(
+        "source_content_transmission" in envelope,
+        false,
+        `${cmd} read-command error envelope must omit the top-level source_content_transmission (#240); got keys ${JSON.stringify(Object.keys(envelope))}`,
+      );
+    }
+
+    // continue/resume is NOT a read command: it fail-closes with "not_sent" to assert that no
+    // source was resent, so it MUST keep disclosing (contrast with the read commands above).
+    // (Smoke covers this too, but smoke is CI-skipped — this always-run guard locks the contract.)
+    const continueEnvelope = lastEnvelope(companion(["continue", "--cwd", cwd], cwd, env));
+    assert.equal(continueEnvelope.ok, false, "continue must fail-close");
+    assert.equal(
+      continueEnvelope.source_content_transmission,
+      "not_sent",
+      "continue (resume) error must keep disclosing not_sent (fail-closed: no source resent), not omit (#240)",
+    );
+  } finally {
+    rmTree(root);
+    rmTree(dataDir);
+  }
+});
+
+test("agy git-policy error: read command omits disclosure, run (source-bearing) keeps it (#240)", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "agy-readdisc-wedge-"));
+  const cwd = path.join(root, "ws");
+  mkdirSync(cwd);
+  const dataDir = mkdtempSync(path.join(tmpdir(), "agy-readdisc-wedge-data-"));
+  try {
+    const { real, base } = gitRepo(cwd);
+    // A RELAY_GIT_BINARY override INSIDE the workspace trips the git-policy guard at
+    // resolveWorkspaceRoot — pre-spawn, on any command — so the failure reaches the top-level
+    // error sinks (fail / main().catch). This is the exact shape of the #240 wedged-read case.
+    const gitbin = path.join(cwd, "insidegit");
+    mkdirSync(gitbin);
+    const override = path.join(gitbin, "git");
+    writeFileSync(override, `#!/bin/sh\nexec ${real} "$@"\n`);
+    chmodSync(override, 0o755);
+    const env = { AGY_PLUGIN_DATA: dataDir, RELAY_GIT_BINARY: override };
+
+    // Read command (status): git_binary_rejected, but NO top-level disclosure.
+    const statusEnvelope = lastEnvelope(companion(["status", "--cwd", cwd, "--job", MISSING_JOB], cwd, env));
+    assert.equal(statusEnvelope.ok, false, `status: expected an error envelope, got ${JSON.stringify(statusEnvelope)}`);
+    assert.equal(statusEnvelope.error_code, "git_binary_rejected", "status: expected the git-policy rejection");
+    assert.equal(
+      "source_content_transmission" in statusEnvelope,
+      false,
+      `wedged read-command (status) error must omit the top-level source_content_transmission (#240); got keys ${JSON.stringify(Object.keys(statusEnvelope))}`,
+    );
+
+    // Run command (source-bearing): same git-policy rejection, but it MUST still disclose
+    // (here "not_sent" — honest, the failure is pre-spawn). The gate must not strip run-path
+    // disclosure, preserving the round-2 latch / round-3 finalizer invariants.
+    const runEnvelope = lastEnvelope(companion(
+      ["run", "--mode", "review", "--cwd", cwd, "--scope-base", base, "--timeout-ms", "5000", "please review"],
+      cwd,
+      env,
+    ));
+    assert.equal(runEnvelope.ok, false, `run: expected an error envelope, got ${JSON.stringify(runEnvelope)}`);
+    assert.equal(runEnvelope.error_code, "git_binary_rejected", "run: expected the git-policy rejection");
+    assert.equal(
+      "source_content_transmission" in runEnvelope,
+      true,
+      "run-path (source-bearing) error must STILL disclose source_content_transmission (#240 no-regression)",
+    );
+    assert.equal(runEnvelope.source_content_transmission, "not_sent", "pre-spawn run failure honestly discloses not_sent");
+  } finally {
+    rmTree(root);
+    rmTree(dataDir);
+  }
+});

--- a/tests/unit/agy-run-git-policy-escape.test.mjs
+++ b/tests/unit/agy-run-git-policy-escape.test.mjs
@@ -31,11 +31,12 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { fixtureBranchDiffRepo } from "../helpers/fixture-git.mjs";
 import { writeJobRecordToFile } from "../../plugins/agy/scripts/lib/state.mjs";
 
-const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..", "..");
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
 const COMPANION = path.join(REPO_ROOT, "plugins/agy/scripts/agy-companion.mjs");
 const SECRET = "AGY-ROUND3-LEAK-CANARY-source-body";
 


### PR DESCRIPTION
## What

AGY's top-level error sinks `fail()` and `main().catch` stamped a top-level `source_content_transmission` on **every** command's error envelope. For the read/query commands (`status`/`result`/`cancel`) — which inspect an existing job's persisted state, spawn no target, and transmit nothing — the latch is always false, so they emitted a bare top-level `"not_sent"`. A consumer keying on that top-level field could misread it as "the job's source was not sent", when the job's real disclosure lives nested at `external_review.source_content_transmission` on the persisted record (and stays correct). The other companions (claude/gemini/kimi/grok) already omit the field on read-command errors; AGY was the only outlier.

Surfaced during the post-fix reconciliation of #218 (the 3-model review of round-3) and filed as #240 item 1.

## Fix

Gate the field behind a single-source `errorSinkDisclosure()` helper. **Fail-safe:** the default is to DISCLOSE — only an explicit read set (`status`/`result`/`cancel`) omits, and the latch overrides so a genuinely-sent source is **always** disclosed (never the dangerous under-warning direction). Every source-transmission-bearing command keeps disclosing: `run` (round-2 latch + round-3 finalizer paths unchanged) and `continue`/resume, whose rejection must fail-close with `"not_sent"` to assert no source was resent.

## Tests / verification

- New `tests/unit/agy-read-command-disclosure.test.mjs` (always-run): read-command errors (missing-job + git-wedged) omit the field; a git-wedged `run` still discloses; `continue` still fail-closes with `not_sent`. Non-vacuous in **both** directions (always-emit → 0/2 pass; always-omit → 0/2 pass).
- Full suite **2645 tests / 0 fail**; `npm run lint` exit 0; `node scripts/ci/sync-relay-build.mjs --check` exit 0 (relay-agy mirror regenerated, byte-identical to canonical). Round-3 escape test still 2/2.

## Base / sequencing

The AGY adapter only exists on the #218 branch (not yet on `main`), so this PR is **stacked on `codex/add-agy-adapter` (`d0d8729`)** and targets it for a clean 3-file diff. Retarget to `main` once #218 merges.

Addresses #240 (item 1). Item 2 (AGY → `PROVIDER_POLICY_PROVIDERS` + parity-table row) remains tracked in #240.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
