### PR TITLE
#232: bring AGY review finalization onto the shared contract

### DIFF
--- a/plugins/agy/scripts/agy-companion.mjs
+++ b/plugins/agy/scripts/agy-companion.mjs
@@ -315,7 +315,7 @@ function redactionFieldsForPrompt(prompt) {
 }
 
 function redactionFieldsForSelected(selectedFiles) {
-  const files = sourceFilesForRedaction(selectedFiles);
+  const files = sourceFilesForRedaction(selectedFiles ?? []);
   return files.length > 0
     ? { sourceRedactionRequired: sourceFilesHaveBodies(files), sourceFilesForRedaction: files }
     : {};
@@ -394,10 +394,11 @@ function writeSidecar(workspaceRoot, jobId, name, contents) {
 }
 
 function writeExecutionSidecars(workspaceRoot, jobId, execution) {
+  if (!execution) return;
   for (const [name, contents] of [["stdout.log", execution.stdout], ["stderr.log", execution.stderr]]) {
     try { writeSidecar(workspaceRoot, jobId, name, contents); }
     catch (e) {
-      process.stderr.write(`agy-companion: warning: sidecar ${name} write failed: ${e.message}\n`);
+      process.stderr.write(`agy-companion: warning: sidecar ${name} write failed: ${e?.message ?? String(e)}\n`);
     }
   }
 }

--- a/plugins/agy/scripts/agy-companion.mjs
+++ b/plugins/agy/scripts/agy-companion.mjs
@@ -69,7 +69,12 @@ const PREFLIGHT_MODES = Object.freeze(["review", "adversarial-review", "custom-r
 const REVIEW_PROMPT_SOURCE_DELIMITER_PREFIX = "AGY FILE";
 const AGY_SOURCE_PACKET_MAX_BYTES = 256 * 1024;
 const LARGE_SOURCE_PACKET_FLAG = "--allow-large-source-packet";
-const AGY_WRITABLE_SIDECARS = new Set(["git-status-before.txt", "git-status-after.txt"]);
+const AGY_WRITABLE_SIDECARS = new Set([
+  "git-status-before.txt",
+  "git-status-after.txt",
+  "stdout.log",
+  "stderr.log",
+]);
 
 // Set true once the AGY target process has spawned (onSpawn fires on execve), which is
 // the point the selected source packet is delivered to it via --print argv. The top-level
@@ -278,12 +283,7 @@ function promptFor({ userPrompt, selectedFiles, mode, cwd, scope, scopeBase, sco
   return [contractPrompt, selectedSource].filter(Boolean).join("\n\n");
 }
 
-function hasSubstantiveReview(text) {
-  return /Verdict:\s*(APPROVE|REQUEST_CHANGES|COMMENT|FAIL|REJECT)/i.test(text)
-    && /Blocking findings/i.test(text);
-}
-
-function sourceFilesForRedaction(selectedFiles) {
+function sourceFilesForRedaction(selectedFiles = []) {
   return selectedFiles.map(({ path, text, content }) => ({
     path,
     text: typeof text === "string"
@@ -311,6 +311,13 @@ function redactionFieldsForPrompt(prompt) {
       sourceRedactionRequired: sourceFilesHaveBodies(sourceFilesForRedaction),
       sourceFilesForRedaction,
     }
+    : {};
+}
+
+function redactionFieldsForSelected(selectedFiles) {
+  const files = sourceFilesForRedaction(selectedFiles);
+  return files.length > 0
+    ? { sourceRedactionRequired: sourceFilesHaveBodies(files), sourceFilesForRedaction: files }
     : {};
 }
 
@@ -384,6 +391,15 @@ function writeSidecar(workspaceRoot, jobId, name, contents) {
   const file = agySidecarPath(workspaceRoot, jobId, name);
   prepareSidecarJobDirectory(workspaceRoot, file);
   writeFileAtomicDurable(file, contents ?? "");
+}
+
+function writeExecutionSidecars(workspaceRoot, jobId, execution) {
+  for (const [name, contents] of [["stdout.log", execution.stdout], ["stderr.log", execution.stderr]]) {
+    try { writeSidecar(workspaceRoot, jobId, name, contents); }
+    catch (e) {
+      process.stderr.write(`agy-companion: warning: sidecar ${name} write failed: ${e.message}\n`);
+    }
+  }
 }
 
 function gitStatus(args, cwd, workspaceRoot = null) {
@@ -815,8 +831,7 @@ function executionForRecord({ status, pidInfo = null, parsed = null, exitCode = 
     pidInfo,
     agySessionId: parsed?.sessionId ?? null,
     reviewAuditManifest,
-    sourceFilesForRedaction: sourceFilesForRedaction(selectedFiles),
-    sourceRedactionRequired: true,
+    ...redactionFieldsForSelected(selectedFiles),
   };
 }
 
@@ -1310,8 +1325,7 @@ async function run(rest) {
       process.exit(0);
     }
     const preliminarilyCompleted = execution.parsed.ok
-      && execution.exitCode === 0
-      && hasSubstantiveReview(execution.parsed.result ?? "");
+      && execution.exitCode === 0;
     let parsed = preliminarilyCompleted
       ? execution.parsed
       : {
@@ -1319,7 +1333,7 @@ async function run(rest) {
         ok: false,
         reason: execution.parsed.reason ?? "review_not_completed",
         error: execution.parsed.error ?? "AGY did not produce a substantive review verdict",
-        result: null,
+        result: execution.parsed.result ?? (execution.parsed.reason ? null : ""),
       };
     let recordStatus = preliminarilyCompleted ? "completed" : "failed";
     let recordErrorCode = preliminarilyCompleted ? null : (parsed.reason ?? execution.parsed.reason ?? "review_not_completed");
@@ -1344,7 +1358,7 @@ async function run(rest) {
           ok: false,
           reason: "git_binary_rejected",
           error: error?.message ?? String(error),
-          result: null,
+          result: parsed.result ?? execution.parsed.result ?? "",
         };
         recordStatus = "failed";
         recordErrorCode = "git_binary_rejected";
@@ -1362,7 +1376,7 @@ async function run(rest) {
         ok: false,
         reason: parsed.reason ?? "review_not_completed",
         error: parsed.error ?? "AGY did not produce a usable review under the shared review-quality contract",
-        result: null,
+        result: parsed.result ?? execution.parsed.result ?? "",
       };
       recordStatus = "failed";
       recordErrorCode = parsed.reason ?? "review_not_completed";
@@ -1371,7 +1385,7 @@ async function run(rest) {
         selectedFiles,
         timeoutMs,
         invocation,
-        result: "",
+        result: parsed.result ?? "",
         status: recordStatus,
         errorCode: recordErrorCode,
         pidInfo: execution.pidInfo ?? null,
@@ -1386,10 +1400,10 @@ async function run(rest) {
         reviewAuditManifest,
         execution.runtimeDiagnostics ?? null,
       ),
-      sourceFilesForRedaction: sourceFilesForRedaction(selectedFiles),
-      sourceRedactionRequired: true,
+      ...redactionFieldsForSelected(selectedFiles),
     }, mutationContext.mutations);
     persistRecord(invocation.workspace_root, record);
+    writeExecutionSidecars(invocation.workspace_root, invocation.job_id, execution);
     if (containment) { try { containment.cleanup(); } catch { /* best-effort */ } }
     printLifecycleJson(record, lifecycleEvents);
     process.exit(record.status === "completed" ? 0 : 1);
@@ -1476,15 +1490,14 @@ function finalizeRunGitPolicyEscape({
           ok: false,
           reason: "git_binary_rejected",
           error: message,
-          result: null,
+          result: execution.parsed?.result ?? "",
         },
         reviewAuditManifest,
         runtimeDiagnostics: sourcePacketRuntimeDiagnosticsForManifest(
           reviewAuditManifest,
           execution.runtimeDiagnostics ?? null,
         ),
-        sourceFilesForRedaction: sourceFilesForRedaction(selectedFiles),
-        sourceRedactionRequired: true,
+        ...redactionFieldsForSelected(selectedFiles),
       }
       : executionForRecord({
         status: "failed",

--- a/relay/relay-agy/scripts/agy-companion.mjs
+++ b/relay/relay-agy/scripts/agy-companion.mjs
@@ -315,7 +315,7 @@ function redactionFieldsForPrompt(prompt) {
 }
 
 function redactionFieldsForSelected(selectedFiles) {
-  const files = sourceFilesForRedaction(selectedFiles);
+  const files = sourceFilesForRedaction(selectedFiles ?? []);
   return files.length > 0
     ? { sourceRedactionRequired: sourceFilesHaveBodies(files), sourceFilesForRedaction: files }
     : {};
@@ -394,10 +394,11 @@ function writeSidecar(workspaceRoot, jobId, name, contents) {
 }
 
 function writeExecutionSidecars(workspaceRoot, jobId, execution) {
+  if (!execution) return;
   for (const [name, contents] of [["stdout.log", execution.stdout], ["stderr.log", execution.stderr]]) {
     try { writeSidecar(workspaceRoot, jobId, name, contents); }
     catch (e) {
-      process.stderr.write(`agy-companion: warning: sidecar ${name} write failed: ${e.message}\n`);
+      process.stderr.write(`agy-companion: warning: sidecar ${name} write failed: ${e?.message ?? String(e)}\n`);
     }
   }
 }

--- a/relay/relay-agy/scripts/agy-companion.mjs
+++ b/relay/relay-agy/scripts/agy-companion.mjs
@@ -69,7 +69,12 @@ const PREFLIGHT_MODES = Object.freeze(["review", "adversarial-review", "custom-r
 const REVIEW_PROMPT_SOURCE_DELIMITER_PREFIX = "AGY FILE";
 const AGY_SOURCE_PACKET_MAX_BYTES = 256 * 1024;
 const LARGE_SOURCE_PACKET_FLAG = "--allow-large-source-packet";
-const AGY_WRITABLE_SIDECARS = new Set(["git-status-before.txt", "git-status-after.txt"]);
+const AGY_WRITABLE_SIDECARS = new Set([
+  "git-status-before.txt",
+  "git-status-after.txt",
+  "stdout.log",
+  "stderr.log",
+]);
 
 // Set true once the AGY target process has spawned (onSpawn fires on execve), which is
 // the point the selected source packet is delivered to it via --print argv. The top-level
@@ -278,12 +283,7 @@ function promptFor({ userPrompt, selectedFiles, mode, cwd, scope, scopeBase, sco
   return [contractPrompt, selectedSource].filter(Boolean).join("\n\n");
 }
 
-function hasSubstantiveReview(text) {
-  return /Verdict:\s*(APPROVE|REQUEST_CHANGES|COMMENT|FAIL|REJECT)/i.test(text)
-    && /Blocking findings/i.test(text);
-}
-
-function sourceFilesForRedaction(selectedFiles) {
+function sourceFilesForRedaction(selectedFiles = []) {
   return selectedFiles.map(({ path, text, content }) => ({
     path,
     text: typeof text === "string"
@@ -311,6 +311,13 @@ function redactionFieldsForPrompt(prompt) {
       sourceRedactionRequired: sourceFilesHaveBodies(sourceFilesForRedaction),
       sourceFilesForRedaction,
     }
+    : {};
+}
+
+function redactionFieldsForSelected(selectedFiles) {
+  const files = sourceFilesForRedaction(selectedFiles);
+  return files.length > 0
+    ? { sourceRedactionRequired: sourceFilesHaveBodies(files), sourceFilesForRedaction: files }
     : {};
 }
 
@@ -384,6 +391,15 @@ function writeSidecar(workspaceRoot, jobId, name, contents) {
   const file = agySidecarPath(workspaceRoot, jobId, name);
   prepareSidecarJobDirectory(workspaceRoot, file);
   writeFileAtomicDurable(file, contents ?? "");
+}
+
+function writeExecutionSidecars(workspaceRoot, jobId, execution) {
+  for (const [name, contents] of [["stdout.log", execution.stdout], ["stderr.log", execution.stderr]]) {
+    try { writeSidecar(workspaceRoot, jobId, name, contents); }
+    catch (e) {
+      process.stderr.write(`agy-companion: warning: sidecar ${name} write failed: ${e.message}\n`);
+    }
+  }
 }
 
 function gitStatus(args, cwd, workspaceRoot = null) {
@@ -815,8 +831,7 @@ function executionForRecord({ status, pidInfo = null, parsed = null, exitCode = 
     pidInfo,
     agySessionId: parsed?.sessionId ?? null,
     reviewAuditManifest,
-    sourceFilesForRedaction: sourceFilesForRedaction(selectedFiles),
-    sourceRedactionRequired: true,
+    ...redactionFieldsForSelected(selectedFiles),
   };
 }
 
@@ -1310,8 +1325,7 @@ async function run(rest) {
       process.exit(0);
     }
     const preliminarilyCompleted = execution.parsed.ok
-      && execution.exitCode === 0
-      && hasSubstantiveReview(execution.parsed.result ?? "");
+      && execution.exitCode === 0;
     let parsed = preliminarilyCompleted
       ? execution.parsed
       : {
@@ -1319,7 +1333,7 @@ async function run(rest) {
         ok: false,
         reason: execution.parsed.reason ?? "review_not_completed",
         error: execution.parsed.error ?? "AGY did not produce a substantive review verdict",
-        result: null,
+        result: execution.parsed.result ?? (execution.parsed.reason ? null : ""),
       };
     let recordStatus = preliminarilyCompleted ? "completed" : "failed";
     let recordErrorCode = preliminarilyCompleted ? null : (parsed.reason ?? execution.parsed.reason ?? "review_not_completed");
@@ -1344,7 +1358,7 @@ async function run(rest) {
           ok: false,
           reason: "git_binary_rejected",
           error: error?.message ?? String(error),
-          result: null,
+          result: parsed.result ?? execution.parsed.result ?? "",
         };
         recordStatus = "failed";
         recordErrorCode = "git_binary_rejected";
@@ -1362,7 +1376,7 @@ async function run(rest) {
         ok: false,
         reason: parsed.reason ?? "review_not_completed",
         error: parsed.error ?? "AGY did not produce a usable review under the shared review-quality contract",
-        result: null,
+        result: parsed.result ?? execution.parsed.result ?? "",
       };
       recordStatus = "failed";
       recordErrorCode = parsed.reason ?? "review_not_completed";
@@ -1371,7 +1385,7 @@ async function run(rest) {
         selectedFiles,
         timeoutMs,
         invocation,
-        result: "",
+        result: parsed.result ?? "",
         status: recordStatus,
         errorCode: recordErrorCode,
         pidInfo: execution.pidInfo ?? null,
@@ -1386,10 +1400,10 @@ async function run(rest) {
         reviewAuditManifest,
         execution.runtimeDiagnostics ?? null,
       ),
-      sourceFilesForRedaction: sourceFilesForRedaction(selectedFiles),
-      sourceRedactionRequired: true,
+      ...redactionFieldsForSelected(selectedFiles),
     }, mutationContext.mutations);
     persistRecord(invocation.workspace_root, record);
+    writeExecutionSidecars(invocation.workspace_root, invocation.job_id, execution);
     if (containment) { try { containment.cleanup(); } catch { /* best-effort */ } }
     printLifecycleJson(record, lifecycleEvents);
     process.exit(record.status === "completed" ? 0 : 1);
@@ -1476,15 +1490,14 @@ function finalizeRunGitPolicyEscape({
           ok: false,
           reason: "git_binary_rejected",
           error: message,
-          result: null,
+          result: execution.parsed?.result ?? "",
         },
         reviewAuditManifest,
         runtimeDiagnostics: sourcePacketRuntimeDiagnosticsForManifest(
           reviewAuditManifest,
           execution.runtimeDiagnostics ?? null,
         ),
-        sourceFilesForRedaction: sourceFilesForRedaction(selectedFiles),
-        sourceRedactionRequired: true,
+        ...redactionFieldsForSelected(selectedFiles),
       }
       : executionForRecord({
         status: "failed",

--- a/scripts/ab/verify/P4-agy-substantive-substring.mjs
+++ b/scripts/ab/verify/P4-agy-substantive-substring.mjs
@@ -1,17 +1,6 @@
-// P4 — Root 3 "no-single-source": AGY hasSubstantiveReview substring divergence.
-//
-// CLAIM: AGY-only hasSubstantiveReview requires the literal substring
-// "Blocking findings" (case-insensitive) plus a verdict regex; valid reviews
-// the SHARED contract accepts get relabeled review_not_completed and nulled.
-//
-// METHOD:
-//  1) Import the REAL shared contract (buildReviewAuditManifest -> qualityFlags)
-//     from plugins/agy/scripts/lib/review-prompt.mjs and feed it a review that
-//     uses "Blockers:" (a phrasing the shared contract explicitly whitelists).
-//  2) Replicate the AGY-local hasSubstantiveReview gate VERBATIM from current
-//     HEAD agy-companion.mjs lines 232-233 (function is not exported, so it is
-//     copied byte-for-byte and labeled). Run it on the SAME review text.
-//  3) Show whether the shared contract accepts it while AGY rejects it.
+// P4 regression guard: AGY must not require the literal substring
+// "Blocking findings" after the shared review-quality gate accepts equivalent
+// phrasing such as "Blockers:" or "Must fix:".
 
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
@@ -23,64 +12,54 @@ const reviewPromptPath = resolve(repoRoot, "plugins/agy/scripts/lib/review-promp
 const agyCompanionPath = resolve(repoRoot, "plugins/agy/scripts/agy-companion.mjs");
 
 if (!existsSync(reviewPromptPath) || !existsSync(agyCompanionPath)) {
-  console.log("SKIPPED: requires AGY plugin (PR #218) — not present on this branch");
+  console.log("SKIPPED: requires AGY plugin (PR #218) - not present on this branch");
   process.exit(0);
 }
 
 const { buildReviewAuditManifest } = await import(reviewPromptPath);
-
-// --- VERBATIM copy of AGY-local gate (agy-companion.mjs:231-234, current HEAD).
-// Verified below against the real source to guard against drift.
-function hasSubstantiveReview(text) {
-  return /Verdict:\s*(APPROVE|REQUEST_CHANGES|COMMENT|FAIL|REJECT)/i.test(text)
-    && /Blocking findings/i.test(text);
-}
-
-// Drift guard: assert the two regexes literally appear in current-HEAD source.
 const companionSrc = readFileSync(agyCompanionPath, "utf8");
-const verdictReSrc = "/Verdict:\\s*(APPROVE|REQUEST_CHANGES|COMMENT|FAIL|REJECT)/i";
-const blockingReSrc = "/Blocking findings/i";
-const driftOk = companionSrc.includes(verdictReSrc) && companionSrc.includes(blockingReSrc);
-console.log("[drift-guard] AGY-local regexes present in current-HEAD source:", driftOk);
-if (!driftOk) {
-  console.log("[drift-guard] WARNING: source drifted; copied gate may be stale.");
-}
 
-// Padding so the review exceeds the shared contract's 500-char "looks_shallow"
-// threshold — this isolates the blocking-phrase variable from the length
-// heuristic that both gates share.
-const pad = (n) => Array.from({ length: n }, (_, i) =>
-  `- src/module${i}.js:${100 + i} — inspected the changed control flow and data handling; ` +
-  `confirmed the new branch preserves the invariant and adds no regression. Concrete file/function evidence noted.`
-).join("\n");
+const localGateRemoved = !/\bfunction\s+hasSubstantiveReview\b/.test(companionSrc)
+  && !/hasSubstantiveReview\(/.test(companionSrc)
+  && !/\/Blocking findings\/i/.test(companionSrc);
 
-// A correct, substantive (>500 char) review that phrases its blocking section as
-// "Blockers:" and lacks the literal "Blocking findings". Valid verdict present.
-const reviewWithBlockers = [
-  "Verdict: REQUEST_CHANGES",
-  "",
-  "Blockers:",
-  "- src/auth.js:42 — the token check is bypassed when the header is absent;",
-  "  control flow falls through to the authorized branch. Concrete evidence.",
-  pad(4),
-  "",
-  "Non-blocking:",
-  "- src/util.js:10 — minor naming nit, residual risk negligible.",
-].join("\n");
+console.log("[source-guard] AGY-local hasSubstantiveReview gate removed:", localGateRemoved);
 
-// Same, phrased as "Must fix:" (shared whitelist: blocker/blockers).
-const reviewWithMustFix = [
-  "Verdict: REQUEST_CHANGES",
-  "",
-  "Must fix:",
-  "- src/auth.js:42 — token check bypassed; this is a blocker for merge.",
-  pad(4),
-  "",
-  "Non-blocking:",
-  "- src/util.js:10 — minor concern only.",
-].join("\n");
+const pad = (n) => Array.from({ length: n }, (_, i) => (
+  `- src/module${i}.js:${100 + i} inspected concrete control flow, source routing, tests, and security-sensitive behavior with enough detail to exceed the shared review-quality shallow threshold.`
+)).join("\n");
 
-function sharedContractVerdict(result) {
+const cases = [
+  [
+    "Blockers:",
+    [
+      "Verdict: REQUEST_CHANGES",
+      "",
+      "Blockers:",
+      "- src/auth.js:42 auth validation is bypassed when the header is absent; this blocks merge.",
+      pad(4),
+      "",
+      "Non-blocking concerns:",
+      "- Residual risk: no additional concern was found after reviewing the selected source packet.",
+    ].join("\n"),
+  ],
+  [
+    "Must fix:",
+    [
+      "Verdict: REQUEST_CHANGES",
+      "",
+      "Must fix:",
+      "- src/auth.js:42 auth validation is bypassed when the header is absent; this is a blocker for merge.",
+      pad(4),
+      "",
+      "Non-blocking concerns:",
+      "- Residual risk: no additional concern was found after reviewing the selected source packet.",
+    ].join("\n"),
+  ],
+];
+
+let allAccepted = true;
+for (const [label, result] of cases) {
   const manifest = buildReviewAuditManifest({
     prompt: "review prompt",
     sourceFiles: [],
@@ -89,53 +68,20 @@ function sharedContractVerdict(result) {
     errorCode: null,
   });
   const rq = manifest.review_quality ?? {};
-  return {
-    has_verdict: rq.has_verdict,
-    has_blocking_section: rq.has_blocking_section,
-    has_non_blocking_section: rq.has_non_blocking_section,
-    looks_shallow: rq.looks_shallow,
-    semantic_failure_reasons: rq.semantic_failure_reasons,
-    failed_review_slot: rq.failed_review_slot,
-  };
-}
-
-function report(label, text) {
-  const shared = sharedContractVerdict(text);
-  const agyAccepts = hasSubstantiveReview(text);
-  // AGY pipeline (agy-companion.mjs:1213-1224): preliminarilyCompleted requires
-  // hasSubstantiveReview; otherwise result is nulled with reason
-  // "review_not_completed".
-  const agyOutcome = agyAccepts ? "completed (result kept)" : "review_not_completed (result NULLED)";
+  const accepted = rq.failed_review_slot === false
+    && rq.has_verdict === true
+    && rq.has_blocking_section === true
+    && !/Blocking findings/i.test(result);
+  allAccepted &&= accepted;
   console.log(`\n=== ${label} ===`);
-  console.log("review text contains literal 'Blocking findings':", /Blocking findings/i.test(text));
-  console.log("SHARED contract has_blocking_section:", shared.has_blocking_section);
-  console.log("SHARED contract failed_review_slot:", shared.failed_review_slot);
-  console.log("SHARED contract semantic_failure_reasons:", JSON.stringify(shared.semantic_failure_reasons));
-  console.log("AGY-local hasSubstantiveReview accepts:", agyAccepts);
-  console.log("AGY pipeline outcome:", agyOutcome);
-  const divergence = (shared.failed_review_slot === false) && (agyAccepts === false);
-  console.log("DIVERGENCE (shared accepts, AGY rejects):", divergence);
-  return divergence;
+  console.log("contains literal 'Blocking findings':", /Blocking findings/i.test(result));
+  console.log("shared has_blocking_section:", rq.has_blocking_section);
+  console.log("shared failed_review_slot:", rq.failed_review_slot);
+  console.log("shared semantic_failure_reasons:", JSON.stringify(rq.semantic_failure_reasons));
+  console.log("fixed behavior accepted:", accepted);
 }
 
-const d1 = report("Review phrased with 'Blockers:'", reviewWithBlockers);
-const d2 = report("Review phrased with 'Must fix:'", reviewWithMustFix);
-
-// Sanity control: a review that DOES use the literal "Blocking findings"
-// should pass BOTH gates (proves AGY gate isn't rejecting everything).
-const reviewWithLiteral = [
-  "Verdict: REQUEST_CHANGES",
-  "",
-  "Blocking findings:",
-  "- src/auth.js:42 — token check bypassed.",
-  pad(4),
-  "",
-  "Non-blocking:",
-  "- src/util.js:10 — minor concern.",
-].join("\n");
-const ctl = sharedContractVerdict(reviewWithLiteral);
-console.log("\n=== CONTROL: literal 'Blocking findings:' ===");
-console.log("SHARED failed_review_slot:", ctl.failed_review_slot, "| AGY accepts:", hasSubstantiveReview(reviewWithLiteral));
-
+const fixed = localGateRemoved && allAccepted;
 console.log("\n=== SUMMARY ===");
-console.log("Any valid review accepted by shared contract but rejected by AGY:", d1 || d2);
+console.log("AGY uses shared review-quality gate only for substantive phrasing:", fixed);
+process.exit(fixed ? 0 : 1);

--- a/scripts/ab/verify/P5-agy-hardcoded-redaction-and-nonatomic-persist.mjs
+++ b/scripts/ab/verify/P5-agy-hardcoded-redaction-and-nonatomic-persist.mjs
@@ -1,29 +1,27 @@
-// P5 reproduction: AGY hardcodes sourceRedactionRequired:true at every
-// completed-review job-record build, while kimi/gemini compute it via
-// sourceFilesHaveBodies(...). Empty-source completed reviews therefore throw
-// in buildJobRecord (assertRequiredSourceRedaction) on AGY and never persist,
-// whereas kimi-style redaction fields ({} when no source bodies) do not throw.
-//
-// Imports the REAL repo modules. Read-only; writes nothing to repo source.
+// P5 regression guard: AGY completed records must not hardcode
+// sourceRedactionRequired:true when selected source has no redaction bodies.
+// Empty-source completed records must pass through the real buildJobRecord.
+
 import { fileURLToPath } from "node:url";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.resolve(HERE, "../../..");
 const agyJobRecordPath = path.join(REPO, "plugins/agy/scripts/lib/job-record.mjs");
+const agyCompanionPath = path.join(REPO, "plugins/agy/scripts/agy-companion.mjs");
 
-if (!existsSync(agyJobRecordPath)) {
-  console.log("SKIPPED: requires AGY plugin (PR #218) — not present on this branch");
+if (!existsSync(agyJobRecordPath) || !existsSync(agyCompanionPath)) {
+  console.log("SKIPPED: requires AGY plugin (PR #218) - not present on this branch");
   process.exit(0);
 }
 
 const { buildJobRecord } = await import(agyJobRecordPath);
+const companionSrc = readFileSync(agyCompanionPath, "utf8");
 
-// Minimal valid invocation satisfying assertInvocation's required-field list.
 function makeInvocation() {
   return {
-    job_id: "job-p5-test",
+    job_id: "job-p5-fixed",
     target: "agy",
     mode: "review",
     mode_profile_name: "review",
@@ -31,7 +29,7 @@ function makeInvocation() {
     cwd: "/tmp/p5",
     workspace_root: "/tmp/p5",
     containment: "worktree",
-    scope: "worktree",
+    scope: "branch-diff",
     prompt_head: "review the diff",
     binary: "agy",
     started_at: new Date().toISOString(),
@@ -39,85 +37,61 @@ function makeInvocation() {
   };
 }
 
-// A *completed* parsed result — a real, successful external review.
-const completedParsed = { ok: true, result: "LGTM", structured: null, denials: [] };
+const completedParsed = {
+  ok: true,
+  result: "Verdict: APPROVE\n\nBlocking findings:\n- None.\n\nNon-blocking concerns:\n- None.",
+  structured: null,
+  denials: [],
+};
 
-// ---------------------------------------------------------------------------
-// CASE 1: AGY completed-record path. Mirrors agy-companion.mjs line ~1282-1291:
-//   buildJobRecord(invocation, { ...execution, sourceFilesForRedaction: <empty>,
-//                                sourceRedactionRequired: true }, mutations)
-// when the selected source files have NO bodies (empty array). This is the
-// empty-source completed-review case.
-// ---------------------------------------------------------------------------
-function agyCompletedRecordEmptySource() {
-  const execution = {
+function completedRecordWithComputedEmptySource() {
+  const redactionFields = {};
+  return buildJobRecord(makeInvocation(), {
     exitCode: 0,
     endedAt: new Date().toISOString(),
     parsed: completedParsed,
     pidInfo: null,
     agySessionId: null,
     reviewAuditManifest: null,
-    // AGY hardcodes BOTH of these on the completed path:
-    sourceFilesForRedaction: [], // empty: no source bodies available
-    sourceRedactionRequired: true, // <-- hardcoded literal in agy-companion.mjs
-  };
-  return buildJobRecord(makeInvocation(), execution, []);
-}
-
-// ---------------------------------------------------------------------------
-// CASE 2: kimi/gemini-style. They spread `...redactionFieldsForPrompt(prompt)`,
-// which returns {} when there are no selected source files (so NEITHER
-// sourceRedactionRequired NOR sourceFilesForRedaction is present), and returns
-// sourceRedactionRequired: sourceFilesHaveBodies(...) otherwise. Reproduce the
-// no-source-file completed review: the redaction fields object is {}.
-// ---------------------------------------------------------------------------
-function siblingCompletedRecordEmptySource() {
-  const redactionFields = {}; // kimi redactionFieldsForPrompt(prompt) with no source files
-  const execution = {
-    exitCode: 0,
-    endedAt: new Date().toISOString(),
-    parsed: completedParsed,
-    pidInfo: null,
-    kimiSessionId: null,
-    reviewAuditManifest: null,
     ...redactionFields,
-  };
-  return buildJobRecord(makeInvocation(), execution, []);
+  }, []);
 }
 
-let agyThrew = false;
-let agyErr = null;
-try {
-  const rec = agyCompletedRecordEmptySource();
-  console.log("CASE1 AGY: NO THROW — status=" + rec.status);
-} catch (e) {
-  agyThrew = true;
-  agyErr = e.message;
-  console.log("CASE1 AGY: THREW -> " + e.message);
-}
+const helperPresent = /function\s+redactionFieldsForSelected\s*\(/.test(companionSrc)
+  && /sourceRedactionRequired:\s*sourceFilesHaveBodies\(files\)/.test(companionSrc)
+  && /sourceFilesForRedaction:\s*files/.test(companionSrc);
+const executionForRecordUsesHelper = /function\s+executionForRecord[\s\S]*\.\.\.redactionFieldsForSelected\(selectedFiles\)/.test(companionSrc);
+const noHardcodedSelectedPairs = !/sourceFilesForRedaction:\s*sourceFilesForRedaction\(selectedFiles\)[\s\S]{0,120}sourceRedactionRequired:\s*true/.test(companionSrc)
+  && !/sourceRedactionRequired:\s*true[\s\S]{0,120}sourceFilesForRedaction:\s*sourceFilesForRedaction\(selectedFiles\)/.test(companionSrc);
 
-let siblingThrew = false;
+let recordStatus = null;
+let recordResult = null;
+let threw = false;
 try {
-  const rec = siblingCompletedRecordEmptySource();
-  console.log("CASE2 sibling-style: NO THROW — status=" + rec.status);
+  const rec = completedRecordWithComputedEmptySource();
+  recordStatus = rec.status;
+  recordResult = rec.result;
+  console.log("CASE fixed empty-source completed record: NO THROW - status=" + rec.status);
 } catch (e) {
-  siblingThrew = true;
-  console.log("CASE2 sibling-style: THREW -> " + e.message);
+  threw = true;
+  console.log("CASE fixed empty-source completed record: THREW -> " + e.message);
 }
 
 console.log("---");
-console.log("AGY hardcoded-true completed record threw on empty source: " + agyThrew);
-console.log("Sibling computed-redaction completed record threw on empty source: " + siblingThrew);
+console.log("helper redactionFieldsForSelected present:", helperPresent);
+console.log("executionForRecord uses helper:", executionForRecordUsesHelper);
+console.log("hardcoded selected-file redaction pairs absent:", noHardcodedSelectedPairs);
+console.log("empty-source completed record threw:", threw);
+console.log("empty-source completed record status:", recordStatus);
 
-const pinned =
-  agyThrew &&
-  agyErr === "source redaction unavailable: selected source bodies missing for required scan" &&
-  !siblingThrew;
+const fixed = helperPresent
+  && executionForRecordUsesHelper
+  && noHardcodedSelectedPairs
+  && !threw
+  && recordStatus === "completed"
+  && recordResult === completedParsed.result;
 
-console.log(
-  "VERDICT: " +
-    (pinned
-      ? "PINNED — AGY completed review with no source bodies throws in buildJobRecord and never persists; kimi-style does not."
-      : "NOT-PINNED — see output above.")
-);
-process.exit(pinned ? 0 : 3);
+console.log("VERDICT: " + (fixed
+  ? "FIXED - AGY computes redaction fields and empty-source completed records persist."
+  : "NOT-FIXED - see output above."));
+process.exit(fixed ? 0 : 3);

--- a/scripts/ab/verify/P7-raw-loss-agy-specific.mjs
+++ b/scripts/ab/verify/P7-raw-loss-agy-specific.mjs
@@ -1,23 +1,14 @@
-// P7 verification: is discarded raw output AGY-SPECIFIC, or a shared job-record behavior?
-//
-// CORRECTION UNDER TEST: the nulling of parsed.result is AGY-SPECIFIC (AGY companion
-// nulls result before record construction), while gemini/kimi/claude store result when
-// present AND write stdout/stderr sidecars — so raw-output recovery exists for non-AGY
-// providers but not AGY.
-//
-// Strategy: import the REAL buildJobRecord from agy + gemini job-record.mjs. Feed an
-// IDENTICAL execution where the CLI DID produce a non-empty result/stdout, but the run
-// is treated as a review FAILURE. Apply each provider's companion-specific transform to
-// `parsed` exactly as the real companion does on the failure path, then call the real
-// buildJobRecord and inspect the persisted `result`. Separately, check whether each
-// provider's companion writes stdout.log/stderr.log sidecars (the recovery path).
+// P7 regression guard: AGY review-failure finalization must retain produced
+// result text and provide stdout/stderr sidecar recovery, matching the shared
+// sibling-provider contract.
 
 import { buildJobRecord as buildGeminiRecord } from "../../../plugins/gemini/scripts/lib/job-record.mjs";
 import { existsSync, readFileSync } from "node:fs";
 
 const agyJobRecordUrl = new URL("../../../plugins/agy/scripts/lib/job-record.mjs", import.meta.url);
-if (!existsSync(agyJobRecordUrl)) {
-  console.log("SKIPPED: requires AGY plugin (PR #218) — not present on this branch");
+const agyCompanionUrl = new URL("../../../plugins/agy/scripts/agy-companion.mjs", import.meta.url);
+if (!existsSync(agyJobRecordUrl) || !existsSync(agyCompanionUrl)) {
+  console.log("SKIPPED: requires AGY plugin (PR #218) - not present on this branch");
   process.exit(0);
 }
 const { buildJobRecord: buildAgyRecord } = await import(agyJobRecordUrl);
@@ -25,13 +16,12 @@ const { buildJobRecord: buildAgyRecord } = await import(agyJobRecordUrl);
 const C = (s) => `\x1b[36m${s}\x1b[0m`;
 function line() { console.log("-".repeat(72)); }
 
-// ---- Shared, identical raw execution output (the CLI DID produce content) ----
 const RAW_STDOUT = '{"ok":true,"result":"REVIEW BODY: 3 findings, see below ...."}';
 const RAW_RESULT = "REVIEW BODY: 3 findings, see below ....";
 
 function makeInvocation() {
   return {
-    job_id: "job-P7",
+    job_id: "job-P7-fixed",
     target: "tgt",
     mode: "review",
     mode_profile_name: "default",
@@ -47,7 +37,6 @@ function makeInvocation() {
   };
 }
 
-// Execution as it exists at finalize time: CLI succeeded shape-wise, result present.
 function makeExecution(parsedOverride) {
   return {
     exitCode: 0,
@@ -58,78 +47,66 @@ function makeExecution(parsedOverride) {
   };
 }
 
-// ---- AGY companion failure-path transform (agy-companion.mjs lines ~1216-1267) ----
-// On a review-not-completed / mutation / policy failure, AGY rebuilds `parsed` with
-//   result: null   BEFORE calling buildJobRecord.
-function agyCompanionFailureTransform(execParsed) {
+function retainedReviewFailureParsed(execParsed) {
   return {
     ...execParsed,
     ok: false,
     reason: execParsed.reason ?? "review_not_completed",
-    error: execParsed.error ?? "AGY did not produce a substantive review verdict",
-    result: null, // <-- the AGY-specific nulling
+    error: execParsed.error ?? "AGY did not produce a usable review under the shared review-quality contract",
+    result: execParsed.result ?? "",
   };
 }
 
-// ---- Gemini companion finalize (gemini-companion.mjs buildGeminiFinalRecord ~1749) ----
-// Passes parsed: execution.parsed UNMODIFIED. No result nulling on review failure.
-function geminiCompanionFinalizeTransform(execParsed) {
-  return execParsed; // pass-through; result retained
-}
+console.log(C("\n=== P7: AGY raw-output retention and sidecar recovery ===\n"));
 
-console.log(C("\n=== P7: AGY-specific raw-output loss vs non-AGY retention ===\n"));
-
-// 1) AGY path
-const agyParsed = agyCompanionFailureTransform({ ok: true, result: RAW_RESULT });
+const agyParsed = retainedReviewFailureParsed({ ok: true, result: RAW_RESULT });
 const agyRecord = buildAgyRecord(makeInvocation(), makeExecution(agyParsed), []);
-console.log(C("AGY companion (failure path) -> buildJobRecord:"));
-console.log(`  parsed.result fed in (post-transform): ${JSON.stringify(agyParsed.result)}`);
-console.log(`  persisted record.result            : ${JSON.stringify(agyRecord.result)}`);
-console.log(`  raw stdout that existed             : ${JSON.stringify(RAW_STDOUT.slice(0, 40))}...`);
+console.log(C("AGY fixed failure path -> buildJobRecord:"));
+console.log(`  parsed.result fed in          : ${JSON.stringify(agyParsed.result)}`);
+console.log(`  persisted record.result       : ${JSON.stringify(agyRecord.result)}`);
+console.log(`  raw stdout that existed       : ${JSON.stringify(RAW_STDOUT.slice(0, 40))}...`);
 line();
 
-// 2) Gemini path (SAME raw execution, treated as the SAME kind of run)
-const gemParsed = geminiCompanionFinalizeTransform({ ok: true, result: RAW_RESULT });
+const gemParsed = { ok: false, reason: "review_not_completed", error: "review quality failed", result: RAW_RESULT };
 const gemRecord = buildGeminiRecord(makeInvocation(), makeExecution(gemParsed), []);
-console.log(C("Gemini companion (finalize) -> buildJobRecord:"));
-console.log(`  parsed.result fed in (pass-through): ${JSON.stringify(gemParsed.result)}`);
-console.log(`  persisted record.result            : ${JSON.stringify(gemRecord.result)}`);
+console.log(C("Gemini failure path -> buildJobRecord:"));
+console.log(`  parsed.result fed in          : ${JSON.stringify(gemParsed.result)}`);
+console.log(`  persisted record.result       : ${JSON.stringify(gemRecord.result)}`);
 line();
 
-// 3) Sidecar recovery presence: grep the REAL companion sources for stdout.log/stderr.log writes.
 function companionWritesRawSidecar(path) {
   const src = readFileSync(path, "utf8");
   return /\[\s*"stdout\.log"\s*,\s*execution\.stdout\s*\]/.test(src)
-    || /"stdout\.log"\s*,\s*\w+\.stdout/.test(src);
+    && /\[\s*"stderr\.log"\s*,\s*execution\.stderr\s*\]/.test(src);
 }
+
 const base = "../../../plugins";
 const sidecarTable = [
-  ["agy",    new URL(`${base}/agy/scripts/agy-companion.mjs`, import.meta.url)],
+  ["agy", new URL(`${base}/agy/scripts/agy-companion.mjs`, import.meta.url)],
   ["gemini", new URL(`${base}/gemini/scripts/gemini-companion.mjs`, import.meta.url)],
-  ["kimi",   new URL(`${base}/kimi/scripts/kimi-companion.mjs`, import.meta.url)],
+  ["kimi", new URL(`${base}/kimi/scripts/kimi-companion.mjs`, import.meta.url)],
   ["claude", new URL(`${base}/claude/scripts/claude-companion.mjs`, import.meta.url)],
 ];
-console.log(C("Raw stdout/stderr sidecar (recovery path) written by companion?"));
+console.log(C("Raw stdout/stderr sidecar written by companion?"));
 const sidecarResults = {};
 for (const [name, url] of sidecarTable) {
   const has = companionWritesRawSidecar(url);
   sidecarResults[name] = has;
-  console.log(`  ${name.padEnd(7)} writes stdout.log sidecar: ${has}`);
+  console.log(`  ${name.padEnd(7)} writes stdout/stderr sidecars: ${has}`);
 }
 line();
 
-// ---- Verdict ----
-const agyLostResult = agyRecord.result === null;
+const agyRetainedResult = agyRecord.result === RAW_RESULT;
 const gemRetainedResult = gemRecord.result === RAW_RESULT;
-const agyNoSidecar = sidecarResults.agy === false;
+const agyHasSidecar = sidecarResults.agy === true;
 const othersHaveSidecar = sidecarResults.gemini && sidecarResults.kimi && sidecarResults.claude;
 
 console.log(C("VERDICT"));
-console.log(`  AGY nulled result in persisted record   : ${agyLostResult}`);
+console.log(`  AGY retained result in persisted record : ${agyRetainedResult}`);
 console.log(`  Gemini retained result (same raw input) : ${gemRetainedResult}`);
-console.log(`  AGY lacks raw stdout sidecar recovery   : ${agyNoSidecar}`);
-console.log(`  gemini+kimi+claude HAVE sidecar recovery: ${othersHaveSidecar}`);
+console.log(`  AGY has raw stdout/stderr sidecars      : ${agyHasSidecar}`);
+console.log(`  gemini+kimi+claude have sidecars        : ${othersHaveSidecar}`);
 
-const asymmetryHolds = agyLostResult && gemRetainedResult && agyNoSidecar && othersHaveSidecar;
-console.log(`\n  ASYMMETRY HOLDS (AGY loses raw output, non-AGY recoverable): ${asymmetryHolds}`);
-process.exit(asymmetryHolds ? 0 : 1);
+const fixed = agyRetainedResult && gemRetainedResult && agyHasSidecar && othersHaveSidecar;
+console.log(`\n  FIXED CONTRACT HOLDS: ${fixed}`);
+process.exit(fixed ? 0 : 1);

--- a/tests/unit/agy-shared-finalization.test.mjs
+++ b/tests/unit/agy-shared-finalization.test.mjs
@@ -255,6 +255,71 @@ test("empty-source completed AGY review persists through buildJobRecord", async 
   assert.equal(record.result, reviewBody);
 });
 
+test("source-bearing AGY review redacts the canonical record while the raw sidecar stays local-only", () => {
+  // I1 boundary (PR #218): the spawn-based companion contract persists RAW
+  // stdout.log/stderr.log diagnostics in the owner-only job dir
+  // (docs/artifact-cleanup-inventory.md line 19), but the transmitted/canonical
+  // JobRecord MUST stay redacted. This pins both surfaces in one source-bearing
+  // run so a future change that routes raw target output into record.result
+  // (the exact leak the review panel split on) fails loudly here.
+  const cwd = mkdtempSync(path.join(tmpdir(), "agy-i1-boundary-cwd-"));
+  const dataDir = mkdtempSync(path.join(tmpdir(), "agy-i1-boundary-data-"));
+  const sentinel = "SOURCELEAKSENTINELq7zX";
+  // One contiguous line > MAX_SOURCE_CONTIGUOUS_CHARS (200) so the privacy
+  // redactor collapses the whole run (sentinel included) to the excerpt marker.
+  const sourceLine = `leak probe ${"A".repeat(110)}${sentinel}${"B".repeat(110)} end`;
+  assert.ok(sourceLine.length > 200, "probe source line must exceed the contiguous redaction threshold");
+  const reviewBody = [
+    "Verdict: APPROVE",
+    "",
+    "Blocking findings:",
+    "- None. I inspected the selected source packet and found no blocking issue.",
+    ...padReviewLines(),
+    "",
+    "Quoted source under review:",
+    sourceLine,
+    "",
+    "Non-blocking concerns:",
+    "- Residual risk: no additional non-blocking concerns were found after reviewing the selected source packet.",
+    "",
+  ].join("\n");
+  const stderrText = `worker diagnostics carrying the raw packet ${sentinel}\n`;
+  const binary = writeAgyReviewMock(cwd, "agy-i1-boundary-mock", { body: reviewBody, stderr: stderrText });
+  const { base } = fixtureBranchDiffRepo(cwd, {
+    changedFileName: "secret-source.js",
+    changedFileContents: `${sourceLine}\n`,
+  });
+  const run = runCompanion(
+    ["run", "--mode", "review", "--foreground", "--lifecycle-events", "jsonl",
+      "--binary", binary, "--cwd", cwd, "--scope-base", base, "--", "review redaction boundary"],
+    { cwd, dataDir },
+  );
+  try {
+    assert.equal(run.status, 0, `exit ${run.status}: ${run.stderr || run.stdout}`);
+    const record = terminalRecord(run);
+    assert.equal(record.status, "completed", `status ${record.status}: ${JSON.stringify(record.review_quality)}`);
+
+    // Canonical/transmitted surface: the source excerpt is redacted out.
+    const resultRun = runCompanion(["result", "--job", record.job_id, "--cwd", cwd], { cwd, dataDir });
+    assert.equal(resultRun.status, 0, `exit ${resultRun.status}: ${resultRun.stderr || resultRun.stdout}`);
+    const persisted = JSON.parse(resultRun.stdout);
+    assert.doesNotMatch(persisted.result, new RegExp(sentinel),
+      `canonical JobRecord.result must not carry the raw source excerpt; got: ${persisted.result}`);
+    assert.match(persisted.result, /\[redacted_source_excerpt\]/,
+      "the >200-char source run must collapse to the redaction marker in the record");
+
+    // Local diagnostic surface: raw, owner-only, never transmitted (line-19 contract).
+    const dir = jobDir(dataDir, record.job_id);
+    assert.match(readFileSync(path.join(dir, "stdout.log"), "utf8"), new RegExp(sentinel),
+      "stdout.log sidecar must preserve the raw target output verbatim");
+    assert.match(readFileSync(path.join(dir, "stderr.log"), "utf8"), new RegExp(sentinel),
+      "stderr.log sidecar must preserve the raw target diagnostics verbatim");
+  } finally {
+    rmTree(dataDir);
+    rmTree(cwd);
+  }
+});
+
 test("AGY finalize path writes stdout and stderr sidecars", () => {
   const cwd = mkdtempSync(path.join(tmpdir(), "agy-sidecar-cwd-"));
   const dataDir = mkdtempSync(path.join(tmpdir(), "agy-sidecar-data-"));

--- a/tests/unit/agy-shared-finalization.test.mjs
+++ b/tests/unit/agy-shared-finalization.test.mjs
@@ -1,0 +1,290 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { fixtureBranchDiffRepo } from "../helpers/fixture-git.mjs";
+import { buildJobRecord } from "../../plugins/agy/scripts/lib/job-record.mjs";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const COMPANION = path.join(REPO_ROOT, "plugins/agy/scripts/agy-companion.mjs");
+
+function rmTree(target) {
+  rmSync(target, { recursive: true, force: true });
+}
+
+function writeExecutable(dir, name, source) {
+  const bin = path.join(dir, name);
+  writeFileSync(bin, source, "utf8");
+  chmodSync(bin, 0o755);
+  return bin;
+}
+
+function padReviewLines(count = 6) {
+  return Array.from({ length: count }, (_, i) => (
+    `- src/module${i}.js:${100 + i} inspected concrete control flow, source routing, tests, and security-sensitive behavior with enough detail to exceed the shared review-quality shallow threshold.`
+  ));
+}
+
+function writeAgyReviewMock(dir, name, { body, stderr = "mock stderr sidecar\n" }) {
+  return writeExecutable(dir, name, [
+    "#!/usr/bin/env node",
+    "const args = process.argv.slice(2);",
+    "if (args[0] === 'models') { console.log('verified-local-model'); process.exit(0); }",
+    `process.stderr.write(${JSON.stringify(stderr)});`,
+    `process.stdout.write(${JSON.stringify(body)});`,
+    "",
+  ].join("\n"));
+}
+
+function runCompanion(args, { cwd, dataDir = mkdtempSync(path.join(tmpdir(), "agy-shared-data-")), env = {} } = {}) {
+  assert.equal(existsSync(COMPANION), true, "AGY companion entrypoint must exist");
+  const result = spawnSync(process.execPath, [COMPANION, ...args], {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      AGY_PLUGIN_DATA: dataDir,
+      ...env,
+    },
+  });
+  return { ...result, dataDir };
+}
+
+function parseJsonStream(raw) {
+  const objs = [];
+  let depth = 0;
+  let start = -1;
+  let inStr = false;
+  let esc = false;
+  for (let i = 0; i < raw.length; i += 1) {
+    const c = raw[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (c === "\\") esc = true;
+      else if (c === "\"") inStr = false;
+      continue;
+    }
+    if (c === "\"") inStr = true;
+    else if (c === "{") {
+      if (depth === 0) start = i;
+      depth += 1;
+    } else if (c === "}") {
+      depth -= 1;
+      if (depth === 0 && start >= 0) {
+        objs.push(JSON.parse(raw.slice(start, i + 1)));
+        start = -1;
+      }
+    }
+  }
+  return objs;
+}
+
+function terminalRecord(run) {
+  const records = parseJsonStream(run.stdout);
+  assert.ok(records.length > 0, `missing terminal record; stdout=${run.stdout} stderr=${run.stderr}`);
+  return records.at(-1);
+}
+
+function firstWorkspaceJobsDir(dataDir) {
+  const stateRoot = path.join(dataDir, "state");
+  const workspaceDirs = readdirSync(stateRoot);
+  assert.equal(workspaceDirs.length, 1, `expected one state workspace, got ${workspaceDirs.join(",")}`);
+  return path.join(stateRoot, workspaceDirs[0], "jobs");
+}
+
+function jobDir(dataDir, jobId) {
+  return path.join(firstWorkspaceJobsDir(dataDir), jobId);
+}
+
+async function loadCompanionInternals(exports) {
+  const source = readFileSync(COMPANION, "utf8")
+    .replace(/from "\.\/lib\/([^"]+)"/g, (_, rel) => (
+      `from ${JSON.stringify(pathToFileURL(path.join(REPO_ROOT, "plugins/agy/scripts/lib", rel)).href)}`
+    ))
+    .replace(
+      /\nmain\(\)\.catch\(\(error\) => \{[\s\S]*?\n\}\);\s*$/u,
+      `\nexport { ${exports.join(", ")} };\n`,
+    );
+  assert.match(source, /export \{ /, "test loader must disable the AGY companion main() call");
+  const dir = mkdtempSync(path.join(tmpdir(), "agy-internals-"));
+  const modulePath = path.join(dir, "agy-companion-internals.mjs");
+  writeFileSync(modulePath, source, "utf8");
+  try {
+    return await import(`${pathToFileURL(modulePath).href}?t=${Date.now()}`);
+  } finally {
+    rmTree(dir);
+  }
+}
+
+function makeInvocation({ jobId = "agy-shared-finalization-job", cwd = tmpdir() } = {}) {
+  return {
+    job_id: jobId,
+    target: "agy",
+    mode: "review",
+    mode_profile_name: "review",
+    model: null,
+    cwd,
+    workspace_root: cwd,
+    containment: "worktree",
+    scope: "branch-diff",
+    scope_base: "main",
+    scope_paths: null,
+    prompt_head: "review empty source",
+    binary: "agy",
+    started_at: new Date().toISOString(),
+    run_kind: "review",
+  };
+}
+
+test("quality-failed AGY review retains produced body in the persisted failed record", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "agy-quality-failed-cwd-"));
+  const dataDir = mkdtempSync(path.join(tmpdir(), "agy-quality-failed-data-"));
+  const reviewBody = [
+    "Verdict: REQUEST_CHANGES",
+    "",
+    "Blockers:",
+    "- src/auth.js:42 auth validation is bypassed when the header is absent; this blocks merge.",
+    ...padReviewLines(),
+    "",
+    "Follow-up:",
+    "- Selected source inspection failed for the final runtime checklist; treat this as failed review slot because the reviewer could not inspect every required artifact.",
+    "",
+  ].join("\n");
+  const binary = writeAgyReviewMock(cwd, "agy-quality-failed-mock", { body: reviewBody });
+  const { base } = fixtureBranchDiffRepo(cwd);
+  const run = runCompanion(
+    ["run", "--mode", "review", "--foreground", "--lifecycle-events", "jsonl",
+      "--binary", binary, "--cwd", cwd, "--scope-base", base, "--", "review quality failure"],
+    { cwd, dataDir },
+  );
+  try {
+    assert.equal(run.status, 1, `exit ${run.status}: ${run.stderr || run.stdout}`);
+    const record = terminalRecord(run);
+    assert.equal(record.status, "failed");
+    assert.equal(record.error_code, "review_not_completed");
+    assert.equal(record.review_quality.failed_review_slot, true);
+    const resultRun = runCompanion(["result", "--job", record.job_id, "--cwd", cwd], { cwd, dataDir });
+    assert.equal(resultRun.status, 0, `exit ${resultRun.status}: ${resultRun.stderr || resultRun.stdout}`);
+    const persisted = JSON.parse(resultRun.stdout);
+    assert.equal(persisted.result, reviewBody);
+    assert.ok(persisted.result.length > 500, "regression body must exceed shallow-review threshold");
+  } finally {
+    rmTree(dataDir);
+    rmTree(cwd);
+  }
+});
+
+test("Blockers and Must fix phrasing are accepted by the shared review-quality gate", () => {
+  for (const [label, section] of [["blockers", "Blockers:"], ["must-fix", "Must fix:"]]) {
+    const cwd = mkdtempSync(path.join(tmpdir(), `agy-${label}-cwd-`));
+    const dataDir = mkdtempSync(path.join(tmpdir(), `agy-${label}-data-`));
+    const reviewBody = [
+      "Verdict: REQUEST_CHANGES",
+      "",
+      section,
+      "- src/auth.js:42 auth validation is bypassed when the header is absent; this blocks merge.",
+      ...padReviewLines(),
+      "",
+      "Non-blocking concerns:",
+      "- Residual risk: the focused source packet was reviewed and no additional non-blocking concern was found.",
+      "",
+    ].join("\n");
+    const binary = writeAgyReviewMock(cwd, `agy-${label}-mock`, { body: reviewBody });
+    const { base } = fixtureBranchDiffRepo(cwd);
+    const run = runCompanion(
+      ["run", "--mode", "review", "--foreground", "--lifecycle-events", "jsonl",
+        "--binary", binary, "--cwd", cwd, "--scope-base", base, "--", `review ${label} phrasing`],
+      { cwd, dataDir },
+    );
+    try {
+      assert.equal(run.status, 0, `exit ${run.status}: ${run.stderr || run.stdout}`);
+      const record = terminalRecord(run);
+      assert.equal(record.status, "completed");
+      assert.equal(record.error_code, null);
+      assert.equal(record.review_quality.failed_review_slot, false);
+      const resultRun = runCompanion(["result", "--job", record.job_id, "--cwd", cwd], { cwd, dataDir });
+      assert.equal(resultRun.status, 0, `exit ${resultRun.status}: ${resultRun.stderr || resultRun.stdout}`);
+      const persisted = JSON.parse(resultRun.stdout);
+      assert.equal(persisted.result, reviewBody);
+      assert.doesNotMatch(reviewBody, /Blocking findings/i);
+    } finally {
+      rmTree(dataDir);
+      rmTree(cwd);
+    }
+  }
+});
+
+test("empty-source completed AGY review persists through buildJobRecord", async () => {
+  const reviewBody = [
+    "Verdict: APPROVE",
+    "",
+    "Blocking findings:",
+    "- None. I inspected the repository state for this empty-source review and found no blocking issue.",
+    ...padReviewLines(),
+    "",
+    "Non-blocking concerns:",
+    "- Residual risk: no selected source files were present, and the review result still follows the shared contract.",
+    "",
+  ].join("\n");
+  const { executionForRecord } = await loadCompanionInternals(["executionForRecord"]);
+  const execution = executionForRecord({
+    status: "completed",
+    pidInfo: null,
+    parsed: { ok: true, result: reviewBody, structured: null, denials: [] },
+    exitCode: 0,
+    endedAt: new Date().toISOString(),
+    reviewAuditManifest: null,
+    selectedFiles: [],
+  });
+  const record = buildJobRecord(makeInvocation(), execution, []);
+  assert.equal(record.status, "completed");
+  assert.equal(record.error_code, null);
+  assert.equal(record.result, reviewBody);
+});
+
+test("AGY finalize path writes stdout and stderr sidecars", () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "agy-sidecar-cwd-"));
+  const dataDir = mkdtempSync(path.join(tmpdir(), "agy-sidecar-data-"));
+  const stderrText = "mock stderr sidecar content\n";
+  const reviewBody = [
+    "Verdict: APPROVE",
+    "",
+    "Blocking findings:",
+    "- None. I inspected the selected source packet and found no blocking issue.",
+    ...padReviewLines(),
+    "",
+    "Non-blocking concerns:",
+    "- Residual risk: no additional non-blocking concerns were found after reviewing the selected source packet.",
+    "",
+  ].join("\n");
+  const binary = writeAgyReviewMock(cwd, "agy-sidecar-mock", { body: reviewBody, stderr: stderrText });
+  const { base } = fixtureBranchDiffRepo(cwd);
+  const run = runCompanion(
+    ["run", "--mode", "review", "--foreground", "--lifecycle-events", "jsonl",
+      "--binary", binary, "--cwd", cwd, "--scope-base", base, "--", "review sidecars"],
+    { cwd, dataDir },
+  );
+  try {
+    assert.equal(run.status, 0, `exit ${run.status}: ${run.stderr || run.stdout}`);
+    const record = terminalRecord(run);
+    const dir = jobDir(dataDir, record.job_id);
+    assert.equal(readFileSync(path.join(dir, "stdout.log"), "utf8"), reviewBody);
+    assert.equal(readFileSync(path.join(dir, "stderr.log"), "utf8"), stderrText);
+  } finally {
+    rmTree(dataDir);
+    rmTree(cwd);
+  }
+});


### PR DESCRIPTION
## What
Brings AGY's review finalization onto the shared `buildJobRecord` contract that gemini/kimi/claude already use. AGY's adapter fed the shared helper the wrong inputs in three ways, each destroying produced review output:

- **P7** — retain `parsed.result` on quality/failure paths instead of nulling it; add stdout/stderr sidecars (mirrors gemini's `writeExecutionSidecars`).
- **P4** — drop the local `hasSubstantiveReview` literal-'Blocking findings' gate; delegate substance to the shared `review_quality.failed_review_slot`.
- **P5** — compute redaction fields via `redactionFieldsForSelected` (returns `{}` when no source bodies) instead of hardcoding `sourceRedactionRequired`, which made empty-source completed reviews throw in `assertRequiredSourceRedaction`.

## Why it's safe
- `buildJobRecord` already redacts `result` for every record → retaining a quality-failed body is leak-safe.
- Git-policy-escape hardening (#218/#240/#241) preserved (containment cleanup, durable write, classifyExecution disclosure); only the post-spawn review body is now retained.
- Counting / disposition unchanged.

## Verification
- New `tests/unit/agy-shared-finalization.test.mjs` drives the real finalize path (fail-on-revert proven by hand).
- P4/P5/P7 AB probes updated to assert fixed behavior (no longer assert the bug).
- `relay/relay-agy` synced byte-identical; `npm run lint` clean.
- Full suite: 2845 tests / 2839 pass / 0 fail.

Part of #232 (lossy review transforms). Down-payment on #251 (shared-runtime consolidation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)