### PR TITLE
#247: untrack committed node_modules symlink; ignore symlink form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# No trailing slash: also ignores a `node_modules` *symlink* (worktrees symlink
+# it to share installed deps). A `node_modules/` rule matches only a directory
+# and lets the symlink form be committed — see #247. Do not re-add the slash.
 node_modules
 .codex-plugin-*/jobs/
 .codex-plugin-data/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-node_modules/
+node_modules
 .codex-plugin-*/jobs/
 .codex-plugin-data/
 coverage/

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/spson/Projects/Claude/relay/node_modules

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "plugins/relay-deepseek"
   ],
   "scripts": {
-    "lint": "node scripts/ci/check-manifests.mjs && npm run lint:sync",
+    "lint": "node scripts/ci/check-manifests.mjs && node scripts/ci/check-no-foreign-symlinks.mjs && npm run lint:sync",
     "lint:sync": "node scripts/ci/sync-diff-source.mjs --check && node scripts/ci/sync-codex-env.mjs --check && node scripts/ci/sync-companion-common.mjs --check && node scripts/ci/sync-external-review.mjs --check && node scripts/ci/sync-review-panel.mjs --check && node scripts/ci/sync-time.mjs --check && node scripts/ci/sync-external-model-failure-classification.mjs --check && node scripts/ci/sync-external-model-review-quality.mjs --check && node scripts/ci/sync-privacy-redaction.mjs --check && node scripts/ci/sync-provider-route-policy.mjs --check && node scripts/ci/sync-review-prompt.mjs --check && node scripts/ci/sync-external-model-contracts.mjs --check && node scripts/ci/check-default-auth-policy.mjs --check && node scripts/ci/sync-auth-selection.mjs --check && node scripts/ci/sync-provider-env.mjs --check && node scripts/ci/sync-usage-limit.mjs --check && node scripts/ci/sync-review-workload.mjs --check && node scripts/ci/sync-provider-identity.mjs --check && node scripts/ci/sync-relay-build.mjs --check",
     "lint:self-test": "node scripts/ci/check-manifests-self-test.mjs",
     "test": "node scripts/ci/run-tests.mjs",

--- a/scripts/ci/check-no-foreign-symlinks.mjs
+++ b/scripts/ci/check-no-foreign-symlinks.mjs
@@ -20,11 +20,21 @@
 // the current working directory, so it is correct in worktrees and testable
 // against a throwaway repo.
 //
+// Git is invoked via the absolute DEFAULT_GIT_BINARY with a fixed safe PATH
+// (the repo-canonical trusted-binary pattern; see provider-readiness-manifest),
+// never a $PATH-resolved bare name. `ls-files -s -z` is NUL-delimited and not
+// C-quoted, so paths with special bytes are preserved verbatim (no quoting
+// bypass of the escape check).
+//
 // Run in CI via `npm run lint`.
 
 import { execFileSync } from "node:child_process";
 import { posix } from "node:path";
 import { pathToFileURL } from "node:url";
+import { DEFAULT_GIT_BINARY, gitEnv } from "../../plugins/api-reviewers/scripts/lib/git-binary.mjs";
+import { cleanGitEnv } from "../../plugins/api-reviewers/scripts/lib/git-env.mjs";
+
+const TRUSTED_GIT_ENV = gitEnv(cleanGitEnv());
 
 // Absolute target detection across POSIX + Windows forms. Git stores the symlink
 // target verbatim; reject anything machine-rooted.
@@ -54,29 +64,34 @@ export function findForeignSymlinks(entries) {
   return offenders;
 }
 
-// Parse `git ls-files -s` output → [{ mode, sha, path }].
-// Line format: "<mode> <sha> <stage>\t<path>". Paths may contain spaces, so the
-// path is everything after the first tab.
+// Parse `git ls-files -s -z` output → [{ mode, sha, path }].
+// Record format: "<mode> <sha> <stage>\t<path>", records NUL-delimited. `-z`
+// disables C-quoting, so special bytes in a path survive intact.
 export function parseLsFilesStage(output) {
   const out = [];
-  for (const line of output.split("\n")) {
-    if (!line) continue;
-    const tab = line.indexOf("\t");
+  for (const rec of output.split("\0")) {
+    if (!rec) continue;
+    const tab = rec.indexOf("\t");
     if (tab === -1) continue;
-    const meta = line.slice(0, tab).split(/\s+/);
-    out.push({ mode: meta[0], sha: meta[1], path: line.slice(tab + 1) });
+    const meta = rec.slice(0, tab).split(/\s+/);
+    out.push({ mode: meta[0], sha: meta[1], path: rec.slice(tab + 1) });
   }
   return out;
 }
 
 function makeRunGit(cwd) {
   return (args) =>
-    execFileSync("git", args, { cwd, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
+    execFileSync(DEFAULT_GIT_BINARY, ["-C", cwd, ...args], {
+      encoding: "utf8",
+      env: TRUSTED_GIT_ENV,
+      timeout: 15000,
+      maxBuffer: 64 * 1024 * 1024,
+    });
 }
 
 // Collect tracked symlinks and their committed targets via git.
 export function collectTrackedSymlinks(runGit) {
-  const symlinks = parseLsFilesStage(runGit(["ls-files", "-s"])).filter((e) => e.mode === "120000");
+  const symlinks = parseLsFilesStage(runGit(["ls-files", "-s", "-z"])).filter((e) => e.mode === "120000");
   return symlinks.map((e) => ({
     path: e.path,
     // A symlink blob's content IS its target string (no trailing newline).
@@ -87,9 +102,10 @@ export function collectTrackedSymlinks(runGit) {
 export function main(cwd = process.cwd()) {
   // Anchor to the enclosing git toplevel so `git ls-files` covers the whole repo
   // regardless of the directory the check was invoked from.
-  const toplevel = execFileSync("git", ["rev-parse", "--show-toplevel"], {
-    cwd,
+  const toplevel = execFileSync(DEFAULT_GIT_BINARY, ["-C", cwd, "rev-parse", "--show-toplevel"], {
     encoding: "utf8",
+    env: TRUSTED_GIT_ENV,
+    timeout: 15000,
   }).trim();
   const runGit = makeRunGit(toplevel);
 

--- a/scripts/ci/check-no-foreign-symlinks.mjs
+++ b/scripts/ci/check-no-foreign-symlinks.mjs
@@ -2,9 +2,12 @@
 // Repo-hygiene guard: every tracked symlink (git mode 120000) must point to a
 // RELATIVE target that resolves INSIDE the repository.
 //
-// Rejects:
-//   - absolute targets (machine-specific; e.g. /Users/x/relay/node_modules)
-//   - relative targets that escape the repo root via ../
+// Rejects (under POSIX *and* Windows path semantics — the committed blob is the
+// same bytes on every clone, so a target that is foreign on ANY supported OS is
+// rejected regardless of where the check runs):
+//   - absolute / machine-rooted targets: POSIX /x; Windows \x, C:\x, C:/x;
+//     UNC \\server; and drive-relative C:foo / C: (bind to a drive's cwd)
+//   - relative targets that escape the repo root via ../ or ..\ (Windows sep)
 //
 // Why this exists (#247): a `node_modules` symlink whose target was the absolute
 // path /Users/.../relay/node_modules was committed to main, because .gitignore's
@@ -29,21 +32,23 @@
 // Run in CI via `npm run lint`.
 
 import { execFileSync } from "node:child_process";
-import { posix } from "node:path";
+import { posix, win32 } from "node:path";
 import { pathToFileURL } from "node:url";
 import { DEFAULT_GIT_BINARY, gitEnv } from "../../plugins/api-reviewers/scripts/lib/git-binary.mjs";
 import { cleanGitEnv } from "../../plugins/api-reviewers/scripts/lib/git-env.mjs";
 
 const TRUSTED_GIT_ENV = gitEnv(cleanGitEnv());
 
-// Absolute target detection across POSIX + Windows forms. Git stores the symlink
-// target verbatim; reject anything machine-rooted.
+// Absolute / machine-rooted target detection across POSIX + Windows forms. Git
+// stores the symlink target verbatim; reject anything that binds to a machine
+// path on any clone OS. node:path's own isAbsolute does the heavy lifting:
+//   - posix.isAbsolute("/x")                      -> true
+//   - win32.isAbsolute("\\x" | "C:\\x" | "C:/x" | "\\\\unc") -> true
+// win32.isAbsolute treats drive-RELATIVE forms (C:foo, C:) as NOT absolute, but
+// they are still machine-specific (they resolve against drive C:'s current dir),
+// so catch the leading-drive form explicitly.
 function isAbsoluteTarget(target) {
-  return (
-    target.startsWith("/") || // POSIX absolute
-    /^[A-Za-z]:[\\/]/.test(target) || // Windows drive (C:\ or C:/)
-    target.startsWith("\\\\") // Windows UNC
-  );
+  return posix.isAbsolute(target) || win32.isAbsolute(target) || /^[A-Za-z]:/.test(target);
 }
 
 // Pure core: given tracked symlink entries [{ path, target }] (repo-relative,
@@ -56,7 +61,12 @@ export function findForeignSymlinks(entries) {
       continue;
     }
     // Resolve the relative target lexically against the link's own directory.
-    const resolved = posix.normalize(posix.join(posix.dirname(linkPath), target));
+    // Unify backslashes to "/" first: a target like `..\x` is a parent escape on
+    // Windows, and the committed blob is the same bytes on every clone, so it must
+    // be analyzed under separator semantics that hold on EVERY OS (otherwise
+    // `..\..\outside` would slip through as a single literal filename here).
+    const unifiedTarget = target.replace(/\\/g, "/");
+    const resolved = posix.normalize(posix.join(posix.dirname(linkPath), unifiedTarget));
     if (resolved === ".." || resolved.startsWith("../")) {
       offenders.push({ path: linkPath, target, reason: `escapes repo root (resolves to ${resolved})` });
     }

--- a/scripts/ci/check-no-foreign-symlinks.mjs
+++ b/scripts/ci/check-no-foreign-symlinks.mjs
@@ -2,12 +2,19 @@
 // Repo-hygiene guard: every tracked symlink (git mode 120000) must point to a
 // RELATIVE target that resolves INSIDE the repository.
 //
-// Rejects (under POSIX *and* Windows path semantics — the committed blob is the
-// same bytes on every clone, so a target that is foreign on ANY supported OS is
-// rejected regardless of where the check runs):
-//   - absolute / machine-rooted targets: POSIX /x; Windows \x, C:\x, C:/x;
-//     UNC \\server; and drive-relative C:foo / C: (bind to a drive's cwd)
-//   - relative targets that escape the repo root via ../ or ..\ (Windows sep)
+// Model: ALLOWLIST, fail-closed. The committed blob is the same bytes on every
+// clone, and we cannot resolve a foreign machine path against clones we don't
+// have — so a target is ACCEPTED only when it is the one provably-portable,
+// in-repo shape, and EVERYTHING ELSE is rejected. New or exotic absolute/escape
+// syntaxes therefore fail closed without a per-form detector (a blocklist of
+// "bad" forms — drive letters, UNC, \ escapes … — is unbounded whack-a-mole;
+// requiring the single safe shape is the class fix).
+//
+// Accepts: a NON-empty, RELATIVE, forward-slash target that resolves INSIDE the
+//   repo (e.g. ../plugins/api-reviewers, claude-mock.mjs).
+// Rejects everything else: any "\" (Windows separator / non-portable byte on
+//   POSIX — subsumes \x, C:\x, \\UNC, ..\ escapes), a leading "/" or an "X:"
+//   drive qualifier (machine-rooted), and "../" escapes above the repo root.
 //
 // Why this exists (#247): a `node_modules` symlink whose target was the absolute
 // path /Users/.../relay/node_modules was committed to main, because .gitignore's
@@ -32,23 +39,44 @@
 // Run in CI via `npm run lint`.
 
 import { execFileSync } from "node:child_process";
-import { posix, win32 } from "node:path";
+import { posix } from "node:path";
 import { pathToFileURL } from "node:url";
 import { DEFAULT_GIT_BINARY, gitEnv } from "../../plugins/api-reviewers/scripts/lib/git-binary.mjs";
 import { cleanGitEnv } from "../../plugins/api-reviewers/scripts/lib/git-env.mjs";
 
 const TRUSTED_GIT_ENV = gitEnv(cleanGitEnv());
 
-// Absolute / machine-rooted target detection across POSIX + Windows forms. Git
-// stores the symlink target verbatim; reject anything that binds to a machine
-// path on any clone OS. node:path's own isAbsolute does the heavy lifting:
-//   - posix.isAbsolute("/x")                      -> true
-//   - win32.isAbsolute("\\x" | "C:\\x" | "C:/x" | "\\\\unc") -> true
-// win32.isAbsolute treats drive-RELATIVE forms (C:foo, C:) as NOT absolute, but
-// they are still machine-specific (they resolve against drive C:'s current dir),
-// so catch the leading-drive form explicitly.
-function isAbsoluteTarget(target) {
-  return posix.isAbsolute(target) || win32.isAbsolute(target) || /^[A-Za-z]:/.test(target);
+// Classify a tracked symlink's committed target. Returns a human-readable reason
+// when the target is foreign, or null when it is the one safe shape.
+//
+// This is an ALLOWLIST (see file header): rather than enumerate every machine-
+// rooted syntax (POSIX absolute, Windows drive/UNC/root-relative, drive-relative,
+// \ escapes …) — a list that grows every time a new form is found — it requires
+// the single portable, in-repo shape and rejects all else, so unknown forms fail
+// closed. Each rejection below removes a whole sub-class, not one instance.
+function classifyForeignTarget(linkPath, target) {
+  if (target === "") {
+    return "empty target";
+  }
+  // A portable git symlink target uses "/". A backslash is a Windows path
+  // separator (and a divergent, non-portable byte on POSIX), so ANY "\" makes the
+  // target non-portable — this single rule subsumes \x, C:\x, \\UNC and ..\ escapes.
+  if (target.includes("\\")) {
+    return "non-portable '\\' separator (symlink targets must use '/')";
+  }
+  // Machine-rooted under any OS: a leading "/" (POSIX absolute) or an "X:" drive
+  // qualifier (Windows absolute or drive-relative). A portable relative segment
+  // never begins with "/" or a drive letter, so either is machine-bound.
+  if (posix.isAbsolute(target) || /^[A-Za-z]:/.test(target)) {
+    return "absolute / drive-rooted target (machine-specific)";
+  }
+  // Containment: resolve lexically against the link's own directory; it must not
+  // climb above the repo root.
+  const resolved = posix.normalize(posix.join(posix.dirname(linkPath), target));
+  if (resolved === ".." || resolved.startsWith("../")) {
+    return `escapes repo root (resolves to ${resolved})`;
+  }
+  return null;
 }
 
 // Pure core: given tracked symlink entries [{ path, target }] (repo-relative,
@@ -56,19 +84,9 @@ function isAbsoluteTarget(target) {
 export function findForeignSymlinks(entries) {
   const offenders = [];
   for (const { path: linkPath, target } of entries) {
-    if (isAbsoluteTarget(target)) {
-      offenders.push({ path: linkPath, target, reason: "absolute target (machine-specific)" });
-      continue;
-    }
-    // Resolve the relative target lexically against the link's own directory.
-    // Unify backslashes to "/" first: a target like `..\x` is a parent escape on
-    // Windows, and the committed blob is the same bytes on every clone, so it must
-    // be analyzed under separator semantics that hold on EVERY OS (otherwise
-    // `..\..\outside` would slip through as a single literal filename here).
-    const unifiedTarget = target.replace(/\\/g, "/");
-    const resolved = posix.normalize(posix.join(posix.dirname(linkPath), unifiedTarget));
-    if (resolved === ".." || resolved.startsWith("../")) {
-      offenders.push({ path: linkPath, target, reason: `escapes repo root (resolves to ${resolved})` });
+    const reason = classifyForeignTarget(linkPath, target);
+    if (reason) {
+      offenders.push({ path: linkPath, target, reason });
     }
   }
   return offenders;

--- a/scripts/ci/check-no-foreign-symlinks.mjs
+++ b/scripts/ci/check-no-foreign-symlinks.mjs
@@ -14,13 +14,17 @@
 //    distinction and reports only the final resolved path). This is the #247
 //    class and is checked directly on the blob string.
 //
-// 2. Actual resolution (kernel realpath + membership). The materialized symlink
-//    is resolved with fs.realpathSync against the working tree and accepted only
-//    when the real path stays inside the canonical repo root and names either a
-//    tracked file or a directory prefix containing tracked files. The kernel
-//    performs resolution, so intermediate symlinks, `..` through symlinks or
-//    files (ENOTDIR), and cycles (ELOOP) need no hand-rolled path logic. The
-//    tracked path set from `git ls-files -s -z` is the membership source of truth.
+// 2. Actual resolution (kernel realpath + membership). First a coherence guard:
+//    the working-tree symlink must equal its committed blob, else realpath would
+//    validate a surface that differs from what gets checked out elsewhere (a
+//    dirty index) — so a divergent working tree is rejected, fail-closed. Then the
+//    materialized symlink is resolved with fs.realpathSync against the working
+//    tree and accepted only when the real path stays inside the canonical repo
+//    root and names either a tracked file or a directory prefix containing tracked
+//    files. The kernel performs resolution, so intermediate symlinks, `..` through
+//    symlinks or files (ENOTDIR), and cycles (ELOOP) need no hand-rolled path
+//    logic. The tracked path set from `git ls-files -s -z` is the membership
+//    source of truth.
 //
 // A symlink must pass BOTH gates. Gate 1 only adds rejections, so it can never
 // turn a realpath rejection into an accept; its worst case is a fail-closed
@@ -51,7 +55,7 @@
 // Run in CI via `npm run lint`.
 
 import { execFileSync } from "node:child_process";
-import { lstatSync, realpathSync } from "node:fs";
+import { lstatSync, readlinkSync, realpathSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { DEFAULT_GIT_BINARY, gitEnv } from "../../plugins/api-reviewers/scripts/lib/git-binary.mjs";
@@ -94,7 +98,7 @@ function errorCode(e) {
   return e && typeof e === "object" && "code" in e ? e.code : "UNKNOWN";
 }
 
-function resolveTrackedSymlink(absPath) {
+function resolveTrackedSymlink(absPath, blobTarget) {
   let st;
   try {
     st = lstatSync(absPath);
@@ -103,6 +107,24 @@ function resolveTrackedSymlink(absPath) {
   }
   if (!st.isSymbolicLink()) {
     return { reason: "not a materialized symlink (is core.symlinks disabled?)" };
+  }
+  // Coherence: gate 2 resolves the WORKING TREE, but a symlink only matters for
+  // what gets COMMITTED. realpath(working tree) is a faithful proxy for the
+  // committed blob only when the two agree. A dirty index can diverge them (a bad
+  // blob staged, then the working-tree link swapped to a benign target), which
+  // would let realpath validate a surface that never ships. Refuse to trust a
+  // divergent working tree — fail closed. In a clean checkout (CI) a materialized
+  // symlink always equals its blob, so this never fires there.
+  let wtTarget;
+  try {
+    wtTarget = readlinkSync(absPath);
+  } catch (e) {
+    return { reason: `unreadable symlink (${errorCode(e)})` };
+  }
+  if (wtTarget !== blobTarget) {
+    return {
+      reason: `working-tree target (${wtTarget}) differs from the committed blob; stage the symlink change`,
+    };
   }
   try {
     return { realPath: realpathSync(absPath) };
@@ -122,7 +144,7 @@ export function findForeignSymlinks(symlinks, repoRoot, isTrackedPath) {
       continue;
     }
     const abs = path.join(repoRoot, linkPath);
-    const resolved = resolveTrackedSymlink(abs);
+    const resolved = resolveTrackedSymlink(abs, target);
     const reason =
       resolved.reason ?? classifyResolvedSymlink(resolved.realPath, repoRoot, isTrackedPath);
     if (reason) {

--- a/scripts/ci/check-no-foreign-symlinks.mjs
+++ b/scripts/ci/check-no-foreign-symlinks.mjs
@@ -10,11 +10,15 @@
 // "bad" forms — drive letters, UNC, \ escapes … — is unbounded whack-a-mole;
 // requiring the single safe shape is the class fix).
 //
-// Accepts: a NON-empty, RELATIVE, forward-slash target that resolves INSIDE the
-//   repo (e.g. ../plugins/api-reviewers, claude-mock.mjs).
-// Rejects everything else: any "\" (Windows separator / non-portable byte on
-//   POSIX — subsumes \x, C:\x, \\UNC, ..\ escapes), a leading "/" or an "X:"
-//   drive qualifier (machine-rooted), and "../" escapes above the repo root.
+// Accepts: a NON-empty, RELATIVE, forward-slash target whose EVERY segment is a
+//   portable filename and which resolves INSIDE the repo on every clone OS
+//   (e.g. ../plugins/api-reviewers, claude-mock.mjs).
+// Rejects everything else: any "\" (Windows separator; subsumes \x, C:\x, \\UNC),
+//   a leading "/" (POSIX absolute), a segment that is not a portable filename
+//   (a Windows-illegal char incl. ":" — which covers drive qualifiers C:foo and
+//   NTFS streams name:stream — or a control byte; a trailing dot/space Windows
+//   strips; or a reserved device name CON/NUL/COM1… that binds to a device, not
+//   a file), and "../" escapes above the repo root.
 //
 // Why this exists (#247): a `node_modules` symlink whose target was the absolute
 // path /Users/.../relay/node_modules was committed to main, because .gitignore's
@@ -46,12 +50,32 @@ import { cleanGitEnv } from "../../plugins/api-reviewers/scripts/lib/git-env.mjs
 
 const TRUSTED_GIT_ENV = gitEnv(cleanGitEnv());
 
+// Windows reserves a FIXED, OS-defined set of device names: any path segment that
+// is one of these (with or without an extension) refers to the DEVICE, not an
+// in-repo file, on a Windows clone. A closed set — not open-ended path syntax.
+const WIN_RESERVED_SEGMENT = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\.|$)/i;
+// Punctuation illegal in a Windows path segment (the "/" separator excepted, and
+// "\" already rejected wholesale). ":" also covers drive qualifiers (C:foo) and
+// NTFS alternate-data-streams (name:stream).
+const WIN_ILLEGAL_PUNCT = '<>:"|?*';
+
+// True when a segment contains a byte illegal in a portable filename: a control
+// byte (NUL .. US, 0x00–0x1f — covers embedded newline/NUL) or Windows-illegal
+// punctuation. A codepoint scan avoids a control-character regex literal.
+function hasNonPortableChar(segment) {
+  for (const ch of segment) {
+    const code = ch.codePointAt(0);
+    if (code <= 0x1f) return true;
+    if (WIN_ILLEGAL_PUNCT.includes(ch)) return true;
+  }
+  return false;
+}
+
 // Classify a tracked symlink's committed target. Returns a human-readable reason
 // when the target is foreign, or null when it is the one safe shape.
 //
-// This is an ALLOWLIST (see file header): rather than enumerate every machine-
-// rooted syntax (POSIX absolute, Windows drive/UNC/root-relative, drive-relative,
-// \ escapes …) — a list that grows every time a new form is found — it requires
+// This is an ALLOWLIST (see file header): rather than enumerate every foreign
+// target syntax — a list that grows every time a new form is found — it requires
 // the single portable, in-repo shape and rejects all else, so unknown forms fail
 // closed. Each rejection below removes a whole sub-class, not one instance.
 function classifyForeignTarget(linkPath, target) {
@@ -60,15 +84,32 @@ function classifyForeignTarget(linkPath, target) {
   }
   // A portable git symlink target uses "/". A backslash is a Windows path
   // separator (and a divergent, non-portable byte on POSIX), so ANY "\" makes the
-  // target non-portable — this single rule subsumes \x, C:\x, \\UNC and ..\ escapes.
+  // target non-portable — this single rule subsumes \x, C:\x and \\UNC.
   if (target.includes("\\")) {
     return "non-portable '\\' separator (symlink targets must use '/')";
   }
-  // Machine-rooted under any OS: a leading "/" (POSIX absolute) or an "X:" drive
-  // qualifier (Windows absolute or drive-relative). A portable relative segment
-  // never begins with "/" or a drive letter, so either is machine-bound.
-  if (posix.isAbsolute(target) || /^[A-Za-z]:/.test(target)) {
-    return "absolute / drive-rooted target (machine-specific)";
+  // A leading "/" is POSIX-absolute → machine-rooted.
+  if (posix.isAbsolute(target)) {
+    return "absolute target (machine-specific)";
+  }
+  // Every segment must be a portable filename that names an in-repo file on EVERY
+  // clone OS. One cohesive rule (vs. enumerating "bad target syntaxes") rejects:
+  // Windows-illegal characters (incl. ":" → drive qualifiers and NTFS streams, and
+  // control bytes), trailing dot/space (Windows silently strips them), and reserved
+  // device names (which resolve to a device, not a file).
+  for (const segment of target.split("/")) {
+    if (segment === "" || segment === "." || segment === "..") {
+      continue; // separators and lexical navigation — handled by containment below
+    }
+    if (hasNonPortableChar(segment)) {
+      return `non-portable character in path segment "${segment}"`;
+    }
+    if (/[ .]$/.test(segment)) {
+      return `path segment "${segment}" ends with a space or dot (non-portable on Windows)`;
+    }
+    if (WIN_RESERVED_SEGMENT.test(segment)) {
+      return `Windows reserved device name "${segment}" (machine-bound, not an in-repo file)`;
+    }
   }
   // Containment: resolve lexically against the link's own directory; it must not
   // climb above the repo root.

--- a/scripts/ci/check-no-foreign-symlinks.mjs
+++ b/scripts/ci/check-no-foreign-symlinks.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+// Repo-hygiene guard: every tracked symlink (git mode 120000) must point to a
+// RELATIVE target that resolves INSIDE the repository.
+//
+// Rejects:
+//   - absolute targets (machine-specific; e.g. /Users/x/relay/node_modules)
+//   - relative targets that escape the repo root via ../
+//
+// Why this exists (#247): a `node_modules` symlink whose target was the absolute
+// path /Users/.../relay/node_modules was committed to main, because .gitignore's
+// `node_modules/` (directory-only) never matched the symlink form. That ignore
+// rule is now corrected, but an ignore rule NEVER blocks a path that is
+// explicitly `git add`-ed. This check closes the recurrence class for ALL
+// symlinks, regardless of .gitignore form — it catches the consequence (a
+// foreign/escaping target) rather than any single pattern. Subsumes both the
+// per-pattern .gitignore gap and the reintroduction risk.
+//
+// Reads the committed blob (not the working-tree link) so it works on a fresh
+// clone where the link target may be absent. Operates on the git repo enclosing
+// the current working directory, so it is correct in worktrees and testable
+// against a throwaway repo.
+//
+// Run in CI via `npm run lint`.
+
+import { execFileSync } from "node:child_process";
+import { posix } from "node:path";
+import { pathToFileURL } from "node:url";
+
+// Absolute target detection across POSIX + Windows forms. Git stores the symlink
+// target verbatim; reject anything machine-rooted.
+function isAbsoluteTarget(target) {
+  return (
+    target.startsWith("/") || // POSIX absolute
+    /^[A-Za-z]:[\\/]/.test(target) || // Windows drive (C:\ or C:/)
+    target.startsWith("\\\\") // Windows UNC
+  );
+}
+
+// Pure core: given tracked symlink entries [{ path, target }] (repo-relative,
+// POSIX paths), return offenders [{ path, target, reason }].
+export function findForeignSymlinks(entries) {
+  const offenders = [];
+  for (const { path: linkPath, target } of entries) {
+    if (isAbsoluteTarget(target)) {
+      offenders.push({ path: linkPath, target, reason: "absolute target (machine-specific)" });
+      continue;
+    }
+    // Resolve the relative target lexically against the link's own directory.
+    const resolved = posix.normalize(posix.join(posix.dirname(linkPath), target));
+    if (resolved === ".." || resolved.startsWith("../")) {
+      offenders.push({ path: linkPath, target, reason: `escapes repo root (resolves to ${resolved})` });
+    }
+  }
+  return offenders;
+}
+
+// Parse `git ls-files -s` output → [{ mode, sha, path }].
+// Line format: "<mode> <sha> <stage>\t<path>". Paths may contain spaces, so the
+// path is everything after the first tab.
+export function parseLsFilesStage(output) {
+  const out = [];
+  for (const line of output.split("\n")) {
+    if (!line) continue;
+    const tab = line.indexOf("\t");
+    if (tab === -1) continue;
+    const meta = line.slice(0, tab).split(/\s+/);
+    out.push({ mode: meta[0], sha: meta[1], path: line.slice(tab + 1) });
+  }
+  return out;
+}
+
+function makeRunGit(cwd) {
+  return (args) =>
+    execFileSync("git", args, { cwd, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
+}
+
+// Collect tracked symlinks and their committed targets via git.
+export function collectTrackedSymlinks(runGit) {
+  const symlinks = parseLsFilesStage(runGit(["ls-files", "-s"])).filter((e) => e.mode === "120000");
+  return symlinks.map((e) => ({
+    path: e.path,
+    // A symlink blob's content IS its target string (no trailing newline).
+    target: runGit(["cat-file", "blob", e.sha]).replace(/\r?\n$/, ""),
+  }));
+}
+
+export function main(cwd = process.cwd()) {
+  // Anchor to the enclosing git toplevel so `git ls-files` covers the whole repo
+  // regardless of the directory the check was invoked from.
+  const toplevel = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+    cwd,
+    encoding: "utf8",
+  }).trim();
+  const runGit = makeRunGit(toplevel);
+
+  const entries = collectTrackedSymlinks(runGit);
+  const offenders = findForeignSymlinks(entries);
+  if (offenders.length > 0) {
+    process.stderr.write("Foreign-symlink check FAILED:\n");
+    for (const o of offenders) {
+      process.stderr.write(`  ✗ ${o.path} -> ${o.target}  (${o.reason})\n`);
+    }
+    process.stderr.write(
+      "\nTracked symlinks must use a RELATIVE target that resolves inside the repo.\n" +
+        "An absolute or escaping target is machine-specific and breaks other clones (see #247).\n"
+    );
+    process.exit(1);
+  }
+  process.stdout.write(`✓ All ${entries.length} tracked symlink(s) resolve inside the repo\n`);
+}
+
+// Execute only when invoked directly (not when imported by tests).
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/ci/check-no-foreign-symlinks.mjs
+++ b/scripts/ci/check-no-foreign-symlinks.mjs
@@ -1,29 +1,30 @@
 #!/usr/bin/env node
-// Repo-hygiene guard: every tracked symlink (git mode 120000) must resolve to a
-// path that is itself tracked by this repository.
+// Repo-hygiene guard: every tracked symlink (git mode 120000) must resolve via
+// the OS to tracked repository contents.
 //
-// Model: membership, fail-closed. The committed symlink blob is the same bytes
-// on every clone, but a target that is not represented by tracked repo contents
-// may be machine-specific, ignored, or absent on a fresh checkout. A tracked
-// symlink is accepted only when its non-empty, relative target resolves to a
-// tracked file or to a directory prefix containing tracked files. The tracked
-// path set from `git ls-files -s -z` is the single source of truth.
+// Model: kernel realpath + membership, fail-closed. Each tracked symlink is
+// resolved with fs.realpathSync against the materialized working tree and
+// accepted only when the resolved real path stays inside the canonical repo root
+// and names either a tracked file or a directory prefix containing tracked files.
+// The kernel performs resolution, so intermediate symlinks, `..` through
+// symlinks or files (ENOTDIR), cycles (ELOOP), and absolute/escaping targets are
+// handled without hand-rolled path logic. The tracked path set from
+// `git ls-files -s -z` is the membership source of truth.
 //
-// Empty and POSIX-absolute targets are explicit early rejects. All other foreign
-// forms are rejected by membership instead of by predicting every bad filename
-// or platform-specific path spelling.
+// This assumes a clean, materialized checkout, which is the CI case. A symlink
+// whose target is absent, unresolvable, escaping, untracked, or not materialized
+// as a real symlink is rejected.
 //
 // Why this exists (#247): a `node_modules` symlink whose target was the absolute
 // path /Users/.../relay/node_modules was committed to main, because .gitignore's
 // `node_modules/` (directory-only) never matched the symlink form. That ignore
 // rule is now corrected, but an ignore rule NEVER blocks a path that is
 // explicitly `git add`-ed. This check closes the recurrence class for ALL
-// symlinks by requiring their targets to resolve to tracked repo contents.
+// symlinks by requiring the kernel-resolved target to remain inside tracked repo
+// contents. The committed symlink blob is kept only for offender display.
 //
-// Reads the committed blob (not the working-tree link) so it works on a fresh
-// clone where the link target may be absent. Operates on the git repo enclosing
-// the current working directory, so it is correct in worktrees and testable
-// against a throwaway repo.
+// Operates on the git repo enclosing the current working directory, so it is
+// correct in worktrees and testable against a throwaway repo.
 //
 // Git is invoked via the absolute DEFAULT_GIT_BINARY with a fixed safe PATH
 // (the repo-canonical trusted-binary pattern; see provider-readiness-manifest),
@@ -34,7 +35,8 @@
 // Run in CI via `npm run lint`.
 
 import { execFileSync } from "node:child_process";
-import { posix } from "node:path";
+import { lstatSync, realpathSync } from "node:fs";
+import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { DEFAULT_GIT_BINARY, gitEnv } from "../../plugins/api-reviewers/scripts/lib/git-binary.mjs";
 import { cleanGitEnv } from "../../plugins/api-reviewers/scripts/lib/git-env.mjs";
@@ -42,32 +44,47 @@ import { cleanGitEnv } from "../../plugins/api-reviewers/scripts/lib/git-env.mjs
 const TRUSTED_GIT_ENV = gitEnv(cleanGitEnv());
 
 // isTrackedPath: (repoRelativePosixPath) => boolean
-function classifyForeignTarget(linkPath, target, isTrackedPath) {
-  if (target === "") {
-    return "empty target";
+export function classifyResolvedSymlink(realPath, repoRoot, isTrackedPath) {
+  if (realPath !== repoRoot && !realPath.startsWith(repoRoot + path.sep)) {
+    return `resolves outside the repo (${realPath})`;
   }
-  // MUST stay explicit and BEFORE the join: posix.join(".", "/plugins/x") strips the
-  // leading "/", which would alias an absolute target onto the tracked relative path
-  // "plugins/x" and false-green. (Proven.)
-  if (posix.isAbsolute(target)) {
-    return "absolute target (machine-specific)";
-  }
-  // A directory target may carry a trailing "/" (e.g. "pkg/sub/"); posix.normalize keeps
-  // it, but "pkg/sub/" and "pkg/sub" name the same directory. Strip it before membership.
-  // Safe: posix-absolute targets are already rejected above, so `resolved` is never "/".
-  const resolved = posix.normalize(posix.join(posix.dirname(linkPath), target)).replace(/\/+$/, "");
-  if (!isTrackedPath(resolved)) {
-    return `does not resolve to a tracked in-repo file (resolves to ${resolved})`;
+  const rel = path.relative(repoRoot, realPath).split(path.sep).join("/");
+  if (rel !== "" && !isTrackedPath(rel)) {
+    return `resolves to an untracked path (${rel})`;
   }
   return null;
 }
 
-// Pure core: given tracked symlink entries [{ path, target }] (repo-relative,
-// POSIX paths), return offenders [{ path, target, reason }].
-export function findForeignSymlinks(entries, isTrackedPath) {
+function errorCode(e) {
+  return e && typeof e === "object" && "code" in e ? e.code : "UNKNOWN";
+}
+
+function resolveTrackedSymlink(absPath) {
+  let st;
+  try {
+    st = lstatSync(absPath);
+  } catch (e) {
+    return { reason: `missing from the working tree (${errorCode(e)})` };
+  }
+  if (!st.isSymbolicLink()) {
+    return { reason: "not a materialized symlink (is core.symlinks disabled?)" };
+  }
+  try {
+    return { realPath: realpathSync(absPath) };
+  } catch (e) {
+    return { reason: `unresolvable (${errorCode(e)})` };
+  }
+}
+
+// symlinks: [{ path, target }] where target is kept only for the offender message.
+// repoRoot: canonical absolute repo root.
+export function findForeignSymlinks(symlinks, repoRoot, isTrackedPath) {
   const offenders = [];
-  for (const { path: linkPath, target } of entries) {
-    const reason = classifyForeignTarget(linkPath, target, isTrackedPath);
+  for (const { path: linkPath, target } of symlinks) {
+    const abs = path.join(repoRoot, linkPath);
+    const resolved = resolveTrackedSymlink(abs);
+    const reason =
+      resolved.reason ?? classifyResolvedSymlink(resolved.realPath, repoRoot, isTrackedPath);
     if (reason) {
       offenders.push({ path: linkPath, target, reason });
     }
@@ -137,10 +154,11 @@ export function main(cwd = process.cwd()) {
     env: TRUSTED_GIT_ENV,
     timeout: 15000,
   }).trim();
+  const repoRoot = realpathSync(toplevel);
   const runGit = makeRunGit(toplevel);
 
   const { symlinks, isTrackedPath } = collectTrackedSymlinkState(runGit);
-  const offenders = findForeignSymlinks(symlinks, isTrackedPath);
+  const offenders = findForeignSymlinks(symlinks, repoRoot, isTrackedPath);
   if (offenders.length > 0) {
     process.stderr.write("Foreign-symlink check FAILED:\n");
     for (const o of offenders) {
@@ -157,5 +175,5 @@ export function main(cwd = process.cwd()) {
 
 // Execute only when invoked directly (not when imported by tests).
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  main();
+  main(process.argv[2]);
 }

--- a/scripts/ci/check-no-foreign-symlinks.mjs
+++ b/scripts/ci/check-no-foreign-symlinks.mjs
@@ -146,10 +146,13 @@ export function collectTrackedSymlinks(runGit) {
   return collectTrackedSymlinkState(runGit).symlinks;
 }
 
-export function main(cwd = process.cwd()) {
+export function main() {
   // Anchor to the enclosing git toplevel so `git ls-files` covers the whole repo
-  // regardless of the directory the check was invoked from.
-  const toplevel = execFileSync(DEFAULT_GIT_BINARY, ["-C", cwd, "rev-parse", "--show-toplevel"], {
+  // regardless of the directory the check was invoked from. Git runs in the
+  // process's own working directory — no untrusted path argument is accepted, so
+  // a `node check-no-foreign-symlinks.mjs <path>` invocation cannot steer git at
+  // an arbitrary location.
+  const toplevel = execFileSync(DEFAULT_GIT_BINARY, ["rev-parse", "--show-toplevel"], {
     encoding: "utf8",
     env: TRUSTED_GIT_ENV,
     timeout: 15000,
@@ -175,5 +178,5 @@ export function main(cwd = process.cwd()) {
 
 // Execute only when invoked directly (not when imported by tests).
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  main(process.argv[2]);
+  main();
 }

--- a/scripts/ci/check-no-foreign-symlinks.mjs
+++ b/scripts/ci/check-no-foreign-symlinks.mjs
@@ -115,6 +115,12 @@ function resolveTrackedSymlink(absPath, blobTarget) {
   // would let realpath validate a surface that never ships. Refuse to trust a
   // divergent working tree — fail closed. In a clean checkout (CI) a materialized
   // symlink always equals its blob, so this never fires there.
+  //
+  // The comparison is exact-string. A path-equivalent but non-identical
+  // working-tree target (e.g. `./x` vs a staged `x`) is therefore also treated as
+  // dirty — that is not a guard defect: the working tree genuinely differs from
+  // the index, and the rejection message tells the developer to `git add` the
+  // symlink so the check sees the target they intend to commit.
   let wtTarget;
   try {
     wtTarget = readlinkSync(absPath);

--- a/scripts/ci/check-no-foreign-symlinks.mjs
+++ b/scripts/ci/check-no-foreign-symlinks.mjs
@@ -1,33 +1,24 @@
 #!/usr/bin/env node
-// Repo-hygiene guard: every tracked symlink (git mode 120000) must point to a
-// RELATIVE target that resolves INSIDE the repository.
+// Repo-hygiene guard: every tracked symlink (git mode 120000) must resolve to a
+// path that is itself tracked by this repository.
 //
-// Model: ALLOWLIST, fail-closed. The committed blob is the same bytes on every
-// clone, and we cannot resolve a foreign machine path against clones we don't
-// have — so a target is ACCEPTED only when it is the one provably-portable,
-// in-repo shape, and EVERYTHING ELSE is rejected. New or exotic absolute/escape
-// syntaxes therefore fail closed without a per-form detector (a blocklist of
-// "bad" forms — drive letters, UNC, \ escapes … — is unbounded whack-a-mole;
-// requiring the single safe shape is the class fix).
+// Model: membership, fail-closed. The committed symlink blob is the same bytes
+// on every clone, but a target that is not represented by tracked repo contents
+// may be machine-specific, ignored, or absent on a fresh checkout. A tracked
+// symlink is accepted only when its non-empty, relative target resolves to a
+// tracked file or to a directory prefix containing tracked files. The tracked
+// path set from `git ls-files -s -z` is the single source of truth.
 //
-// Accepts: a NON-empty, RELATIVE, forward-slash target whose EVERY segment is a
-//   portable filename and which resolves INSIDE the repo on every clone OS
-//   (e.g. ../plugins/api-reviewers, claude-mock.mjs).
-// Rejects everything else: any "\" (Windows separator; subsumes \x, C:\x, \\UNC),
-//   a leading "/" (POSIX absolute), a segment that is not a portable filename
-//   (a Windows-illegal char incl. ":" — which covers drive qualifiers C:foo and
-//   NTFS streams name:stream — or a control byte; a trailing dot/space Windows
-//   strips; or a reserved device name CON/NUL/COM1… that binds to a device, not
-//   a file), and "../" escapes above the repo root.
+// Empty and POSIX-absolute targets are explicit early rejects. All other foreign
+// forms are rejected by membership instead of by predicting every bad filename
+// or platform-specific path spelling.
 //
 // Why this exists (#247): a `node_modules` symlink whose target was the absolute
 // path /Users/.../relay/node_modules was committed to main, because .gitignore's
 // `node_modules/` (directory-only) never matched the symlink form. That ignore
 // rule is now corrected, but an ignore rule NEVER blocks a path that is
 // explicitly `git add`-ed. This check closes the recurrence class for ALL
-// symlinks, regardless of .gitignore form — it catches the consequence (a
-// foreign/escaping target) rather than any single pattern. Subsumes both the
-// per-pattern .gitignore gap and the reintroduction risk.
+// symlinks by requiring their targets to resolve to tracked repo contents.
 //
 // Reads the committed blob (not the working-tree link) so it works on a fresh
 // clone where the link target may be absent. Operates on the git repo enclosing
@@ -50,82 +41,33 @@ import { cleanGitEnv } from "../../plugins/api-reviewers/scripts/lib/git-env.mjs
 
 const TRUSTED_GIT_ENV = gitEnv(cleanGitEnv());
 
-// Windows reserves a FIXED, OS-defined set of device names: any path segment that
-// is one of these (with or without an extension) refers to the DEVICE, not an
-// in-repo file, on a Windows clone. A closed set — not open-ended path syntax.
-const WIN_RESERVED_SEGMENT = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\.|$)/i;
-// Punctuation illegal in a Windows path segment (the "/" separator excepted, and
-// "\" already rejected wholesale). ":" also covers drive qualifiers (C:foo) and
-// NTFS alternate-data-streams (name:stream).
-const WIN_ILLEGAL_PUNCT = '<>:"|?*';
-
-// True when a segment contains a byte illegal in a portable filename: a control
-// byte (NUL .. US, 0x00–0x1f — covers embedded newline/NUL) or Windows-illegal
-// punctuation. A codepoint scan avoids a control-character regex literal.
-function hasNonPortableChar(segment) {
-  for (const ch of segment) {
-    const code = ch.codePointAt(0);
-    if (code <= 0x1f) return true;
-    if (WIN_ILLEGAL_PUNCT.includes(ch)) return true;
-  }
-  return false;
-}
-
-// Classify a tracked symlink's committed target. Returns a human-readable reason
-// when the target is foreign, or null when it is the one safe shape.
-//
-// This is an ALLOWLIST (see file header): rather than enumerate every foreign
-// target syntax — a list that grows every time a new form is found — it requires
-// the single portable, in-repo shape and rejects all else, so unknown forms fail
-// closed. Each rejection below removes a whole sub-class, not one instance.
-function classifyForeignTarget(linkPath, target) {
+// isTrackedPath: (repoRelativePosixPath) => boolean
+function classifyForeignTarget(linkPath, target, isTrackedPath) {
   if (target === "") {
     return "empty target";
   }
-  // A portable git symlink target uses "/". A backslash is a Windows path
-  // separator (and a divergent, non-portable byte on POSIX), so ANY "\" makes the
-  // target non-portable — this single rule subsumes \x, C:\x and \\UNC.
-  if (target.includes("\\")) {
-    return "non-portable '\\' separator (symlink targets must use '/')";
-  }
-  // A leading "/" is POSIX-absolute → machine-rooted.
+  // MUST stay explicit and BEFORE the join: posix.join(".", "/plugins/x") strips the
+  // leading "/", which would alias an absolute target onto the tracked relative path
+  // "plugins/x" and false-green. (Proven.)
   if (posix.isAbsolute(target)) {
     return "absolute target (machine-specific)";
   }
-  // Every segment must be a portable filename that names an in-repo file on EVERY
-  // clone OS. One cohesive rule (vs. enumerating "bad target syntaxes") rejects:
-  // Windows-illegal characters (incl. ":" → drive qualifiers and NTFS streams, and
-  // control bytes), trailing dot/space (Windows silently strips them), and reserved
-  // device names (which resolve to a device, not a file).
-  for (const segment of target.split("/")) {
-    if (segment === "" || segment === "." || segment === "..") {
-      continue; // separators and lexical navigation — handled by containment below
-    }
-    if (hasNonPortableChar(segment)) {
-      return `non-portable character in path segment "${segment}"`;
-    }
-    if (/[ .]$/.test(segment)) {
-      return `path segment "${segment}" ends with a space or dot (non-portable on Windows)`;
-    }
-    if (WIN_RESERVED_SEGMENT.test(segment)) {
-      return `Windows reserved device name "${segment}" (machine-bound, not an in-repo file)`;
-    }
-  }
-  // Containment: resolve lexically against the link's own directory; it must not
-  // climb above the repo root.
-  const resolved = posix.normalize(posix.join(posix.dirname(linkPath), target));
-  if (resolved === ".." || resolved.startsWith("../")) {
-    return `escapes repo root (resolves to ${resolved})`;
+  // A directory target may carry a trailing "/" (e.g. "pkg/sub/"); posix.normalize keeps
+  // it, but "pkg/sub/" and "pkg/sub" name the same directory. Strip it before membership.
+  // Safe: posix-absolute targets are already rejected above, so `resolved` is never "/".
+  const resolved = posix.normalize(posix.join(posix.dirname(linkPath), target)).replace(/\/+$/, "");
+  if (!isTrackedPath(resolved)) {
+    return `does not resolve to a tracked in-repo file (resolves to ${resolved})`;
   }
   return null;
 }
 
 // Pure core: given tracked symlink entries [{ path, target }] (repo-relative,
 // POSIX paths), return offenders [{ path, target, reason }].
-export function findForeignSymlinks(entries) {
+export function findForeignSymlinks(entries, isTrackedPath) {
   const offenders = [];
   for (const { path: linkPath, target } of entries) {
-    const reason = classifyForeignTarget(linkPath, target);
+    const reason = classifyForeignTarget(linkPath, target, isTrackedPath);
     if (reason) {
       offenders.push({ path: linkPath, target, reason });
     }
@@ -158,14 +100,33 @@ function makeRunGit(cwd) {
     });
 }
 
+function makeIsTrackedPath(trackedPaths) {
+  return (p) => {
+    if (p === "" || p === ".") return true;
+    if (trackedPaths.has(p)) return true;
+    for (const f of trackedPaths) {
+      if (f.startsWith(p + "/")) return true;
+    }
+    return false;
+  };
+}
+
+function collectTrackedSymlinkState(runGit) {
+  const entries = parseLsFilesStage(runGit(["ls-files", "-s", "-z"]));
+  const trackedPaths = new Set(entries.map((e) => e.path));
+  const symlinks = entries
+    .filter((e) => e.mode === "120000")
+    .map((e) => ({
+      path: e.path,
+      // A symlink blob's content IS its target string.
+      target: runGit(["cat-file", "blob", e.sha]),
+    }));
+  return { symlinks, isTrackedPath: makeIsTrackedPath(trackedPaths) };
+}
+
 // Collect tracked symlinks and their committed targets via git.
 export function collectTrackedSymlinks(runGit) {
-  const symlinks = parseLsFilesStage(runGit(["ls-files", "-s", "-z"])).filter((e) => e.mode === "120000");
-  return symlinks.map((e) => ({
-    path: e.path,
-    // A symlink blob's content IS its target string (no trailing newline).
-    target: runGit(["cat-file", "blob", e.sha]).replace(/\r?\n$/, ""),
-  }));
+  return collectTrackedSymlinkState(runGit).symlinks;
 }
 
 export function main(cwd = process.cwd()) {
@@ -178,20 +139,20 @@ export function main(cwd = process.cwd()) {
   }).trim();
   const runGit = makeRunGit(toplevel);
 
-  const entries = collectTrackedSymlinks(runGit);
-  const offenders = findForeignSymlinks(entries);
+  const { symlinks, isTrackedPath } = collectTrackedSymlinkState(runGit);
+  const offenders = findForeignSymlinks(symlinks, isTrackedPath);
   if (offenders.length > 0) {
     process.stderr.write("Foreign-symlink check FAILED:\n");
     for (const o of offenders) {
       process.stderr.write(`  ✗ ${o.path} -> ${o.target}  (${o.reason})\n`);
     }
     process.stderr.write(
-      "\nTracked symlinks must use a RELATIVE target that resolves inside the repo.\n" +
-        "An absolute or escaping target is machine-specific and breaks other clones (see #247).\n"
+      "\nTracked symlinks must use a relative target that resolves to tracked repo contents.\n" +
+        "An absolute or untracked target is machine-specific and breaks other clones (see #247).\n"
     );
     process.exit(1);
   }
-  process.stdout.write(`✓ All ${entries.length} tracked symlink(s) resolve inside the repo\n`);
+  process.stdout.write(`✓ All ${symlinks.length} tracked symlink(s) resolve inside the repo\n`);
 }
 
 // Execute only when invoked directly (not when imported by tests).

--- a/scripts/ci/check-no-foreign-symlinks.mjs
+++ b/scripts/ci/check-no-foreign-symlinks.mjs
@@ -2,14 +2,30 @@
 // Repo-hygiene guard: every tracked symlink (git mode 120000) must resolve via
 // the OS to tracked repository contents.
 //
-// Model: kernel realpath + membership, fail-closed. Each tracked symlink is
-// resolved with fs.realpathSync against the materialized working tree and
-// accepted only when the resolved real path stays inside the canonical repo root
-// and names either a tracked file or a directory prefix containing tracked files.
-// The kernel performs resolution, so intermediate symlinks, `..` through
-// symlinks or files (ENOTDIR), cycles (ELOOP), and absolute/escaping targets are
-// handled without hand-rolled path logic. The tracked path set from
-// `git ls-files -s -z` is the membership source of truth.
+// Model: two complementary, fail-closed gates per tracked symlink.
+//
+// 1. Portability of form (pure, on the committed blob target). A target is
+//    portable across clones only when it is relative AND, resolved lexically
+//    against the link's own directory, stays within the repo root. An absolute
+//    target is pinned to one machine's filesystem; a `..` target that climbs
+//    above the root depends on whatever sits outside the repo on a given clone.
+//    Both can still resolve "inside" on the checkout that authored them, so a
+//    realpath check alone cannot see them (realpath erases the absolute/relative
+//    distinction and reports only the final resolved path). This is the #247
+//    class and is checked directly on the blob string.
+//
+// 2. Actual resolution (kernel realpath + membership). The materialized symlink
+//    is resolved with fs.realpathSync against the working tree and accepted only
+//    when the real path stays inside the canonical repo root and names either a
+//    tracked file or a directory prefix containing tracked files. The kernel
+//    performs resolution, so intermediate symlinks, `..` through symlinks or
+//    files (ENOTDIR), and cycles (ELOOP) need no hand-rolled path logic. The
+//    tracked path set from `git ls-files -s -z` is the membership source of truth.
+//
+// A symlink must pass BOTH gates. Gate 1 only adds rejections, so it can never
+// turn a realpath rejection into an accept; its worst case is a fail-closed
+// rejection of an exotic target that escapes lexically yet stays in-repo via an
+// intermediate symlink — acceptable hygiene, never a silent accept.
 //
 // This assumes a clean, materialized checkout, which is the CI case. A symlink
 // whose target is absent, unresolvable, escaping, untracked, or not materialized
@@ -43,6 +59,25 @@ import { cleanGitEnv } from "../../plugins/api-reviewers/scripts/lib/git-env.mjs
 
 const TRUSTED_GIT_ENV = gitEnv(cleanGitEnv());
 
+// Gate 1 — portability of the committed target FORM (pure; no filesystem).
+// linkPath is the git-tracked POSIX path of the symlink; target is its blob.
+// Returns a rejection reason, or null when the form is portable. Because this is
+// AND-ed with the realpath gate it can only add rejections, never relax one.
+export function classifyTargetPortability(linkPath, target) {
+  if (path.posix.isAbsolute(target)) {
+    return "absolute target (machine-specific; breaks other clones)";
+  }
+  // Resolve the target lexically (plain path arithmetic, no symlink-following)
+  // against the link's own directory. A result that climbs to or above the repo
+  // root cannot be relocated to another clone's checkout root.
+  const resolvedRel = path.posix.join(path.posix.dirname(linkPath), target);
+  if (resolvedRel === ".." || resolvedRel.startsWith("../")) {
+    return `target escapes the repo root (${target})`;
+  }
+  return null;
+}
+
+// Gate 2 — actual resolution + membership.
 // isTrackedPath: (repoRelativePosixPath) => boolean
 export function classifyResolvedSymlink(realPath, repoRoot, isTrackedPath) {
   if (realPath !== repoRoot && !realPath.startsWith(repoRoot + path.sep)) {
@@ -81,6 +116,11 @@ function resolveTrackedSymlink(absPath) {
 export function findForeignSymlinks(symlinks, repoRoot, isTrackedPath) {
   const offenders = [];
   for (const { path: linkPath, target } of symlinks) {
+    const portability = classifyTargetPortability(linkPath, target);
+    if (portability) {
+      offenders.push({ path: linkPath, target, reason: portability });
+      continue;
+    }
     const abs = path.join(repoRoot, linkPath);
     const resolved = resolveTrackedSymlink(abs);
     const reason =

--- a/tests/unit/no-foreign-symlinks.test.mjs
+++ b/tests/unit/no-foreign-symlinks.test.mjs
@@ -251,6 +251,48 @@ test("CLI rejects a non-portable staged blob even when the working tree was swap
   });
 });
 
+// Coherence gate: a relative-but-invalid blob (gate 1 passes the FORM) cannot be
+// masked by swapping the working-tree symlink to a benign target. Gate 2 first
+// requires the working tree to equal the committed blob, else it fails closed.
+test("CLI rejects a dirty symlink whose working tree differs from the staged blob", () => {
+  withFixtureRepo("dirty-relative-blob-", (dir) => {
+    writeFileSync(path.join(dir, "safe.txt"), "safe\n", "utf8");
+    symlinkSync("missing.txt", path.join(dir, "link")); // stage a relative-but-broken blob
+    fixtureGit(dir, ["add", "-A"]);
+    unlinkSync(path.join(dir, "link"));
+    symlinkSync("safe.txt", path.join(dir, "link")); // swap working tree to a valid target
+
+    const combined = checkFails(dir);
+    assert.match(combined, /link -> missing\.txt\s+\(working-tree target \(safe\.txt\) differs from the committed blob/);
+  });
+});
+
+test("CLI rejects a dirty symlink with an empty staged blob masked by the working tree", () => {
+  withFixtureRepo("dirty-empty-blob-", (dir) => {
+    writeFileSync(path.join(dir, "safe.txt"), "safe\n", "utf8");
+    const emptySha = fixtureGit(dir, ["hash-object", "-w", "--stdin"], { input: "" }).stdout.trim();
+    fixtureGit(dir, ["update-index", "--add", "--cacheinfo", `120000,${emptySha},link`]);
+    symlinkSync("safe.txt", path.join(dir, "link")); // working tree disagrees with the empty blob
+
+    const combined = checkFails(dir);
+    assert.match(combined, /\(working-tree target \(safe\.txt\) differs from the committed blob/);
+  });
+});
+
+// The flip side / CI guarantee: on a CLEAN checkout (working tree == blob), the
+// same broken blob IS caught — so a bad symlink cannot survive CI even though the
+// local dirty case above is what the coherence gate fails closed on.
+test("CLI rejects a broken relative blob on a clean checkout (the CI guarantee)", () => {
+  withFixtureRepo("clean-broken-blob-", (dir) => {
+    writeFileSync(path.join(dir, "safe.txt"), "safe\n", "utf8");
+    symlinkSync("missing.txt", path.join(dir, "link")); // points at a non-existent in-repo path
+    fixtureGit(dir, ["add", "-A"]); // working tree already matches the blob (clean)
+
+    const combined = checkFails(dir);
+    assert.match(combined, /link -> missing\.txt\s+\(unresolvable/);
+  });
+});
+
 test("CLI rejects an intermediate-symlink '..' escape (real git repo)", () => {
   withFixtureRepo("intermediate-symlink-", (dir) => {
     writeFileSync(path.join(dir, "safe"), "root safe\n", "utf8");

--- a/tests/unit/no-foreign-symlinks.test.mjs
+++ b/tests/unit/no-foreign-symlinks.test.mjs
@@ -1,13 +1,14 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
   classifyResolvedSymlink,
+  classifyTargetPortability,
   parseLsFilesStage,
   collectTrackedSymlinks,
 } from "../../scripts/ci/check-no-foreign-symlinks.mjs";
@@ -77,6 +78,42 @@ test("classifyResolvedSymlink: rejects a resolved path inside the repo but untra
   assert.match(classifyResolvedSymlink("/repo/nope", ROOT, tracked(["sub/f.txt"])), /untracked/);
 });
 
+// ---------------------------------------------------------------------------
+// Gate 1 (pure): the committed target FORM is portable iff it is relative and
+// lexically stays within the repo root. realpath cannot see this class (#247),
+// because an absolute or escape-and-re-enter target still resolves inside on the
+// checkout that authored it.
+// ---------------------------------------------------------------------------
+
+test("classifyTargetPortability: accepts a same-directory relative target", () => {
+  assert.equal(classifyTargetPortability("tests/smoke/claude", "claude-mock.mjs"), null);
+});
+
+test("classifyTargetPortability: accepts a relative target that stays inside via ..", () => {
+  assert.equal(classifyTargetPortability("relay/relay-api-reviewers", "../plugins/api-reviewers"), null);
+});
+
+test("classifyTargetPortability: rejects an absolute target (machine-specific)", () => {
+  assert.match(classifyTargetPortability("abslink", "/private/var/tmp/x/safe.txt"), /absolute target/);
+});
+
+test("classifyTargetPortability: rejects an absolute target pointing at a directory", () => {
+  assert.match(classifyTargetPortability("absdir", "/private/var/tmp/x/pkg"), /absolute target/);
+});
+
+test("classifyTargetPortability: rejects a target that escapes the repo root", () => {
+  assert.match(classifyTargetPortability("escaper", "../../outside"), /escapes the repo root/);
+});
+
+test("classifyTargetPortability: rejects an escape-and-re-enter-by-name target", () => {
+  // Resolves inside on a checkout named `relay`, but breaks on any other clone.
+  assert.match(classifyTargetPortability("reenter", "../relay/safe.txt"), /escapes the repo root/);
+});
+
+test("classifyTargetPortability: rejects a bare .. target", () => {
+  assert.match(classifyTargetPortability("up", ".."), /escapes the repo root/);
+});
+
 test("parseLsFilesStage: parses NUL-delimited (-z) records; tolerates spaces in paths", () => {
   const out =
     "120000 be9723c077bfb81c7747f25dfa964da1f3134e24 0\tnode_modules\0" +
@@ -143,7 +180,33 @@ test("CLI rejects the #247 absolute symlink target and names the offender", () =
 
     const combined = checkFails(dir);
     assert.match(combined, /bad-link ->/);
-    assert.match(combined, /(resolves outside the repo|unresolvable)/);
+    assert.match(combined, /absolute target/);
+  });
+});
+
+// The #247 portability class proper: an ABSOLUTE target that happens to point at
+// tracked content inside the *current* checkout. realpath resolves it inside, so
+// gate 2 alone would accept it; gate 1 rejects it on form.
+test("CLI rejects an absolute symlink that resolves to a tracked file in this checkout", () => {
+  withFixtureRepo("absolute-inside-file-", (dir) => {
+    writeFileSync(path.join(dir, "safe.txt"), "safe\n", "utf8");
+    symlinkSync(path.join(dir, "safe.txt"), path.join(dir, "abslink"));
+    fixtureGit(dir, ["add", "-A"]);
+
+    const combined = checkFails(dir);
+    assert.match(combined, /abslink ->.*\(absolute target/s);
+  });
+});
+
+test("CLI rejects an absolute symlink that resolves to a tracked directory in this checkout", () => {
+  withFixtureRepo("absolute-inside-dir-", (dir) => {
+    mkdirSync(path.join(dir, "pkg", "inside"), { recursive: true });
+    writeFileSync(path.join(dir, "pkg", "inside", "f.txt"), "x\n", "utf8");
+    symlinkSync(path.join(dir, "pkg"), path.join(dir, "absdir"));
+    fixtureGit(dir, ["add", "-A"]);
+
+    const combined = checkFails(dir);
+    assert.match(combined, /absdir ->.*\(absolute target/s);
   });
 });
 
@@ -153,7 +216,38 @@ test("CLI rejects a relative symlink that resolves outside tracked paths", () =>
     fixtureGit(dir, ["add", "-A"]);
 
     const combined = checkFails(dir);
-    assert.match(combined, /escaper -> \.\.\/\.\.\/outside-the-repo\s+\((unresolvable|resolves outside the repo)/);
+    assert.match(combined, /escaper -> \.\.\/\.\.\/outside-the-repo\s+\(target escapes the repo root/);
+  });
+});
+
+// Escape-and-re-enter by the checkout's directory name: realpath resolves it
+// inside on a repo cloned under that exact name, but it breaks anywhere else.
+test("CLI rejects a relative symlink that escapes then re-enters by the repo basename", () => {
+  withFixtureRepo("reenter-symlink-", (dir) => {
+    writeFileSync(path.join(dir, "safe.txt"), "safe\n", "utf8");
+    const base = path.basename(dir);
+    symlinkSync(`../${base}/safe.txt`, path.join(dir, "reenter"));
+    fixtureGit(dir, ["add", "-A"]);
+
+    const combined = checkFails(dir);
+    assert.match(combined, /reenter ->.*\(target escapes the repo root/s);
+  });
+});
+
+// Gate 1 validates the committed BLOB, so a dirty working tree cannot mask a
+// non-portable staged symlink: the index blob is absolute even though the
+// working-tree link was swapped to a benign relative target (gate 2 alone, which
+// resolves the working tree, would accept it).
+test("CLI rejects a non-portable staged blob even when the working tree was swapped", () => {
+  withFixtureRepo("dirty-blob-symlink-", (dir) => {
+    writeFileSync(path.join(dir, "safe.txt"), "safe\n", "utf8");
+    symlinkSync("/etc/passwd", path.join(dir, "link")); // stage an absolute blob
+    fixtureGit(dir, ["add", "-A"]);
+    unlinkSync(path.join(dir, "link"));
+    symlinkSync("safe.txt", path.join(dir, "link")); // swap working tree to safe
+
+    const combined = checkFails(dir);
+    assert.match(combined, /link -> \/etc\/passwd\s+\(absolute target/);
   });
 });
 

--- a/tests/unit/no-foreign-symlinks.test.mjs
+++ b/tests/unit/no-foreign-symlinks.test.mjs
@@ -1,0 +1,152 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  findForeignSymlinks,
+  parseLsFilesStage,
+  collectTrackedSymlinks,
+} from "../../scripts/ci/check-no-foreign-symlinks.mjs";
+import { fixtureGit, fixtureGitEnv } from "../helpers/fixture-git.mjs";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const CHECK = path.join(REPO_ROOT, "scripts/ci/check-no-foreign-symlinks.mjs");
+
+// ---------------------------------------------------------------------------
+// Pure-function truth table — the recurrence-prevention logic for #247.
+// ---------------------------------------------------------------------------
+
+test("findForeignSymlinks: flags an absolute (machine-specific) target — the #247 bug", () => {
+  const offenders = findForeignSymlinks([
+    { path: "node_modules", target: "/Users/x/relay/node_modules" },
+  ]);
+  assert.equal(offenders.length, 1);
+  assert.equal(offenders[0].path, "node_modules");
+  assert.match(offenders[0].reason, /absolute/);
+});
+
+test("findForeignSymlinks: flags Windows-drive and UNC absolute targets", () => {
+  const offenders = findForeignSymlinks([
+    { path: "a", target: "C:\\Windows\\system32" },
+    { path: "b", target: "C:/Windows" },
+    { path: "c", target: "\\\\server\\share" },
+  ]);
+  assert.equal(offenders.length, 3);
+  for (const o of offenders) assert.match(o.reason, /absolute/);
+});
+
+test("findForeignSymlinks: flags relative targets that escape the repo root", () => {
+  const offenders = findForeignSymlinks([
+    { path: "link", target: "../outside" },
+    { path: "a/b/link", target: "../../../etc/passwd" },
+  ]);
+  assert.equal(offenders.length, 2);
+  for (const o of offenders) assert.match(o.reason, /escapes repo root/);
+});
+
+test("findForeignSymlinks: allows relative targets resolving inside the repo (the 2 legit links)", () => {
+  const offenders = findForeignSymlinks([
+    { path: "relay/relay-api-reviewers", target: "../plugins/api-reviewers" },
+    { path: "tests/smoke/claude", target: "claude-mock.mjs" },
+    { path: "a/b/c", target: "../d" }, // -> a/d, still inside
+    { path: "x", target: "./y" }, // -> y, inside
+  ]);
+  assert.deepEqual(offenders, []);
+});
+
+test("parseLsFilesStage: parses mode/sha/path and tolerates spaces in paths", () => {
+  const out =
+    "120000 be9723c077bfb81c7747f25dfa964da1f3134e24 0\tnode_modules\n" +
+    "100644 def4560000000000000000000000000000000000 0\tdir/some file.txt\n";
+  assert.deepEqual(parseLsFilesStage(out), [
+    { mode: "120000", sha: "be9723c077bfb81c7747f25dfa964da1f3134e24", path: "node_modules" },
+    { mode: "100644", sha: "def4560000000000000000000000000000000000", path: "dir/some file.txt" },
+  ]);
+});
+
+test("collectTrackedSymlinks: filters to mode 120000 and reads the blob target", () => {
+  const lsFiles =
+    "100644 aaa 0\treal.txt\n" +
+    "120000 bbb 0\tlink-abs\n" +
+    "120000 ccc 0\tsub/link-rel\n";
+  const blobs = { bbb: "/abs/target\n", ccc: "../inside" };
+  const runGit = (args) => {
+    if (args[0] === "ls-files") return lsFiles;
+    if (args[0] === "cat-file") return blobs[args[2]];
+    throw new Error(`unexpected git ${args.join(" ")}`);
+  };
+  assert.deepEqual(collectTrackedSymlinks(runGit), [
+    { path: "link-abs", target: "/abs/target" }, // trailing newline stripped
+    { path: "sub/link-rel", target: "../inside" },
+  ]);
+});
+
+// ---------------------------------------------------------------------------
+// Integration — the CLI end-to-end against real git repos.
+// ---------------------------------------------------------------------------
+
+test("CLI passes on the real repo (the 2 legit relative symlinks resolve inside)", () => {
+  const out = execFileSync("node", [CHECK], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    env: fixtureGitEnv(),
+  });
+  assert.match(out, /✓ All \d+ tracked symlink\(s\) resolve inside the repo/);
+});
+
+test("CLI exits non-zero and names the offender when a foreign symlink is committed (fail-on-revert)", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "foreign-symlink-"));
+  try {
+    fixtureGit(dir, ["init"]);
+    fixtureGit(dir, ["config", "user.email", "test@example.com"]);
+    fixtureGit(dir, ["config", "user.name", "Test User"]);
+    writeFileSync(path.join(dir, "real.txt"), "x\n", "utf8");
+    // Absolute target need not exist; git records the symlink as mode 120000.
+    symlinkSync("/Users/someone/elsewhere", path.join(dir, "bad-link"));
+    fixtureGit(dir, ["add", "-A"]);
+
+    let threw = false;
+    let combined = "";
+    try {
+      execFileSync("node", [CHECK], { cwd: dir, encoding: "utf8", env: fixtureGitEnv() });
+    } catch (e) {
+      threw = true;
+      combined = `${e.stdout ?? ""}${e.stderr ?? ""}`;
+    }
+    assert.ok(threw, "expected the check to exit non-zero on a foreign symlink");
+    assert.match(combined, /FAILED/);
+    assert.match(combined, /bad-link/);
+    assert.match(combined, /absolute target/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("CLI flags a relative symlink that escapes the repo root", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "escaping-symlink-"));
+  try {
+    fixtureGit(dir, ["init"]);
+    fixtureGit(dir, ["config", "user.email", "test@example.com"]);
+    fixtureGit(dir, ["config", "user.name", "Test User"]);
+    symlinkSync("../../outside-the-repo", path.join(dir, "escaper"));
+    fixtureGit(dir, ["add", "-A"]);
+
+    let threw = false;
+    let combined = "";
+    try {
+      execFileSync("node", [CHECK], { cwd: dir, encoding: "utf8", env: fixtureGitEnv() });
+    } catch (e) {
+      threw = true;
+      combined = `${e.stdout ?? ""}${e.stderr ?? ""}`;
+    }
+    assert.ok(threw, "expected the check to exit non-zero on an escaping symlink");
+    assert.match(combined, /escaper/);
+    assert.match(combined, /escapes repo root/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/no-foreign-symlinks.test.mjs
+++ b/tests/unit/no-foreign-symlinks.test.mjs
@@ -29,41 +29,55 @@ test("findForeignSymlinks: flags an absolute (machine-specific) target — the #
   assert.match(offenders[0].reason, /absolute/);
 });
 
-test("findForeignSymlinks: flags every machine-rooted Windows form (drive, UNC, root-relative, drive-relative)", () => {
-  // The committed blob is identical on every clone OS, so a target that is
-  // machine-rooted under WINDOWS semantics must be rejected even when the check
-  // runs on POSIX. Covers the reviewer-found gaps: single-backslash root-relative
-  // (`\Windows\System32`) and drive-relative (`C:foo`, `C:`).
+// The guard is an allowlist: it accepts only a non-empty, relative, forward-slash
+// target that resolves inside the repo, and rejects everything else. The next
+// three tests pin the three rejection sub-classes; each row is a whole class, not
+// a single enumerated syntax.
+
+test("findForeignSymlinks: rejects any backslash target (Windows sep / UNC / drive+backslash / \\-escape)", () => {
+  // ONE rule (`includes("\\")`) subsumes all of these — they are non-portable on
+  // every clone, so the guard never has to enumerate the individual forms.
   const offenders = findForeignSymlinks([
     { path: "a", target: "C:\\Windows\\system32" }, // drive + backslash
+    { path: "b", target: "\\\\server\\share" }, // UNC
+    { path: "c", target: "\\Windows\\System32" }, // single-backslash current-drive root
+    { path: "toplink", target: "..\\outside" }, // backslash escape from root
+    { path: "sub/nestlink", target: "..\\..\\outside" }, // nested backslash escape
+    { path: "z", target: "sub\\file" }, // diverges across OSes (sub/file on Win, literal on POSIX)
+  ]);
+  assert.equal(offenders.length, 6);
+  for (const o of offenders) assert.match(o.reason, /non-portable/);
+});
+
+test("findForeignSymlinks: rejects forward-slash absolute and drive-qualified targets", () => {
+  const offenders = findForeignSymlinks([
+    { path: "n", target: "/Users/x/relay/node_modules" }, // POSIX absolute (the #247 bug)
     { path: "b", target: "C:/Windows" }, // drive + forward slash
-    { path: "c", target: "\\\\server\\share" }, // UNC
-    { path: "d", target: "\\Windows\\System32" }, // single-backslash current-drive root
     { path: "e", target: "C:foo" }, // drive-relative (binds to C:'s cwd)
     { path: "f", target: "C:" }, // bare drive
   ]);
-  assert.equal(offenders.length, 6);
+  assert.equal(offenders.length, 4);
   for (const o of offenders) assert.match(o.reason, /machine-specific/);
 });
 
-test("findForeignSymlinks: flags relative targets that escape the repo root, incl. backslash separators", () => {
+test("findForeignSymlinks: rejects empty target and forward-slash escapes above the repo root", () => {
   const offenders = findForeignSymlinks([
+    { path: "x", target: "" }, // empty — fail closed
     { path: "link", target: "../outside" },
     { path: "a/b/link", target: "../../../etc/passwd" },
-    { path: "toplink", target: "..\\outside" }, // Windows-separator escape from root
-    { path: "sub/nestlink", target: "..\\..\\outside" }, // Windows-separator nested escape
   ]);
-  assert.equal(offenders.length, 4);
-  for (const o of offenders) assert.match(o.reason, /escapes repo root/);
+  assert.equal(offenders.length, 3);
+  assert.match(offenders[0].reason, /empty/);
+  assert.match(offenders[1].reason, /escapes repo root/);
+  assert.match(offenders[2].reason, /escapes repo root/);
 });
 
-test("findForeignSymlinks: allows relative targets resolving inside the repo (the 2 legit links)", () => {
+test("findForeignSymlinks: allows safe relative forward-slash targets resolving inside the repo", () => {
   const offenders = findForeignSymlinks([
     { path: "relay/relay-api-reviewers", target: "../plugins/api-reviewers" },
     { path: "tests/smoke/claude", target: "claude-mock.mjs" },
     { path: "a/b/c", target: "../d" }, // -> a/d, still inside
     { path: "x", target: "./y" }, // -> y, inside
-    { path: "z", target: "sub\\file" }, // backslash, but -> sub/file, inside (no false positive)
   ]);
   assert.deepEqual(offenders, []);
 });
@@ -142,7 +156,7 @@ test("CLI exits non-zero and names the offender when a foreign symlink is commit
     assert.ok(threw, "expected the check to exit non-zero on a foreign symlink");
     assert.match(combined, /FAILED/);
     assert.match(combined, /bad-link/);
-    assert.match(combined, /absolute target/);
+    assert.match(combined, /machine-specific/);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -173,18 +187,20 @@ test("CLI flags a relative symlink that escapes the repo root", () => {
   }
 });
 
-// Windows-form bypasses found by external review (Kimi/GPT) and reproduced as
-// real committable blobs from POSIX — these would be CI false-greens on a
-// Windows clone of the #247 class. End-to-end through git, on POSIX.
-test("CLI flags a single-backslash Windows current-drive-root symlink target", () => {
-  const dir = mkdtempSync(path.join(tmpdir(), "winroot-symlink-"));
+// Forms found by external review (Kimi/GPT) and reproduced as real committable
+// blobs from POSIX — CI false-greens on a Windows clone of the #247 class under
+// the old POSIX-only guard. End-to-end through git, on POSIX. These cover the two
+// rejection mechanisms a forward-slash-only test cannot reach: a backslash byte,
+// and a drive qualifier with no backslash and no leading slash.
+test("CLI flags a backslash-bearing symlink target (Windows separator / UNC / \\-escape)", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "backslash-symlink-"));
   try {
     fixtureGit(dir, ["init"]);
     fixtureGit(dir, ["config", "user.email", "test@example.com"]);
     fixtureGit(dir, ["config", "user.name", "Test User"]);
-    // `\Windows\System32`: absolute on Windows (current drive root), literal
-    // filename on POSIX — git stores the bytes verbatim either way.
-    symlinkSync("\\Windows\\System32", path.join(dir, "winroot"));
+    // `\Windows\System32`: absolute on Windows, literal filename on POSIX — git
+    // stores the bytes verbatim. The backslash alone makes it non-portable.
+    symlinkSync("\\Windows\\System32", path.join(dir, "winlink"));
     fixtureGit(dir, ["add", "-A"]);
 
     let threw = false;
@@ -195,23 +211,23 @@ test("CLI flags a single-backslash Windows current-drive-root symlink target", (
       threw = true;
       combined = `${e.stdout ?? ""}${e.stderr ?? ""}`;
     }
-    assert.ok(threw, "expected the check to exit non-zero on a \\-rooted Windows target");
-    assert.match(combined, /winroot/);
-    assert.match(combined, /machine-specific/);
+    assert.ok(threw, "expected the check to exit non-zero on a backslash target");
+    assert.match(combined, /winlink/);
+    assert.match(combined, /non-portable/);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
 });
 
-test("CLI flags a Windows-separator relative escape (..\\..\\outside)", () => {
-  const dir = mkdtempSync(path.join(tmpdir(), "winescape-symlink-"));
+test("CLI flags a Windows drive-relative target with no backslash (C:foo)", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "driverel-symlink-"));
   try {
     fixtureGit(dir, ["init"]);
     fixtureGit(dir, ["config", "user.email", "test@example.com"]);
     fixtureGit(dir, ["config", "user.name", "Test User"]);
-    // `..\outside` from a top-level link escapes the repo on Windows; on POSIX it
-    // is a literal name — the old guard saw only POSIX and let it pass.
-    symlinkSync("..\\outside", path.join(dir, "toplink"));
+    // `C:foo`: drive-relative on Windows (binds to drive C:'s cwd), literal name
+    // on POSIX. No backslash and not POSIX-absolute, so only the drive rule catches it.
+    symlinkSync("C:foo", path.join(dir, "driverel"));
     fixtureGit(dir, ["add", "-A"]);
 
     let threw = false;
@@ -222,9 +238,9 @@ test("CLI flags a Windows-separator relative escape (..\\..\\outside)", () => {
       threw = true;
       combined = `${e.stdout ?? ""}${e.stderr ?? ""}`;
     }
-    assert.ok(threw, "expected the check to exit non-zero on a \\-separator escape");
-    assert.match(combined, /toplink/);
-    assert.match(combined, /escapes repo root/);
+    assert.ok(threw, "expected the check to exit non-zero on a drive-relative target");
+    assert.match(combined, /driverel/);
+    assert.match(combined, /machine-specific/);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/tests/unit/no-foreign-symlinks.test.mjs
+++ b/tests/unit/no-foreign-symlinks.test.mjs
@@ -49,15 +49,56 @@ test("findForeignSymlinks: rejects any backslash target (Windows sep / UNC / dri
   for (const o of offenders) assert.match(o.reason, /non-portable/);
 });
 
-test("findForeignSymlinks: rejects forward-slash absolute and drive-qualified targets", () => {
+test("findForeignSymlinks: rejects forward-slash POSIX-absolute targets", () => {
   const offenders = findForeignSymlinks([
-    { path: "n", target: "/Users/x/relay/node_modules" }, // POSIX absolute (the #247 bug)
-    { path: "b", target: "C:/Windows" }, // drive + forward slash
-    { path: "e", target: "C:foo" }, // drive-relative (binds to C:'s cwd)
-    { path: "f", target: "C:" }, // bare drive
+    { path: "n", target: "/Users/x/relay/node_modules" }, // the #247 bug
+    { path: "e", target: "/etc/passwd" },
   ]);
-  assert.equal(offenders.length, 4);
+  assert.equal(offenders.length, 2);
   for (const o of offenders) assert.match(o.reason, /machine-specific/);
+});
+
+test("findForeignSymlinks: rejects a segment with a Windows-illegal char (':' drive/stream, control bytes, < > | ? * \")", () => {
+  // ':' subsumes the old drive-qualifier special case (C:foo, C:, C:/x) AND NTFS
+  // alternate-data-streams (name:stream); the control range covers NUL/newline.
+  const offenders = findForeignSymlinks([
+    { path: "a", target: "C:/Windows" }, // drive + forward slash -> ':' illegal
+    { path: "b", target: "C:foo" }, // drive-relative -> ':' illegal
+    { path: "c", target: "C:" }, // bare drive -> ':' illegal
+    { path: "d", target: "foo:bar" }, // NTFS stream / colon mid-segment
+    { path: "e", target: "a|b" },
+    { path: "f", target: "a?b" },
+    { path: "g", target: "a*b" },
+    { path: "h", target: 'a"b' },
+    { path: "i", target: "a<b" },
+    { path: "j", target: "ctrl" + String.fromCharCode(0) + "byte" }, // embedded control byte (NUL)
+  ]);
+  assert.equal(offenders.length, 10);
+  for (const o of offenders) assert.match(o.reason, /non-portable character/);
+});
+
+test("findForeignSymlinks: rejects Windows reserved device-name segments (CON, NUL, COM1 …)", () => {
+  const offenders = findForeignSymlinks([
+    { path: "a", target: "nul" },
+    { path: "b", target: "con.txt" }, // reserved + extension still reserved
+    { path: "c", target: "AUX" }, // case-insensitive
+    { path: "d", target: "prn" },
+    { path: "e", target: "com1" },
+    { path: "f", target: "lpt9" },
+    { path: "g", target: "sub/con" }, // reserved as a non-leading segment
+  ]);
+  assert.equal(offenders.length, 7);
+  for (const o of offenders) assert.match(o.reason, /reserved device name/);
+});
+
+test("findForeignSymlinks: rejects a segment ending in a space or dot (Windows strips them)", () => {
+  const offenders = findForeignSymlinks([
+    { path: "a", target: "trail." },
+    { path: "b", target: "trail " },
+    { path: "c", target: "sub/baz." },
+  ]);
+  assert.equal(offenders.length, 3);
+  for (const o of offenders) assert.match(o.reason, /space or dot/);
 });
 
 test("findForeignSymlinks: rejects empty target and forward-slash escapes above the repo root", () => {
@@ -72,12 +113,18 @@ test("findForeignSymlinks: rejects empty target and forward-slash escapes above 
   assert.match(offenders[2].reason, /escapes repo root/);
 });
 
-test("findForeignSymlinks: allows safe relative forward-slash targets resolving inside the repo", () => {
+test("findForeignSymlinks: allows safe relative forward-slash targets, incl. names that merely contain reserved substrings", () => {
   const offenders = findForeignSymlinks([
     { path: "relay/relay-api-reviewers", target: "../plugins/api-reviewers" },
     { path: "tests/smoke/claude", target: "claude-mock.mjs" },
     { path: "a/b/c", target: "../d" }, // -> a/d, still inside
     { path: "x", target: "./y" }, // -> y, inside
+    // No over-match: these CONTAIN reserved names but are not reserved segments.
+    { path: "p", target: "console.mjs" }, // "con" but not the CON segment
+    { path: "q", target: "command.ts" }, // "com" with no digit
+    { path: "r", target: "aux-helper.js" }, // "aux" then "-"
+    { path: "s", target: "nullable.json" }, // "nul" then "l"
+    { path: "t", target: "lpt-notes.md" }, // "lpt" then "-"
   ]);
   assert.deepEqual(offenders, []);
 });
@@ -156,7 +203,7 @@ test("CLI exits non-zero and names the offender when a foreign symlink is commit
     assert.ok(threw, "expected the check to exit non-zero on a foreign symlink");
     assert.match(combined, /FAILED/);
     assert.match(combined, /bad-link/);
-    assert.match(combined, /machine-specific/);
+    assert.match(combined, /absolute target/);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -226,7 +273,8 @@ test("CLI flags a Windows drive-relative target with no backslash (C:foo)", () =
     fixtureGit(dir, ["config", "user.email", "test@example.com"]);
     fixtureGit(dir, ["config", "user.name", "Test User"]);
     // `C:foo`: drive-relative on Windows (binds to drive C:'s cwd), literal name
-    // on POSIX. No backslash and not POSIX-absolute, so only the drive rule catches it.
+    // on POSIX. No backslash and not POSIX-absolute, so the illegal-character rule
+    // (the ':') catches it. Assert that specific reason, not the static footer.
     symlinkSync("C:foo", path.join(dir, "driverel"));
     fixtureGit(dir, ["add", "-A"]);
 
@@ -240,7 +288,35 @@ test("CLI flags a Windows drive-relative target with no backslash (C:foo)", () =
     }
     assert.ok(threw, "expected the check to exit non-zero on a drive-relative target");
     assert.match(combined, /driverel/);
-    assert.match(combined, /machine-specific/);
+    assert.match(combined, /non-portable character/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// Kimi's BLOCK repro, end-to-end: a symlink target `nul` is a relative,
+// forward-slash, in-repo-looking name on POSIX, but resolves to the NUL DEVICE on
+// a Windows clone — the allowlist's missing "portable filename" half. Pins the fix.
+test("CLI flags a Windows reserved device-name target (nul)", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "reserved-symlink-"));
+  try {
+    fixtureGit(dir, ["init"]);
+    fixtureGit(dir, ["config", "user.email", "test@example.com"]);
+    fixtureGit(dir, ["config", "user.name", "Test User"]);
+    symlinkSync("nul", path.join(dir, "devlink"));
+    fixtureGit(dir, ["add", "-A"]);
+
+    let threw = false;
+    let combined = "";
+    try {
+      execFileSync("node", [CHECK], { cwd: dir, encoding: "utf8", env: fixtureGitEnv() });
+    } catch (e) {
+      threw = true;
+      combined = `${e.stdout ?? ""}${e.stderr ?? ""}`;
+    }
+    assert.ok(threw, "expected the check to exit non-zero on a reserved device name");
+    assert.match(combined, /devlink/);
+    assert.match(combined, /reserved device name/);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/tests/unit/no-foreign-symlinks.test.mjs
+++ b/tests/unit/no-foreign-symlinks.test.mjs
@@ -228,27 +228,6 @@ test("CLI rejects a force-added self-referential node_modules symlink", () => {
   });
 });
 
-test("CLI honors a positional path argument (not just process.cwd())", () => {
-  withFixtureRepo("argpath-symlink-", (dir) => {
-    symlinkSync(tmpdir(), path.join(dir, "bad-link"));
-    fixtureGit(dir, ["add", "-A"]);
-    let combined = "";
-    try {
-      execFileSync("node", [CHECK, dir], {
-        cwd: REPO_ROOT,
-        encoding: "utf8",
-        env: fixtureGitEnv(),
-      });
-      assert.fail("expected non-zero exit for the arg-dir offender");
-    } catch (e) {
-      combined = `${e.stdout ?? ""}${e.stderr ?? ""}`;
-    }
-
-    assert.match(combined, /bad-link ->/);
-    assert.match(combined, /(resolves outside the repo|unresolvable)/);
-  });
-});
-
 test("CLI rejects a nul target as unresolvable", () => {
   withFixtureRepo("nul-symlink-", (dir) => {
     symlinkSync("nul", path.join(dir, "devlink"));

--- a/tests/unit/no-foreign-symlinks.test.mjs
+++ b/tests/unit/no-foreign-symlinks.test.mjs
@@ -1,13 +1,13 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
-  findForeignSymlinks,
+  classifyResolvedSymlink,
   parseLsFilesStage,
   collectTrackedSymlinks,
 } from "../../scripts/ci/check-no-foreign-symlinks.mjs";
@@ -47,84 +47,34 @@ function checkFails(dir) {
 }
 
 // ---------------------------------------------------------------------------
-// Pure-function truth table: a tracked symlink is valid iff its resolved target
-// is a tracked file or tracked-directory prefix.
+// Pure core: an already-resolved real path is valid iff it remains inside the
+// repo and maps to a tracked file or tracked-directory prefix.
 // ---------------------------------------------------------------------------
 
-test("findForeignSymlinks: accepts tracked files, tracked directory prefixes, and safe relatives", () => {
-  const isTrackedPath = tracked([
-    "plugins/api-reviewers/plugin.json",
-    "tests/smoke/claude-mock.mjs",
-    "a/d",
-    "y",
-    "console.mjs",
-    "command.ts",
-    "aux-helper.js",
-  ]);
+const ROOT = "/repo";
 
-  const offenders = findForeignSymlinks(
-    [
-      { path: "relay/relay-api-reviewers", target: "../plugins/api-reviewers" },
-      { path: "tests/smoke/claude", target: "claude-mock.mjs" },
-      { path: "a/b/c", target: "../d" },
-      { path: "x", target: "./y" },
-      { path: "console-link", target: "console.mjs" },
-      { path: "command-link", target: "command.ts" },
-      { path: "aux-link", target: "aux-helper.js" },
-    ],
-    isTrackedPath
-  );
-
-  assert.deepEqual(offenders, []);
+test("classifyResolvedSymlink: accepts a resolved path that is a tracked file", () => {
+  assert.equal(classifyResolvedSymlink("/repo/sub/f.txt", ROOT, tracked(["sub/f.txt"])), null);
 });
 
-test("findForeignSymlinks: accepts a directory target written with a trailing slash", () => {
-  const isTrackedPath = tracked(["pkg/sub/f.txt"]);
-  const offenders = findForeignSymlinks(
-    [
-      { path: "link", target: "pkg/sub/" },
-      { path: "root", target: "./" },
-    ],
-    isTrackedPath
-  );
-
-  assert.deepEqual(offenders, []);
+test("classifyResolvedSymlink: accepts a resolved path that is a tracked directory prefix", () => {
+  assert.equal(classifyResolvedSymlink("/repo/sub", ROOT, tracked(["sub/f.txt"])), null);
 });
 
-test("findForeignSymlinks: rejects empty and absolute targets before membership", () => {
-  const offenders = findForeignSymlinks(
-    [
-      { path: "empty", target: "" },
-      { path: "node_modules", target: "/Users/x/relay/node_modules" },
-      { path: "relay/link", target: "/plugins/api-reviewers" },
-    ],
-    tracked(["Users/x/relay/node_modules", "plugins/api-reviewers/plugin.json"])
-  );
-
-  assert.equal(offenders.length, 3);
-  assert.match(offenders[0].reason, /empty/);
-  assert.match(offenders[1].reason, /absolute/);
-  assert.match(offenders[2].reason, /absolute/);
+test("classifyResolvedSymlink: accepts a resolution to the repo root itself", () => {
+  assert.equal(classifyResolvedSymlink("/repo", ROOT, tracked(["sub/f.txt"])), null);
 });
 
-test("findForeignSymlinks: rejects untracked resolved targets by membership", () => {
-  const entries = [
-    { path: "rootlink", target: "../outside" },
-    { path: "devlink", target: "nul" },
-    { path: "comlink", target: "COM¹" },
-    { path: "node_modules", target: "node_modules" },
-    { path: "slash", target: "sub\\file" },
-    { path: "driverel", target: "C:foo" },
-    { path: "control", target: "safe\n" },
-  ];
+test("classifyResolvedSymlink: rejects a resolved path outside the repo", () => {
+  assert.match(classifyResolvedSymlink("/elsewhere/x", ROOT, tracked(["sub/f.txt"])), /outside the repo/);
+});
 
-  const offenders = findForeignSymlinks(entries, tracked(["tracked/file.txt"]));
+test("classifyResolvedSymlink: rejects a sibling-prefix path outside the repo", () => {
+  assert.match(classifyResolvedSymlink("/repo-evil/x", ROOT, tracked([])), /outside the repo/);
+});
 
-  assert.equal(offenders.length, entries.length);
-  for (const o of offenders) {
-    assert.match(o.reason, /does not resolve to a tracked/);
-    assert.doesNotMatch(o.reason, /reserved|non-portable|space or dot|escapes repo root/);
-  }
+test("classifyResolvedSymlink: rejects a resolved path inside the repo but untracked", () => {
+  assert.match(classifyResolvedSymlink("/repo/nope", ROOT, tracked(["sub/f.txt"])), /untracked/);
 });
 
 test("parseLsFilesStage: parses NUL-delimited (-z) records; tolerates spaces in paths", () => {
@@ -188,11 +138,12 @@ test("CLI passes on the real repo", () => {
 test("CLI rejects the #247 absolute symlink target and names the offender", () => {
   withFixtureRepo("absolute-symlink-", (dir) => {
     writeFileSync(path.join(dir, "real.txt"), "x\n", "utf8");
-    symlinkSync("/Users/someone/elsewhere", path.join(dir, "bad-link"));
+    symlinkSync(tmpdir(), path.join(dir, "bad-link"));
     fixtureGit(dir, ["add", "-A"]);
 
     const combined = checkFails(dir);
-    assert.match(combined, /bad-link -> \/Users\/someone\/elsewhere\s+\(absolute target/);
+    assert.match(combined, /bad-link ->/);
+    assert.match(combined, /(resolves outside the repo|unresolvable)/);
   });
 });
 
@@ -202,27 +153,119 @@ test("CLI rejects a relative symlink that resolves outside tracked paths", () =>
     fixtureGit(dir, ["add", "-A"]);
 
     const combined = checkFails(dir);
-    assert.match(combined, /escaper -> \.\.\/\.\.\/outside-the-repo\s+\(does not resolve to a tracked/);
+    assert.match(combined, /escaper -> \.\.\/\.\.\/outside-the-repo\s+\((unresolvable|resolves outside the repo)/);
   });
 });
 
-test("CLI rejects a nul target by membership", () => {
+test("CLI rejects an intermediate-symlink '..' escape (real git repo)", () => {
+  withFixtureRepo("intermediate-symlink-", (dir) => {
+    writeFileSync(path.join(dir, "safe"), "root safe\n", "utf8");
+    mkdirSync(path.join(dir, "sub", "inside"), { recursive: true });
+    writeFileSync(path.join(dir, "sub", "inside", "file.txt"), "inside\n", "utf8");
+    symlinkSync("sub/inside", path.join(dir, "d"));
+    symlinkSync("d/../safe", path.join(dir, "a"));
+    fixtureGit(dir, ["add", "-A"]);
+
+    const combined = checkFails(dir);
+    assert.match(combined, /a -> d\/\.\.\/safe\s+\((unresolvable|resolves outside the repo|resolves to an untracked path)/);
+    assert.doesNotMatch(combined, /✗ d ->/);
+  });
+});
+
+test("CLI rejects file/.. ENOTDIR resolution through a symlink target", () => {
+  withFixtureRepo("file-dotdot-symlink-", (dir) => {
+    writeFileSync(path.join(dir, "file.txt"), "file\n", "utf8");
+    writeFileSync(path.join(dir, "safe"), "safe\n", "utf8");
+    symlinkSync("file.txt/../safe", path.join(dir, "link"));
+    fixtureGit(dir, ["add", "-A"]);
+
+    const combined = checkFails(dir);
+    assert.match(combined, /link -> file\.txt\/\.\.\/safe\s+\(unresolvable/);
+  });
+});
+
+test("CLI accepts a valid symlink chain", () => {
+  withFixtureRepo("valid-chain-symlink-", (dir) => {
+    writeFileSync(path.join(dir, "real.txt"), "real\n", "utf8");
+    symlinkSync("real.txt", path.join(dir, "b"));
+    symlinkSync("b", path.join(dir, "a"));
+    fixtureGit(dir, ["add", "-A"]);
+
+    const out = execFileSync("node", [CHECK], {
+      cwd: dir,
+      encoding: "utf8",
+      env: fixtureGitEnv(),
+    });
+    assert.match(out, /✓ All 2 tracked symlink\(s\) resolve inside the repo/);
+  });
+});
+
+test("CLI accepts a valid symlink to a tracked directory", () => {
+  withFixtureRepo("valid-dir-symlink-", (dir) => {
+    mkdirSync(path.join(dir, "pkg", "inside"), { recursive: true });
+    writeFileSync(path.join(dir, "pkg", "inside", "f.txt"), "inside\n", "utf8");
+    symlinkSync("pkg/inside", path.join(dir, "link"));
+    fixtureGit(dir, ["add", "-A"]);
+
+    const out = execFileSync("node", [CHECK], {
+      cwd: dir,
+      encoding: "utf8",
+      env: fixtureGitEnv(),
+    });
+    assert.match(out, /✓ All 1 tracked symlink\(s\) resolve inside the repo/);
+  });
+});
+
+test("CLI rejects a force-added self-referential node_modules symlink", () => {
+  withFixtureRepo("selfloop-symlink-", (dir) => {
+    writeFileSync(path.join(dir, ".gitignore"), "node_modules\n", "utf8");
+    symlinkSync("node_modules", path.join(dir, "node_modules"));
+    fixtureGit(dir, ["add", ".gitignore"]);
+    fixtureGit(dir, ["add", "-f", "node_modules"]);
+
+    const combined = checkFails(dir);
+    assert.match(combined, /node_modules -> node_modules\s+\(unresolvable/);
+  });
+});
+
+test("CLI honors a positional path argument (not just process.cwd())", () => {
+  withFixtureRepo("argpath-symlink-", (dir) => {
+    symlinkSync(tmpdir(), path.join(dir, "bad-link"));
+    fixtureGit(dir, ["add", "-A"]);
+    let combined = "";
+    try {
+      execFileSync("node", [CHECK, dir], {
+        cwd: REPO_ROOT,
+        encoding: "utf8",
+        env: fixtureGitEnv(),
+      });
+      assert.fail("expected non-zero exit for the arg-dir offender");
+    } catch (e) {
+      combined = `${e.stdout ?? ""}${e.stderr ?? ""}`;
+    }
+
+    assert.match(combined, /bad-link ->/);
+    assert.match(combined, /(resolves outside the repo|unresolvable)/);
+  });
+});
+
+test("CLI rejects a nul target as unresolvable", () => {
   withFixtureRepo("nul-symlink-", (dir) => {
     symlinkSync("nul", path.join(dir, "devlink"));
     fixtureGit(dir, ["add", "-A"]);
 
     const combined = checkFails(dir);
-    assert.match(combined, /devlink -> nul\s+\(does not resolve to a tracked/);
+    assert.match(combined, /devlink -> nul\s+\(unresolvable/);
   });
 });
 
-test("CLI rejects a COM¹ target by membership", () => {
+test("CLI rejects a COM¹ target as unresolvable", () => {
   withFixtureRepo("com-symlink-", (dir) => {
     symlinkSync("COM¹", path.join(dir, "comlink"));
     fixtureGit(dir, ["add", "-A"]);
 
     const combined = checkFails(dir);
-    assert.match(combined, /comlink -> COM¹\s+\(does not resolve to a tracked/);
+    assert.match(combined, /comlink -> COM¹\s+\(unresolvable/);
   });
 });
 
@@ -231,17 +274,12 @@ test("CLI rejects a trailing control byte preserved in the symlink blob", () => 
     try {
       symlinkSync("safe\n", path.join(dir, "control"));
     } catch {
-      const offenders = findForeignSymlinks(
-        [{ path: "control", target: "safe\n" }],
-        tracked(["safe"])
-      );
-      assert.equal(offenders.length, 1);
-      assert.match(offenders[0].reason, /does not resolve to a tracked/);
+      assert.match(classifyResolvedSymlink(`${ROOT}/safe\n`, ROOT, tracked(["safe"])), /untracked/);
       return;
     }
     fixtureGit(dir, ["add", "-A"]);
 
     const combined = checkFails(dir);
-    assert.match(combined, /control -> safe\n\s+\(does not resolve to a tracked/);
+    assert.match(combined, /control -> safe\n\s+\(unresolvable/);
   });
 });

--- a/tests/unit/no-foreign-symlinks.test.mjs
+++ b/tests/unit/no-foreign-symlinks.test.mjs
@@ -58,24 +58,36 @@ test("findForeignSymlinks: allows relative targets resolving inside the repo (th
   assert.deepEqual(offenders, []);
 });
 
-test("parseLsFilesStage: parses mode/sha/path and tolerates spaces in paths", () => {
+test("parseLsFilesStage: parses NUL-delimited (-z) records; tolerates spaces in paths", () => {
   const out =
-    "120000 be9723c077bfb81c7747f25dfa964da1f3134e24 0\tnode_modules\n" +
-    "100644 def4560000000000000000000000000000000000 0\tdir/some file.txt\n";
+    "120000 be9723c077bfb81c7747f25dfa964da1f3134e24 0\tnode_modules\0" +
+    "100644 def4560000000000000000000000000000000000 0\tdir/some file.txt\0";
   assert.deepEqual(parseLsFilesStage(out), [
     { mode: "120000", sha: "be9723c077bfb81c7747f25dfa964da1f3134e24", path: "node_modules" },
     { mode: "100644", sha: "def4560000000000000000000000000000000000", path: "dir/some file.txt" },
   ]);
 });
 
+test("parseLsFilesStage: preserves special bytes in a path (no C-quoting under -z)", () => {
+  // A name with a non-ASCII byte and a space — `-z` keeps it verbatim, so the
+  // escape check sees the real dirname (the quoting-bypass that motivated -z).
+  const out = "120000 abc 0\tsub/né me/link\0";
+  assert.deepEqual(parseLsFilesStage(out), [
+    { mode: "120000", sha: "abc", path: "sub/né me/link" },
+  ]);
+});
+
 test("collectTrackedSymlinks: filters to mode 120000 and reads the blob target", () => {
   const lsFiles =
-    "100644 aaa 0\treal.txt\n" +
-    "120000 bbb 0\tlink-abs\n" +
-    "120000 ccc 0\tsub/link-rel\n";
+    "100644 aaa 0\treal.txt\0" +
+    "120000 bbb 0\tlink-abs\0" +
+    "120000 ccc 0\tsub/link-rel\0";
   const blobs = { bbb: "/abs/target\n", ccc: "../inside" };
   const runGit = (args) => {
-    if (args[0] === "ls-files") return lsFiles;
+    if (args[0] === "ls-files") {
+      assert.deepEqual(args, ["ls-files", "-s", "-z"]); // NUL-delimited form
+      return lsFiles;
+    }
     if (args[0] === "cat-file") return blobs[args[2]];
     throw new Error(`unexpected git ${args.join(" ")}`);
   };

--- a/tests/unit/no-foreign-symlinks.test.mjs
+++ b/tests/unit/no-foreign-symlinks.test.mjs
@@ -29,22 +29,31 @@ test("findForeignSymlinks: flags an absolute (machine-specific) target — the #
   assert.match(offenders[0].reason, /absolute/);
 });
 
-test("findForeignSymlinks: flags Windows-drive and UNC absolute targets", () => {
+test("findForeignSymlinks: flags every machine-rooted Windows form (drive, UNC, root-relative, drive-relative)", () => {
+  // The committed blob is identical on every clone OS, so a target that is
+  // machine-rooted under WINDOWS semantics must be rejected even when the check
+  // runs on POSIX. Covers the reviewer-found gaps: single-backslash root-relative
+  // (`\Windows\System32`) and drive-relative (`C:foo`, `C:`).
   const offenders = findForeignSymlinks([
-    { path: "a", target: "C:\\Windows\\system32" },
-    { path: "b", target: "C:/Windows" },
-    { path: "c", target: "\\\\server\\share" },
+    { path: "a", target: "C:\\Windows\\system32" }, // drive + backslash
+    { path: "b", target: "C:/Windows" }, // drive + forward slash
+    { path: "c", target: "\\\\server\\share" }, // UNC
+    { path: "d", target: "\\Windows\\System32" }, // single-backslash current-drive root
+    { path: "e", target: "C:foo" }, // drive-relative (binds to C:'s cwd)
+    { path: "f", target: "C:" }, // bare drive
   ]);
-  assert.equal(offenders.length, 3);
-  for (const o of offenders) assert.match(o.reason, /absolute/);
+  assert.equal(offenders.length, 6);
+  for (const o of offenders) assert.match(o.reason, /machine-specific/);
 });
 
-test("findForeignSymlinks: flags relative targets that escape the repo root", () => {
+test("findForeignSymlinks: flags relative targets that escape the repo root, incl. backslash separators", () => {
   const offenders = findForeignSymlinks([
     { path: "link", target: "../outside" },
     { path: "a/b/link", target: "../../../etc/passwd" },
+    { path: "toplink", target: "..\\outside" }, // Windows-separator escape from root
+    { path: "sub/nestlink", target: "..\\..\\outside" }, // Windows-separator nested escape
   ]);
-  assert.equal(offenders.length, 2);
+  assert.equal(offenders.length, 4);
   for (const o of offenders) assert.match(o.reason, /escapes repo root/);
 });
 
@@ -54,6 +63,7 @@ test("findForeignSymlinks: allows relative targets resolving inside the repo (th
     { path: "tests/smoke/claude", target: "claude-mock.mjs" },
     { path: "a/b/c", target: "../d" }, // -> a/d, still inside
     { path: "x", target: "./y" }, // -> y, inside
+    { path: "z", target: "sub\\file" }, // backslash, but -> sub/file, inside (no false positive)
   ]);
   assert.deepEqual(offenders, []);
 });
@@ -157,6 +167,63 @@ test("CLI flags a relative symlink that escapes the repo root", () => {
     }
     assert.ok(threw, "expected the check to exit non-zero on an escaping symlink");
     assert.match(combined, /escaper/);
+    assert.match(combined, /escapes repo root/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// Windows-form bypasses found by external review (Kimi/GPT) and reproduced as
+// real committable blobs from POSIX — these would be CI false-greens on a
+// Windows clone of the #247 class. End-to-end through git, on POSIX.
+test("CLI flags a single-backslash Windows current-drive-root symlink target", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "winroot-symlink-"));
+  try {
+    fixtureGit(dir, ["init"]);
+    fixtureGit(dir, ["config", "user.email", "test@example.com"]);
+    fixtureGit(dir, ["config", "user.name", "Test User"]);
+    // `\Windows\System32`: absolute on Windows (current drive root), literal
+    // filename on POSIX — git stores the bytes verbatim either way.
+    symlinkSync("\\Windows\\System32", path.join(dir, "winroot"));
+    fixtureGit(dir, ["add", "-A"]);
+
+    let threw = false;
+    let combined = "";
+    try {
+      execFileSync("node", [CHECK], { cwd: dir, encoding: "utf8", env: fixtureGitEnv() });
+    } catch (e) {
+      threw = true;
+      combined = `${e.stdout ?? ""}${e.stderr ?? ""}`;
+    }
+    assert.ok(threw, "expected the check to exit non-zero on a \\-rooted Windows target");
+    assert.match(combined, /winroot/);
+    assert.match(combined, /machine-specific/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("CLI flags a Windows-separator relative escape (..\\..\\outside)", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "winescape-symlink-"));
+  try {
+    fixtureGit(dir, ["init"]);
+    fixtureGit(dir, ["config", "user.email", "test@example.com"]);
+    fixtureGit(dir, ["config", "user.name", "Test User"]);
+    // `..\outside` from a top-level link escapes the repo on Windows; on POSIX it
+    // is a literal name — the old guard saw only POSIX and let it pass.
+    symlinkSync("..\\outside", path.join(dir, "toplink"));
+    fixtureGit(dir, ["add", "-A"]);
+
+    let threw = false;
+    let combined = "";
+    try {
+      execFileSync("node", [CHECK], { cwd: dir, encoding: "utf8", env: fixtureGitEnv() });
+    } catch (e) {
+      threw = true;
+      combined = `${e.stdout ?? ""}${e.stderr ?? ""}`;
+    }
+    assert.ok(threw, "expected the check to exit non-zero on a \\-separator escape");
+    assert.match(combined, /toplink/);
     assert.match(combined, /escapes repo root/);
   } finally {
     rmSync(dir, { recursive: true, force: true });

--- a/tests/unit/no-foreign-symlinks.test.mjs
+++ b/tests/unit/no-foreign-symlinks.test.mjs
@@ -16,123 +16,122 @@ import { fixtureGit, fixtureGitEnv } from "../helpers/fixture-git.mjs";
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
 const CHECK = path.join(REPO_ROOT, "scripts/ci/check-no-foreign-symlinks.mjs");
 
+const tracked = (paths) => {
+  const set = new Set(paths);
+  return (p) => p === "" || p === "." || set.has(p) || [...set].some((f) => f.startsWith(p + "/"));
+};
+
+function initFixtureRepo(dir) {
+  fixtureGit(dir, ["init"]);
+  fixtureGit(dir, ["config", "user.email", "test@example.com"]);
+  fixtureGit(dir, ["config", "user.name", "Test User"]);
+}
+
+function withFixtureRepo(prefix, fn) {
+  const dir = mkdtempSync(path.join(tmpdir(), prefix));
+  try {
+    initFixtureRepo(dir);
+    fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function checkFails(dir) {
+  try {
+    execFileSync("node", [CHECK], { cwd: dir, encoding: "utf8", env: fixtureGitEnv() });
+  } catch (e) {
+    return `${e.stdout ?? ""}${e.stderr ?? ""}`;
+  }
+  assert.fail("expected the check to exit non-zero");
+}
+
 // ---------------------------------------------------------------------------
-// Pure-function truth table — the recurrence-prevention logic for #247.
+// Pure-function truth table: a tracked symlink is valid iff its resolved target
+// is a tracked file or tracked-directory prefix.
 // ---------------------------------------------------------------------------
 
-test("findForeignSymlinks: flags an absolute (machine-specific) target — the #247 bug", () => {
-  const offenders = findForeignSymlinks([
-    { path: "node_modules", target: "/Users/x/relay/node_modules" },
+test("findForeignSymlinks: accepts tracked files, tracked directory prefixes, and safe relatives", () => {
+  const isTrackedPath = tracked([
+    "plugins/api-reviewers/plugin.json",
+    "tests/smoke/claude-mock.mjs",
+    "a/d",
+    "y",
+    "console.mjs",
+    "command.ts",
+    "aux-helper.js",
   ]);
-  assert.equal(offenders.length, 1);
-  assert.equal(offenders[0].path, "node_modules");
-  assert.match(offenders[0].reason, /absolute/);
+
+  const offenders = findForeignSymlinks(
+    [
+      { path: "relay/relay-api-reviewers", target: "../plugins/api-reviewers" },
+      { path: "tests/smoke/claude", target: "claude-mock.mjs" },
+      { path: "a/b/c", target: "../d" },
+      { path: "x", target: "./y" },
+      { path: "console-link", target: "console.mjs" },
+      { path: "command-link", target: "command.ts" },
+      { path: "aux-link", target: "aux-helper.js" },
+    ],
+    isTrackedPath
+  );
+
+  assert.deepEqual(offenders, []);
 });
 
-// The guard is an allowlist: it accepts only a non-empty, relative, forward-slash
-// target that resolves inside the repo, and rejects everything else. The next
-// three tests pin the three rejection sub-classes; each row is a whole class, not
-// a single enumerated syntax.
+test("findForeignSymlinks: accepts a directory target written with a trailing slash", () => {
+  const isTrackedPath = tracked(["pkg/sub/f.txt"]);
+  const offenders = findForeignSymlinks(
+    [
+      { path: "link", target: "pkg/sub/" },
+      { path: "root", target: "./" },
+    ],
+    isTrackedPath
+  );
 
-test("findForeignSymlinks: rejects any backslash target (Windows sep / UNC / drive+backslash / \\-escape)", () => {
-  // ONE rule (`includes("\\")`) subsumes all of these — they are non-portable on
-  // every clone, so the guard never has to enumerate the individual forms.
-  const offenders = findForeignSymlinks([
-    { path: "a", target: "C:\\Windows\\system32" }, // drive + backslash
-    { path: "b", target: "\\\\server\\share" }, // UNC
-    { path: "c", target: "\\Windows\\System32" }, // single-backslash current-drive root
-    { path: "toplink", target: "..\\outside" }, // backslash escape from root
-    { path: "sub/nestlink", target: "..\\..\\outside" }, // nested backslash escape
-    { path: "z", target: "sub\\file" }, // diverges across OSes (sub/file on Win, literal on POSIX)
-  ]);
-  assert.equal(offenders.length, 6);
-  for (const o of offenders) assert.match(o.reason, /non-portable/);
+  assert.deepEqual(offenders, []);
 });
 
-test("findForeignSymlinks: rejects forward-slash POSIX-absolute targets", () => {
-  const offenders = findForeignSymlinks([
-    { path: "n", target: "/Users/x/relay/node_modules" }, // the #247 bug
-    { path: "e", target: "/etc/passwd" },
-  ]);
-  assert.equal(offenders.length, 2);
-  for (const o of offenders) assert.match(o.reason, /machine-specific/);
-});
+test("findForeignSymlinks: rejects empty and absolute targets before membership", () => {
+  const offenders = findForeignSymlinks(
+    [
+      { path: "empty", target: "" },
+      { path: "node_modules", target: "/Users/x/relay/node_modules" },
+      { path: "relay/link", target: "/plugins/api-reviewers" },
+    ],
+    tracked(["Users/x/relay/node_modules", "plugins/api-reviewers/plugin.json"])
+  );
 
-test("findForeignSymlinks: rejects a segment with a Windows-illegal char (':' drive/stream, control bytes, < > | ? * \")", () => {
-  // ':' subsumes the old drive-qualifier special case (C:foo, C:, C:/x) AND NTFS
-  // alternate-data-streams (name:stream); the control range covers NUL/newline.
-  const offenders = findForeignSymlinks([
-    { path: "a", target: "C:/Windows" }, // drive + forward slash -> ':' illegal
-    { path: "b", target: "C:foo" }, // drive-relative -> ':' illegal
-    { path: "c", target: "C:" }, // bare drive -> ':' illegal
-    { path: "d", target: "foo:bar" }, // NTFS stream / colon mid-segment
-    { path: "e", target: "a|b" },
-    { path: "f", target: "a?b" },
-    { path: "g", target: "a*b" },
-    { path: "h", target: 'a"b' },
-    { path: "i", target: "a<b" },
-    { path: "j", target: "ctrl" + String.fromCharCode(0) + "byte" }, // embedded control byte (NUL)
-  ]);
-  assert.equal(offenders.length, 10);
-  for (const o of offenders) assert.match(o.reason, /non-portable character/);
-});
-
-test("findForeignSymlinks: rejects Windows reserved device-name segments (CON, NUL, COM1 …)", () => {
-  const offenders = findForeignSymlinks([
-    { path: "a", target: "nul" },
-    { path: "b", target: "con.txt" }, // reserved + extension still reserved
-    { path: "c", target: "AUX" }, // case-insensitive
-    { path: "d", target: "prn" },
-    { path: "e", target: "com1" },
-    { path: "f", target: "lpt9" },
-    { path: "g", target: "sub/con" }, // reserved as a non-leading segment
-  ]);
-  assert.equal(offenders.length, 7);
-  for (const o of offenders) assert.match(o.reason, /reserved device name/);
-});
-
-test("findForeignSymlinks: rejects a segment ending in a space or dot (Windows strips them)", () => {
-  const offenders = findForeignSymlinks([
-    { path: "a", target: "trail." },
-    { path: "b", target: "trail " },
-    { path: "c", target: "sub/baz." },
-  ]);
-  assert.equal(offenders.length, 3);
-  for (const o of offenders) assert.match(o.reason, /space or dot/);
-});
-
-test("findForeignSymlinks: rejects empty target and forward-slash escapes above the repo root", () => {
-  const offenders = findForeignSymlinks([
-    { path: "x", target: "" }, // empty — fail closed
-    { path: "link", target: "../outside" },
-    { path: "a/b/link", target: "../../../etc/passwd" },
-  ]);
   assert.equal(offenders.length, 3);
   assert.match(offenders[0].reason, /empty/);
-  assert.match(offenders[1].reason, /escapes repo root/);
-  assert.match(offenders[2].reason, /escapes repo root/);
+  assert.match(offenders[1].reason, /absolute/);
+  assert.match(offenders[2].reason, /absolute/);
 });
 
-test("findForeignSymlinks: allows safe relative forward-slash targets, incl. names that merely contain reserved substrings", () => {
-  const offenders = findForeignSymlinks([
-    { path: "relay/relay-api-reviewers", target: "../plugins/api-reviewers" },
-    { path: "tests/smoke/claude", target: "claude-mock.mjs" },
-    { path: "a/b/c", target: "../d" }, // -> a/d, still inside
-    { path: "x", target: "./y" }, // -> y, inside
-    // No over-match: these CONTAIN reserved names but are not reserved segments.
-    { path: "p", target: "console.mjs" }, // "con" but not the CON segment
-    { path: "q", target: "command.ts" }, // "com" with no digit
-    { path: "r", target: "aux-helper.js" }, // "aux" then "-"
-    { path: "s", target: "nullable.json" }, // "nul" then "l"
-    { path: "t", target: "lpt-notes.md" }, // "lpt" then "-"
-  ]);
-  assert.deepEqual(offenders, []);
+test("findForeignSymlinks: rejects untracked resolved targets by membership", () => {
+  const entries = [
+    { path: "rootlink", target: "../outside" },
+    { path: "devlink", target: "nul" },
+    { path: "comlink", target: "COM¹" },
+    { path: "node_modules", target: "node_modules" },
+    { path: "slash", target: "sub\\file" },
+    { path: "driverel", target: "C:foo" },
+    { path: "control", target: "safe\n" },
+  ];
+
+  const offenders = findForeignSymlinks(entries, tracked(["tracked/file.txt"]));
+
+  assert.equal(offenders.length, entries.length);
+  for (const o of offenders) {
+    assert.match(o.reason, /does not resolve to a tracked/);
+    assert.doesNotMatch(o.reason, /reserved|non-portable|space or dot|escapes repo root/);
+  }
 });
 
 test("parseLsFilesStage: parses NUL-delimited (-z) records; tolerates spaces in paths", () => {
   const out =
     "120000 be9723c077bfb81c7747f25dfa964da1f3134e24 0\tnode_modules\0" +
     "100644 def4560000000000000000000000000000000000 0\tdir/some file.txt\0";
+
   assert.deepEqual(parseLsFilesStage(out), [
     { mode: "120000", sha: "be9723c077bfb81c7747f25dfa964da1f3134e24", path: "node_modules" },
     { mode: "100644", sha: "def4560000000000000000000000000000000000", path: "dir/some file.txt" },
@@ -140,184 +139,109 @@ test("parseLsFilesStage: parses NUL-delimited (-z) records; tolerates spaces in 
 });
 
 test("parseLsFilesStage: preserves special bytes in a path (no C-quoting under -z)", () => {
-  // A name with a non-ASCII byte and a space — `-z` keeps it verbatim, so the
-  // escape check sees the real dirname (the quoting-bypass that motivated -z).
-  const out = "120000 abc 0\tsub/né me/link\0";
+  const out = "120000 abc 0\tsub/spaced link\0";
+
   assert.deepEqual(parseLsFilesStage(out), [
-    { mode: "120000", sha: "abc", path: "sub/né me/link" },
+    { mode: "120000", sha: "abc", path: "sub/spaced link" },
   ]);
 });
 
-test("collectTrackedSymlinks: filters to mode 120000 and reads the blob target", () => {
+test("collectTrackedSymlinks: filters to mode 120000 and preserves blob targets verbatim", () => {
+  const calls = [];
   const lsFiles =
     "100644 aaa 0\treal.txt\0" +
-    "120000 bbb 0\tlink-abs\0" +
+    "120000 bbb 0\tlink-control\0" +
     "120000 ccc 0\tsub/link-rel\0";
-  const blobs = { bbb: "/abs/target\n", ccc: "../inside" };
+  const blobs = { bbb: "foo\n", ccc: "../inside" };
   const runGit = (args) => {
-    if (args[0] === "ls-files") {
-      assert.deepEqual(args, ["ls-files", "-s", "-z"]); // NUL-delimited form
-      return lsFiles;
-    }
+    calls.push(args);
+    if (args[0] === "ls-files") return lsFiles;
     if (args[0] === "cat-file") return blobs[args[2]];
     throw new Error(`unexpected git ${args.join(" ")}`);
   };
+
   assert.deepEqual(collectTrackedSymlinks(runGit), [
-    { path: "link-abs", target: "/abs/target" }, // trailing newline stripped
+    { path: "link-control", target: "foo\n" },
     { path: "sub/link-rel", target: "../inside" },
+  ]);
+  assert.deepEqual(calls, [
+    ["ls-files", "-s", "-z"],
+    ["cat-file", "blob", "bbb"],
+    ["cat-file", "blob", "ccc"],
   ]);
 });
 
 // ---------------------------------------------------------------------------
-// Integration — the CLI end-to-end against real git repos.
+// Integration: the CLI end-to-end against real git repos.
 // ---------------------------------------------------------------------------
 
-test("CLI passes on the real repo (the 2 legit relative symlinks resolve inside)", () => {
+test("CLI passes on the real repo", () => {
   const out = execFileSync("node", [CHECK], {
     cwd: REPO_ROOT,
     encoding: "utf8",
     env: fixtureGitEnv(),
   });
+
   assert.match(out, /✓ All \d+ tracked symlink\(s\) resolve inside the repo/);
 });
 
-test("CLI exits non-zero and names the offender when a foreign symlink is committed (fail-on-revert)", () => {
-  const dir = mkdtempSync(path.join(tmpdir(), "foreign-symlink-"));
-  try {
-    fixtureGit(dir, ["init"]);
-    fixtureGit(dir, ["config", "user.email", "test@example.com"]);
-    fixtureGit(dir, ["config", "user.name", "Test User"]);
+test("CLI rejects the #247 absolute symlink target and names the offender", () => {
+  withFixtureRepo("absolute-symlink-", (dir) => {
     writeFileSync(path.join(dir, "real.txt"), "x\n", "utf8");
-    // Absolute target need not exist; git records the symlink as mode 120000.
     symlinkSync("/Users/someone/elsewhere", path.join(dir, "bad-link"));
     fixtureGit(dir, ["add", "-A"]);
 
-    let threw = false;
-    let combined = "";
-    try {
-      execFileSync("node", [CHECK], { cwd: dir, encoding: "utf8", env: fixtureGitEnv() });
-    } catch (e) {
-      threw = true;
-      combined = `${e.stdout ?? ""}${e.stderr ?? ""}`;
-    }
-    assert.ok(threw, "expected the check to exit non-zero on a foreign symlink");
-    assert.match(combined, /FAILED/);
-    assert.match(combined, /bad-link/);
-    assert.match(combined, /absolute target/);
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
+    const combined = checkFails(dir);
+    assert.match(combined, /bad-link -> \/Users\/someone\/elsewhere\s+\(absolute target/);
+  });
 });
 
-test("CLI flags a relative symlink that escapes the repo root", () => {
-  const dir = mkdtempSync(path.join(tmpdir(), "escaping-symlink-"));
-  try {
-    fixtureGit(dir, ["init"]);
-    fixtureGit(dir, ["config", "user.email", "test@example.com"]);
-    fixtureGit(dir, ["config", "user.name", "Test User"]);
+test("CLI rejects a relative symlink that resolves outside tracked paths", () => {
+  withFixtureRepo("escaping-symlink-", (dir) => {
     symlinkSync("../../outside-the-repo", path.join(dir, "escaper"));
     fixtureGit(dir, ["add", "-A"]);
 
-    let threw = false;
-    let combined = "";
-    try {
-      execFileSync("node", [CHECK], { cwd: dir, encoding: "utf8", env: fixtureGitEnv() });
-    } catch (e) {
-      threw = true;
-      combined = `${e.stdout ?? ""}${e.stderr ?? ""}`;
-    }
-    assert.ok(threw, "expected the check to exit non-zero on an escaping symlink");
-    assert.match(combined, /escaper/);
-    assert.match(combined, /escapes repo root/);
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
+    const combined = checkFails(dir);
+    assert.match(combined, /escaper -> \.\.\/\.\.\/outside-the-repo\s+\(does not resolve to a tracked/);
+  });
 });
 
-// Forms found by external review (Kimi/GPT) and reproduced as real committable
-// blobs from POSIX — CI false-greens on a Windows clone of the #247 class under
-// the old POSIX-only guard. End-to-end through git, on POSIX. These cover the two
-// rejection mechanisms a forward-slash-only test cannot reach: a backslash byte,
-// and a drive qualifier with no backslash and no leading slash.
-test("CLI flags a backslash-bearing symlink target (Windows separator / UNC / \\-escape)", () => {
-  const dir = mkdtempSync(path.join(tmpdir(), "backslash-symlink-"));
-  try {
-    fixtureGit(dir, ["init"]);
-    fixtureGit(dir, ["config", "user.email", "test@example.com"]);
-    fixtureGit(dir, ["config", "user.name", "Test User"]);
-    // `\Windows\System32`: absolute on Windows, literal filename on POSIX — git
-    // stores the bytes verbatim. The backslash alone makes it non-portable.
-    symlinkSync("\\Windows\\System32", path.join(dir, "winlink"));
-    fixtureGit(dir, ["add", "-A"]);
-
-    let threw = false;
-    let combined = "";
-    try {
-      execFileSync("node", [CHECK], { cwd: dir, encoding: "utf8", env: fixtureGitEnv() });
-    } catch (e) {
-      threw = true;
-      combined = `${e.stdout ?? ""}${e.stderr ?? ""}`;
-    }
-    assert.ok(threw, "expected the check to exit non-zero on a backslash target");
-    assert.match(combined, /winlink/);
-    assert.match(combined, /non-portable/);
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
-});
-
-test("CLI flags a Windows drive-relative target with no backslash (C:foo)", () => {
-  const dir = mkdtempSync(path.join(tmpdir(), "driverel-symlink-"));
-  try {
-    fixtureGit(dir, ["init"]);
-    fixtureGit(dir, ["config", "user.email", "test@example.com"]);
-    fixtureGit(dir, ["config", "user.name", "Test User"]);
-    // `C:foo`: drive-relative on Windows (binds to drive C:'s cwd), literal name
-    // on POSIX. No backslash and not POSIX-absolute, so the illegal-character rule
-    // (the ':') catches it. Assert that specific reason, not the static footer.
-    symlinkSync("C:foo", path.join(dir, "driverel"));
-    fixtureGit(dir, ["add", "-A"]);
-
-    let threw = false;
-    let combined = "";
-    try {
-      execFileSync("node", [CHECK], { cwd: dir, encoding: "utf8", env: fixtureGitEnv() });
-    } catch (e) {
-      threw = true;
-      combined = `${e.stdout ?? ""}${e.stderr ?? ""}`;
-    }
-    assert.ok(threw, "expected the check to exit non-zero on a drive-relative target");
-    assert.match(combined, /driverel/);
-    assert.match(combined, /non-portable character/);
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
-});
-
-// Kimi's BLOCK repro, end-to-end: a symlink target `nul` is a relative,
-// forward-slash, in-repo-looking name on POSIX, but resolves to the NUL DEVICE on
-// a Windows clone — the allowlist's missing "portable filename" half. Pins the fix.
-test("CLI flags a Windows reserved device-name target (nul)", () => {
-  const dir = mkdtempSync(path.join(tmpdir(), "reserved-symlink-"));
-  try {
-    fixtureGit(dir, ["init"]);
-    fixtureGit(dir, ["config", "user.email", "test@example.com"]);
-    fixtureGit(dir, ["config", "user.name", "Test User"]);
+test("CLI rejects a nul target by membership", () => {
+  withFixtureRepo("nul-symlink-", (dir) => {
     symlinkSync("nul", path.join(dir, "devlink"));
     fixtureGit(dir, ["add", "-A"]);
 
-    let threw = false;
-    let combined = "";
+    const combined = checkFails(dir);
+    assert.match(combined, /devlink -> nul\s+\(does not resolve to a tracked/);
+  });
+});
+
+test("CLI rejects a COM¹ target by membership", () => {
+  withFixtureRepo("com-symlink-", (dir) => {
+    symlinkSync("COM¹", path.join(dir, "comlink"));
+    fixtureGit(dir, ["add", "-A"]);
+
+    const combined = checkFails(dir);
+    assert.match(combined, /comlink -> COM¹\s+\(does not resolve to a tracked/);
+  });
+});
+
+test("CLI rejects a trailing control byte preserved in the symlink blob", () => {
+  withFixtureRepo("control-symlink-", (dir) => {
     try {
-      execFileSync("node", [CHECK], { cwd: dir, encoding: "utf8", env: fixtureGitEnv() });
-    } catch (e) {
-      threw = true;
-      combined = `${e.stdout ?? ""}${e.stderr ?? ""}`;
+      symlinkSync("safe\n", path.join(dir, "control"));
+    } catch {
+      const offenders = findForeignSymlinks(
+        [{ path: "control", target: "safe\n" }],
+        tracked(["safe"])
+      );
+      assert.equal(offenders.length, 1);
+      assert.match(offenders[0].reason, /does not resolve to a tracked/);
+      return;
     }
-    assert.ok(threw, "expected the check to exit non-zero on a reserved device name");
-    assert.match(combined, /devlink/);
-    assert.match(combined, /reserved device name/);
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
+    fixtureGit(dir, ["add", "-A"]);
+
+    const combined = checkFails(dir);
+    assert.match(combined, /control -> safe\n\s+\(does not resolve to a tracked/);
+  });
 });


### PR DESCRIPTION
## Problem
`main` tracked a `node_modules` **symlink** (git mode `120000`) → the absolute, machine-specific path `/Users/spson/Projects/Claude/relay/node_modules`. On the author's machine it's self-referential (circular: `Too many levels of symbolic links`); for any other clone it's a broken link into a foreign absolute path. Introduced by #218 commit `7900f8e`.

## Root cause (class)
`.gitignore` line 1 was `node_modules/` — the trailing slash matches only a **directory** named `node_modules`, not a **symlink file** of that name. So the symlink form was stageable and got committed despite the ignore rule.

## Fix
- `git rm --cached node_modules` — untrack the symlink.
- `.gitignore`: `node_modules/` → `node_modules` so **both** the directory and symlink forms are ignored (prevents recurrence).
- Real deps restored locally via `npm ci`.

## Verification
- `git check-ignore -v node_modules` now matches the rule; a `node_modules` symlink no longer shows as untracked. The old rule demonstrably let it through (committed in `7900f8e`) — that's the failing control.
- `npm run lint` green (manifests + 19 sync checks).
- Full suite green: **2718 tests, 2712 pass, 0 fail**, 6 skipped.

## Out of scope (verified legit, untouched)
- `relay/relay-api-reviewers` → `../plugins/api-reviewers`
- `tests/smoke/claude` → `claude-mock.mjs`

Closes #247