### PR TITLE
#238: fail-close source-blocked approvals in review-slot disposition

### DIFF
--- a/plugins/api-reviewers/scripts/lib/provider-route-policy.mjs
+++ b/plugins/api-reviewers/scripts/lib/provider-route-policy.mjs
@@ -709,6 +709,7 @@ export function buildReviewSlotDisposition({
   retryDispositionRequired = false,
   requestSettingsHash = null,
   sourceState = "unknown",
+  sourceSendAllowed = null,
   status = null,
   errorCode = null,
   result = "",
@@ -723,6 +724,15 @@ export function buildReviewSlotDisposition({
   if (status === "failed" && errorCode === "timeout") verdict = "timeout";
   else if (status && status !== "completed") verdict = "failed_slot";
   if (reviewQuality?.failed_review_slot === true && (verdict === "approved" || verdict === "request_changes")) {
+    verdict = "failed_slot";
+  }
+  // #238: a verdict reached without the source the review needed cannot count. The source-packet
+  // policy sets source_send_allowed===false ONLY when the review is source-bearing AND a block
+  // applies (source_packet_too_large / resend_confirmation_required) -- so this excludes legit
+  // diff-only reviews (not source-bearing => allowed) and legit resumes (already sent => allowed).
+  // Demote to failed_slot so notCountedReason returns source_not_sent instead of "none". This is
+  // ground truth (was the source delivered), independent of the spoofable review text.
+  if (sourceSendAllowed === false && (verdict === "approved" || verdict === "request_changes")) {
     verdict = "failed_slot";
   }
   const retry_fingerprint = hashValue(retryFingerprint);

--- a/plugins/api-reviewers/scripts/lib/review-prompt.mjs
+++ b/plugins/api-reviewers/scripts/lib/review-prompt.mjs
@@ -1433,6 +1433,7 @@ export function buildReviewAuditManifest({
     retryDispositionRequired: retryPolicy.retry_disposition_required,
     requestSettingsHash,
     sourceState: sourceContentTransmission,
+    sourceSendAllowed: effectiveSourcePacketPolicy.source_send_allowed,
     status,
     errorCode: effectiveErrorCode,
     result,

--- a/plugins/claude/scripts/lib/provider-route-policy.mjs
+++ b/plugins/claude/scripts/lib/provider-route-policy.mjs
@@ -709,6 +709,7 @@ export function buildReviewSlotDisposition({
   retryDispositionRequired = false,
   requestSettingsHash = null,
   sourceState = "unknown",
+  sourceSendAllowed = null,
   status = null,
   errorCode = null,
   result = "",
@@ -723,6 +724,15 @@ export function buildReviewSlotDisposition({
   if (status === "failed" && errorCode === "timeout") verdict = "timeout";
   else if (status && status !== "completed") verdict = "failed_slot";
   if (reviewQuality?.failed_review_slot === true && (verdict === "approved" || verdict === "request_changes")) {
+    verdict = "failed_slot";
+  }
+  // #238: a verdict reached without the source the review needed cannot count. The source-packet
+  // policy sets source_send_allowed===false ONLY when the review is source-bearing AND a block
+  // applies (source_packet_too_large / resend_confirmation_required) -- so this excludes legit
+  // diff-only reviews (not source-bearing => allowed) and legit resumes (already sent => allowed).
+  // Demote to failed_slot so notCountedReason returns source_not_sent instead of "none". This is
+  // ground truth (was the source delivered), independent of the spoofable review text.
+  if (sourceSendAllowed === false && (verdict === "approved" || verdict === "request_changes")) {
     verdict = "failed_slot";
   }
   const retry_fingerprint = hashValue(retryFingerprint);

--- a/plugins/claude/scripts/lib/review-prompt.mjs
+++ b/plugins/claude/scripts/lib/review-prompt.mjs
@@ -1433,6 +1433,7 @@ export function buildReviewAuditManifest({
     retryDispositionRequired: retryPolicy.retry_disposition_required,
     requestSettingsHash,
     sourceState: sourceContentTransmission,
+    sourceSendAllowed: effectiveSourcePacketPolicy.source_send_allowed,
     status,
     errorCode: effectiveErrorCode,
     result,

--- a/plugins/gemini/scripts/lib/provider-route-policy.mjs
+++ b/plugins/gemini/scripts/lib/provider-route-policy.mjs
@@ -709,6 +709,7 @@ export function buildReviewSlotDisposition({
   retryDispositionRequired = false,
   requestSettingsHash = null,
   sourceState = "unknown",
+  sourceSendAllowed = null,
   status = null,
   errorCode = null,
   result = "",
@@ -723,6 +724,15 @@ export function buildReviewSlotDisposition({
   if (status === "failed" && errorCode === "timeout") verdict = "timeout";
   else if (status && status !== "completed") verdict = "failed_slot";
   if (reviewQuality?.failed_review_slot === true && (verdict === "approved" || verdict === "request_changes")) {
+    verdict = "failed_slot";
+  }
+  // #238: a verdict reached without the source the review needed cannot count. The source-packet
+  // policy sets source_send_allowed===false ONLY when the review is source-bearing AND a block
+  // applies (source_packet_too_large / resend_confirmation_required) -- so this excludes legit
+  // diff-only reviews (not source-bearing => allowed) and legit resumes (already sent => allowed).
+  // Demote to failed_slot so notCountedReason returns source_not_sent instead of "none". This is
+  // ground truth (was the source delivered), independent of the spoofable review text.
+  if (sourceSendAllowed === false && (verdict === "approved" || verdict === "request_changes")) {
     verdict = "failed_slot";
   }
   const retry_fingerprint = hashValue(retryFingerprint);

--- a/plugins/gemini/scripts/lib/review-prompt.mjs
+++ b/plugins/gemini/scripts/lib/review-prompt.mjs
@@ -1433,6 +1433,7 @@ export function buildReviewAuditManifest({
     retryDispositionRequired: retryPolicy.retry_disposition_required,
     requestSettingsHash,
     sourceState: sourceContentTransmission,
+    sourceSendAllowed: effectiveSourcePacketPolicy.source_send_allowed,
     status,
     errorCode: effectiveErrorCode,
     result,

--- a/plugins/grok/scripts/lib/provider-route-policy.mjs
+++ b/plugins/grok/scripts/lib/provider-route-policy.mjs
@@ -709,6 +709,7 @@ export function buildReviewSlotDisposition({
   retryDispositionRequired = false,
   requestSettingsHash = null,
   sourceState = "unknown",
+  sourceSendAllowed = null,
   status = null,
   errorCode = null,
   result = "",
@@ -723,6 +724,15 @@ export function buildReviewSlotDisposition({
   if (status === "failed" && errorCode === "timeout") verdict = "timeout";
   else if (status && status !== "completed") verdict = "failed_slot";
   if (reviewQuality?.failed_review_slot === true && (verdict === "approved" || verdict === "request_changes")) {
+    verdict = "failed_slot";
+  }
+  // #238: a verdict reached without the source the review needed cannot count. The source-packet
+  // policy sets source_send_allowed===false ONLY when the review is source-bearing AND a block
+  // applies (source_packet_too_large / resend_confirmation_required) -- so this excludes legit
+  // diff-only reviews (not source-bearing => allowed) and legit resumes (already sent => allowed).
+  // Demote to failed_slot so notCountedReason returns source_not_sent instead of "none". This is
+  // ground truth (was the source delivered), independent of the spoofable review text.
+  if (sourceSendAllowed === false && (verdict === "approved" || verdict === "request_changes")) {
     verdict = "failed_slot";
   }
   const retry_fingerprint = hashValue(retryFingerprint);

--- a/plugins/grok/scripts/lib/review-prompt.mjs
+++ b/plugins/grok/scripts/lib/review-prompt.mjs
@@ -1433,6 +1433,7 @@ export function buildReviewAuditManifest({
     retryDispositionRequired: retryPolicy.retry_disposition_required,
     requestSettingsHash,
     sourceState: sourceContentTransmission,
+    sourceSendAllowed: effectiveSourcePacketPolicy.source_send_allowed,
     status,
     errorCode: effectiveErrorCode,
     result,

--- a/plugins/kimi/scripts/lib/provider-route-policy.mjs
+++ b/plugins/kimi/scripts/lib/provider-route-policy.mjs
@@ -709,6 +709,7 @@ export function buildReviewSlotDisposition({
   retryDispositionRequired = false,
   requestSettingsHash = null,
   sourceState = "unknown",
+  sourceSendAllowed = null,
   status = null,
   errorCode = null,
   result = "",
@@ -723,6 +724,15 @@ export function buildReviewSlotDisposition({
   if (status === "failed" && errorCode === "timeout") verdict = "timeout";
   else if (status && status !== "completed") verdict = "failed_slot";
   if (reviewQuality?.failed_review_slot === true && (verdict === "approved" || verdict === "request_changes")) {
+    verdict = "failed_slot";
+  }
+  // #238: a verdict reached without the source the review needed cannot count. The source-packet
+  // policy sets source_send_allowed===false ONLY when the review is source-bearing AND a block
+  // applies (source_packet_too_large / resend_confirmation_required) -- so this excludes legit
+  // diff-only reviews (not source-bearing => allowed) and legit resumes (already sent => allowed).
+  // Demote to failed_slot so notCountedReason returns source_not_sent instead of "none". This is
+  // ground truth (was the source delivered), independent of the spoofable review text.
+  if (sourceSendAllowed === false && (verdict === "approved" || verdict === "request_changes")) {
     verdict = "failed_slot";
   }
   const retry_fingerprint = hashValue(retryFingerprint);

--- a/plugins/kimi/scripts/lib/review-prompt.mjs
+++ b/plugins/kimi/scripts/lib/review-prompt.mjs
@@ -1433,6 +1433,7 @@ export function buildReviewAuditManifest({
     retryDispositionRequired: retryPolicy.retry_disposition_required,
     requestSettingsHash,
     sourceState: sourceContentTransmission,
+    sourceSendAllowed: effectiveSourcePacketPolicy.source_send_allowed,
     status,
     errorCode: effectiveErrorCode,
     result,

--- a/relay/relay-gemini/scripts/lib/provider-route-policy.mjs
+++ b/relay/relay-gemini/scripts/lib/provider-route-policy.mjs
@@ -709,6 +709,7 @@ export function buildReviewSlotDisposition({
   retryDispositionRequired = false,
   requestSettingsHash = null,
   sourceState = "unknown",
+  sourceSendAllowed = null,
   status = null,
   errorCode = null,
   result = "",
@@ -723,6 +724,15 @@ export function buildReviewSlotDisposition({
   if (status === "failed" && errorCode === "timeout") verdict = "timeout";
   else if (status && status !== "completed") verdict = "failed_slot";
   if (reviewQuality?.failed_review_slot === true && (verdict === "approved" || verdict === "request_changes")) {
+    verdict = "failed_slot";
+  }
+  // #238: a verdict reached without the source the review needed cannot count. The source-packet
+  // policy sets source_send_allowed===false ONLY when the review is source-bearing AND a block
+  // applies (source_packet_too_large / resend_confirmation_required) -- so this excludes legit
+  // diff-only reviews (not source-bearing => allowed) and legit resumes (already sent => allowed).
+  // Demote to failed_slot so notCountedReason returns source_not_sent instead of "none". This is
+  // ground truth (was the source delivered), independent of the spoofable review text.
+  if (sourceSendAllowed === false && (verdict === "approved" || verdict === "request_changes")) {
     verdict = "failed_slot";
   }
   const retry_fingerprint = hashValue(retryFingerprint);

--- a/relay/relay-gemini/scripts/lib/review-prompt.mjs
+++ b/relay/relay-gemini/scripts/lib/review-prompt.mjs
@@ -1433,6 +1433,7 @@ export function buildReviewAuditManifest({
     retryDispositionRequired: retryPolicy.retry_disposition_required,
     requestSettingsHash,
     sourceState: sourceContentTransmission,
+    sourceSendAllowed: effectiveSourcePacketPolicy.source_send_allowed,
     status,
     errorCode: effectiveErrorCode,
     result,

--- a/relay/relay-grok/scripts/lib/provider-route-policy.mjs
+++ b/relay/relay-grok/scripts/lib/provider-route-policy.mjs
@@ -709,6 +709,7 @@ export function buildReviewSlotDisposition({
   retryDispositionRequired = false,
   requestSettingsHash = null,
   sourceState = "unknown",
+  sourceSendAllowed = null,
   status = null,
   errorCode = null,
   result = "",
@@ -723,6 +724,15 @@ export function buildReviewSlotDisposition({
   if (status === "failed" && errorCode === "timeout") verdict = "timeout";
   else if (status && status !== "completed") verdict = "failed_slot";
   if (reviewQuality?.failed_review_slot === true && (verdict === "approved" || verdict === "request_changes")) {
+    verdict = "failed_slot";
+  }
+  // #238: a verdict reached without the source the review needed cannot count. The source-packet
+  // policy sets source_send_allowed===false ONLY when the review is source-bearing AND a block
+  // applies (source_packet_too_large / resend_confirmation_required) -- so this excludes legit
+  // diff-only reviews (not source-bearing => allowed) and legit resumes (already sent => allowed).
+  // Demote to failed_slot so notCountedReason returns source_not_sent instead of "none". This is
+  // ground truth (was the source delivered), independent of the spoofable review text.
+  if (sourceSendAllowed === false && (verdict === "approved" || verdict === "request_changes")) {
     verdict = "failed_slot";
   }
   const retry_fingerprint = hashValue(retryFingerprint);

--- a/relay/relay-grok/scripts/lib/review-prompt.mjs
+++ b/relay/relay-grok/scripts/lib/review-prompt.mjs
@@ -1433,6 +1433,7 @@ export function buildReviewAuditManifest({
     retryDispositionRequired: retryPolicy.retry_disposition_required,
     requestSettingsHash,
     sourceState: sourceContentTransmission,
+    sourceSendAllowed: effectiveSourcePacketPolicy.source_send_allowed,
     status,
     errorCode: effectiveErrorCode,
     result,

--- a/relay/relay-kimi/scripts/lib/provider-route-policy.mjs
+++ b/relay/relay-kimi/scripts/lib/provider-route-policy.mjs
@@ -709,6 +709,7 @@ export function buildReviewSlotDisposition({
   retryDispositionRequired = false,
   requestSettingsHash = null,
   sourceState = "unknown",
+  sourceSendAllowed = null,
   status = null,
   errorCode = null,
   result = "",
@@ -723,6 +724,15 @@ export function buildReviewSlotDisposition({
   if (status === "failed" && errorCode === "timeout") verdict = "timeout";
   else if (status && status !== "completed") verdict = "failed_slot";
   if (reviewQuality?.failed_review_slot === true && (verdict === "approved" || verdict === "request_changes")) {
+    verdict = "failed_slot";
+  }
+  // #238: a verdict reached without the source the review needed cannot count. The source-packet
+  // policy sets source_send_allowed===false ONLY when the review is source-bearing AND a block
+  // applies (source_packet_too_large / resend_confirmation_required) -- so this excludes legit
+  // diff-only reviews (not source-bearing => allowed) and legit resumes (already sent => allowed).
+  // Demote to failed_slot so notCountedReason returns source_not_sent instead of "none". This is
+  // ground truth (was the source delivered), independent of the spoofable review text.
+  if (sourceSendAllowed === false && (verdict === "approved" || verdict === "request_changes")) {
     verdict = "failed_slot";
   }
   const retry_fingerprint = hashValue(retryFingerprint);

--- a/relay/relay-kimi/scripts/lib/review-prompt.mjs
+++ b/relay/relay-kimi/scripts/lib/review-prompt.mjs
@@ -1433,6 +1433,7 @@ export function buildReviewAuditManifest({
     retryDispositionRequired: retryPolicy.retry_disposition_required,
     requestSettingsHash,
     sourceState: sourceContentTransmission,
+    sourceSendAllowed: effectiveSourcePacketPolicy.source_send_allowed,
     status,
     errorCode: effectiveErrorCode,
     result,

--- a/scripts/lib/provider-route-policy.mjs
+++ b/scripts/lib/provider-route-policy.mjs
@@ -709,6 +709,7 @@ export function buildReviewSlotDisposition({
   retryDispositionRequired = false,
   requestSettingsHash = null,
   sourceState = "unknown",
+  sourceSendAllowed = null,
   status = null,
   errorCode = null,
   result = "",
@@ -723,6 +724,15 @@ export function buildReviewSlotDisposition({
   if (status === "failed" && errorCode === "timeout") verdict = "timeout";
   else if (status && status !== "completed") verdict = "failed_slot";
   if (reviewQuality?.failed_review_slot === true && (verdict === "approved" || verdict === "request_changes")) {
+    verdict = "failed_slot";
+  }
+  // #238: a verdict reached without the source the review needed cannot count. The source-packet
+  // policy sets source_send_allowed===false ONLY when the review is source-bearing AND a block
+  // applies (source_packet_too_large / resend_confirmation_required) -- so this excludes legit
+  // diff-only reviews (not source-bearing => allowed) and legit resumes (already sent => allowed).
+  // Demote to failed_slot so notCountedReason returns source_not_sent instead of "none". This is
+  // ground truth (was the source delivered), independent of the spoofable review text.
+  if (sourceSendAllowed === false && (verdict === "approved" || verdict === "request_changes")) {
     verdict = "failed_slot";
   }
   const retry_fingerprint = hashValue(retryFingerprint);

--- a/scripts/lib/review-prompt.mjs
+++ b/scripts/lib/review-prompt.mjs
@@ -1433,6 +1433,7 @@ export function buildReviewAuditManifest({
     retryDispositionRequired: retryPolicy.retry_disposition_required,
     requestSettingsHash,
     sourceState: sourceContentTransmission,
+    sourceSendAllowed: effectiveSourcePacketPolicy.source_send_allowed,
     status,
     errorCode: effectiveErrorCode,
     result,

--- a/tests/unit/provider-route-policy.test.mjs
+++ b/tests/unit/provider-route-policy.test.mjs
@@ -514,6 +514,62 @@ test("review slot disposition never counts failed process output as approval", (
   }
 });
 
+// #238: an approval/request_changes on a source-bearing review whose source send was BLOCKED
+// (source_send_allowed === false: e.g. source_packet_too_large, resend_confirmation_required)
+// reviewed without the source it needed -- it must NOT count as a satisfied review. The decidable
+// signal is source_send_allowed===false, which the policy sets only when the review is
+// source-bearing AND a block applies, so it cleanly excludes legit diff-only (not source-bearing)
+// and legit resume (send still allowed) reviews.
+test("review slot disposition does not count an approval when the required source was blocked (#238)", () => {
+  for (const result of ["Verdict: APPROVE\nBlocking findings: none.", "Verdict: REQUEST_CHANGES\nBlocking findings: one."]) {
+    const disposition = buildReviewSlotDisposition({
+      provider: "claude",
+      mode: "review",
+      stage: "final",
+      attemptId: "job-source-blocked",
+      reviewedHeadSha: "head",
+      currentHeadSha: "head",
+      retryFingerprint: "f".repeat(64),
+      retryCount: 0,
+      sourceState: "not_sent",
+      sourceSendAllowed: false,
+      status: "completed",
+      errorCode: null,
+      result,
+      reviewQuality: { failed_review_slot: false, semantic_failure_reasons: [] },
+    });
+    assert.equal(disposition.verdict, "failed_slot");
+    assert.notEqual(disposition.not_counted_reason, "none");
+    assert.equal(disposition.not_counted_reason, "source_not_sent");
+  }
+});
+
+// Precision guard: the #238 demotion must NOT touch legit approvals -- a not-source-bearing
+// (diff-only) review and a source-sent review keep counting.
+test("review slot disposition still counts legit approvals (diff-only / source-sent) (#238 precision)", () => {
+  const base = {
+    provider: "claude",
+    mode: "review",
+    stage: "final",
+    attemptId: "job-legit",
+    reviewedHeadSha: "head",
+    currentHeadSha: "head",
+    retryFingerprint: "f".repeat(64),
+    retryCount: 0,
+    status: "completed",
+    errorCode: null,
+    result: "Verdict: APPROVE\nBlocking findings: none.",
+    reviewQuality: { failed_review_slot: false, semantic_failure_reasons: [] },
+  };
+  const diffOnly = buildReviewSlotDisposition({ ...base, sourceState: "not_sent", sourceSendAllowed: true });
+  assert.equal(diffOnly.verdict, "approved");
+  assert.equal(diffOnly.not_counted_reason, "none");
+
+  const sourceSent = buildReviewSlotDisposition({ ...base, sourceState: "sent", sourceSendAllowed: true });
+  assert.equal(sourceSent.verdict, "approved");
+  assert.equal(sourceSent.not_counted_reason, "none");
+});
+
 function assertRouteStepLedger(route) {
   assert.deepEqual(route.route_steps.map((step) => step.route), PROVIDER_ROUTE_STEPS);
   for (const step of route.route_steps) {

--- a/tests/unit/review-prompt.test.mjs
+++ b/tests/unit/review-prompt.test.mjs
@@ -3948,3 +3948,51 @@ for (const [name, file] of REVIEW_PROMPT_MODULES) {
     }), "working-tree");
   });
 }
+
+// #238: ground-truth disposition guard -- a clean, substantive approval reached on a SOURCE-BEARING
+// review whose source send was BLOCKED (source_send_allowed=false) must not count as a satisfied
+// slot; it is demoted to failed_slot / source_not_sent. Legit diff-only (not source-bearing) and
+// source-sent approvals keep counting. This is ground truth (was the source delivered) -- it does
+// NOT depend on the spoofable review text. Composed via buildReviewAuditManifest across all copies.
+const SOURCE_BLOCKED_APPROVAL = [
+  "Verdict: Approve",
+  "Blocking findings: none.",
+  "Non-blocking concerns: a minor naming nit in check() could be clearer.",
+  "I inspected the selected source and traced the control flow end to end; the guard returns a consistent boolean across all branches and the early-return path is handled correctly. Test coverage for the happy path and the empty-input path both look adequate, the error messages are actionable, and nothing in this change introduces a regression or a security concern. This is a clean approval after a full and careful read of the supplied source content from top to bottom.",
+].join("\n");
+const SOURCE_BLOCKED_FILE = [{ path: "src/auth.js", text: "export function check(){ return true; }\n".repeat(3) }];
+const SOURCE_BLOCKED_POLICY = Object.freeze({
+  source_bearing: true,
+  source_send_allowed: false,
+  source_content_transmission: "not_sent",
+  source_packet_policy_error_code: "source_packet_too_large",
+  source_packet_action: "narrow_source_packet",
+  review_surface_changed: false,
+});
+
+for (const [name, file] of REVIEW_PROMPT_MODULES) {
+  test(`source-blocked approval is not counted as a satisfied slot (#238) (${name})`, async () => {
+    const { buildReviewAuditManifest: build } = await loadReviewPromptModule(file);
+
+    const blocked = build({
+      prompt: "p", result: SOURCE_BLOCKED_APPROVAL, status: "completed", errorCode: null,
+      sourceFiles: SOURCE_BLOCKED_FILE, route: { sourcePacketPolicy: SOURCE_BLOCKED_POLICY },
+    });
+    assert.equal(blocked.review_slot.verdict, "failed_slot", "source-blocked approval must be demoted");
+    assert.equal(blocked.review_slot.not_counted_reason, "source_not_sent");
+
+    // Precision: diff-only (not source-bearing) approval still counts.
+    const diffOnly = build({
+      prompt: "p", result: SOURCE_BLOCKED_APPROVAL, status: "completed", errorCode: null, sourceFiles: [],
+    });
+    assert.equal(diffOnly.review_slot.verdict, "approved", "diff-only approval must still count");
+    assert.equal(diffOnly.review_slot.not_counted_reason, "none");
+
+    // Precision: source-bearing approval that was actually sent still counts.
+    const sent = build({
+      prompt: "p", result: SOURCE_BLOCKED_APPROVAL, status: "completed", errorCode: null, sourceFiles: SOURCE_BLOCKED_FILE,
+    });
+    assert.equal(sent.review_slot.verdict, "approved", "source-sent approval must still count");
+    assert.equal(sent.review_slot.not_counted_reason, "none");
+  });
+}


### PR DESCRIPTION
## What

`buildReviewSlotDisposition` counted an `approve`/`request_changes` verdict as a satisfied review slot even when the review was **source-bearing but its source send was blocked** (`source_send_allowed=false`) — i.e. the reviewer never received the source it needed. `notCountedReason` short-circuits approved verdicts to `"none"` *before* the `source_state` checks, so `source_not_sent` never applied.

Confirmed live via the composed `buildReviewAuditManifest` path:

| review (clean, >500-char approval) | `verdict` | `not_counted_reason` |
|---|---|---|
| source-bearing, send **blocked** (before fix) | `approved` | `none` → **counts** |
| source-bearing, send **blocked** (after fix) | `failed_slot` | `source_not_sent` → not counted |
| diff-only (not source-bearing) | `approved` | `none` → counts (unchanged) |
| source-bearing, sent | `approved` | `none` → counts (unchanged) |

## Fix — ground truth, not review text

Thread `source_send_allowed` into `buildReviewSlotDisposition`; demote `approved`/`request_changes` → `failed_slot` when `source_send_allowed === false`. The source-packet policy sets that flag **only** for a source-bearing review whose send is blocked (`source_packet_too_large` / `resend_confirmation_required`), so it cleanly excludes the legit cases:
- **diff-only** reviews (not source-bearing ⇒ `allowed`), and
- **resumes** (source sent on a prior attempt ⇒ `allowed`).

`notCountedReason` then returns `source_not_sent`. This fails *toward* flagging (degraded-state invariant) regardless of whether the current orchestration reaches the state.

## Scope (important)

This hardens the **decidable** case — source genuinely not delivered. The motivating #238 evidence also showed a **surface-undecidable** case: a reviewer that *received* the source but claims in free text it didn't (`"I never saw the code"`). A keyword detector for that was implemented and **adversarially disproven** — any version broad enough to catch it demotes genuine `REQUEST_CHANGES` bug reports as false positives (`"the handler could not read the file descriptor"` reads identically to a reviewer admission). Same undecidability class as the reverted praise/dismissal lexicon. That residual stays in #238 for the Way-2 advisory-disposition redesign.

**Boundary:** this changes the authoritative *counting* contract (`review_slot.not_counted_reason` / `verdict`). `review_quality.failed_review_slot` intentionally stays `false` — the review *text* quality is fine; only *source delivery* failed (a distinct signal). The review-panel `readiness()` display keys on `failed_review_slot` and is out of scope here.

## Verification

- New unit test (`buildReviewSlotDisposition`): source-blocked `approve`/`request_changes` → `failed_slot`/`source_not_sent`; diff-only & source-sent still count.
- New composed test (`buildReviewAuditManifest`, parametrized over all module copies): same, end-to-end.
- `provider-route-policy` 46/46, `review-prompt` 406/406, full instrumented unit suite green, `sync --check` rc=0 (both libs), `npm run lint` pass, coverage 85% met.
- Source + 8 synced copies byte-identical; relay build regenerated.

Refs #238 #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)
