### PR TITLE
[codex] fix relay workload admission in sandbox

### DIFF
--- a/docs/superpowers/plans/2026-06-22-concurrent-relays.md
+++ b/docs/superpowers/plans/2026-06-22-concurrent-relays.md
@@ -406,7 +406,7 @@ git commit -m "test(workload): multi-process bound + SIGKILL one-slot + reboot-i
 - `resolveConcurrencyAdmission({ category, declaredLimit, limitEnv, sharedStateIdentity, provider, route, env }) -> { concurrencyKey, limit, lockRoot }`. Throws (caller converts to a pre-send deny) when: `category` unknown; `category==='shared_state'` with `declaredLimit > 1`; `limit` not a positive int; `shared_state` with no resolvable `sharedStateIdentity`. `limitEnv` may only lower `limit`.
 - A `CONCURRENCY_FACTS` table (or per-route lookup) declaring `{category, limit, limit_env}` per provider/route. Stateless default `limit: 4`.
 
-Behavior is defined by §5/§5.1/§5.2. Identity hashing uses `createHash("sha256")` over the resolved dir's `st_dev:st_ino` (via `statSync`) for `shared_state`; lock root is host-stable (`$XDG_STATE_HOME` or `~/.local/state/relay/locks/v2`) and **ignores** `RELAY_PROVIDER_WORKLOAD_LOCK_DIR` for `shared_state` unless `RELAY_WORKLOAD_TEST_MODE` is set.
+Behavior is defined by §5/§5.1/§5.2. Identity hashing uses `createHash("sha256")` over the resolved dir's `st_dev:st_ino` (via `statSync`) for `shared_state`; lock root is `$XDG_STATE_HOME/relay/locks/v2` when `XDG_STATE_HOME` is set, otherwise `os.tmpdir()/relay-<uid>/locks/v2` (or `relay-user` when no numeric uid is available), and **ignores** `RELAY_PROVIDER_WORKLOAD_LOCK_DIR` for `shared_state` unless `RELAY_WORKLOAD_TEST_MODE` is set.
 
 - [ ] **Step 1: Write failing tests**
 

--- a/docs/superpowers/plans/2026-06-22-concurrent-relays.md
+++ b/docs/superpowers/plans/2026-06-22-concurrent-relays.md
@@ -406,7 +406,7 @@ git commit -m "test(workload): multi-process bound + SIGKILL one-slot + reboot-i
 - `resolveConcurrencyAdmission({ category, declaredLimit, limitEnv, sharedStateIdentity, provider, route, env }) -> { concurrencyKey, limit, lockRoot }`. Throws (caller converts to a pre-send deny) when: `category` unknown; `category==='shared_state'` with `declaredLimit > 1`; `limit` not a positive int; `shared_state` with no resolvable `sharedStateIdentity`. `limitEnv` may only lower `limit`.
 - A `CONCURRENCY_FACTS` table (or per-route lookup) declaring `{category, limit, limit_env}` per provider/route. Stateless default `limit: 4`.
 
-Behavior is defined by §5/§5.1/§5.2. Identity hashing uses `createHash("sha256")` over the resolved dir's `st_dev:st_ino` (via `statSync`) for `shared_state`; lock root is `$XDG_STATE_HOME/relay/locks/v2` when `XDG_STATE_HOME` is set, otherwise `os.tmpdir()/relay-<uid>/locks/v2` (or `relay-user` when no numeric uid is available), and **ignores** `RELAY_PROVIDER_WORKLOAD_LOCK_DIR` for `shared_state` unless `RELAY_WORKLOAD_TEST_MODE` is set.
+Behavior is defined by §5/§5.1/§5.2. Identity hashing uses `createHash("sha256")` over the resolved dir's `st_dev:st_ino` (via `statSync`) for `shared_state`; lock root is `$XDG_STATE_HOME/relay/locks/v2` when `XDG_STATE_HOME` is set, otherwise `os.tmpdir()/relay-locks-v2-<uid>` (or `relay-locks-v2-user` when no numeric uid is available), and **ignores** `RELAY_PROVIDER_WORKLOAD_LOCK_DIR` for `shared_state` unless `RELAY_WORKLOAD_TEST_MODE` is set.
 
 - [ ] **Step 1: Write failing tests**
 

--- a/plugins/agy/scripts/lib/provider-route-policy.mjs
+++ b/plugins/agy/scripts/lib/provider-route-policy.mjs
@@ -267,7 +267,10 @@ function defaultProviderWorkloadLockRoot(env = process.env) {
   const xdgStateHome = typeof env?.XDG_STATE_HOME === "string" && env.XDG_STATE_HOME.trim() !== ""
     ? env.XDG_STATE_HOME
     : null;
-  return join(xdgStateHome || tmpdir(), "relay", "locks", "v2");
+  if (xdgStateHome) return join(xdgStateHome, "relay", "locks", "v2");
+  const uid = process.getuid?.();
+  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-${uid}` : "relay-user";
+  return join(tmpdir(), userSegment, "locks", "v2");
 }
 
 function providerWorkloadLockRoot(category, env = process.env) {

--- a/plugins/agy/scripts/lib/provider-route-policy.mjs
+++ b/plugins/agy/scripts/lib/provider-route-policy.mjs
@@ -269,8 +269,8 @@ function defaultProviderWorkloadLockRoot(env = process.env) {
     : null;
   if (xdgStateHome) return join(xdgStateHome, "relay", "locks", "v2");
   const uid = process.getuid?.();
-  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-${uid}` : "relay-user";
-  return join(tmpdir(), userSegment, "locks", "v2");
+  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-locks-v2-${uid}` : "relay-locks-v2-user";
+  return join(tmpdir(), userSegment);
 }
 
 function providerWorkloadLockRoot(category, env = process.env) {

--- a/plugins/agy/scripts/lib/provider-route-policy.mjs
+++ b/plugins/agy/scripts/lib/provider-route-policy.mjs
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { statSync } from "node:fs";
-import { homedir } from "node:os";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { hasSubstantiveInvalidVerdictReason } from "./external-model-review-quality.mjs";
@@ -267,7 +267,7 @@ function defaultProviderWorkloadLockRoot(env = process.env) {
   const xdgStateHome = typeof env?.XDG_STATE_HOME === "string" && env.XDG_STATE_HOME.trim() !== ""
     ? env.XDG_STATE_HOME
     : null;
-  return join(xdgStateHome || join(homedir(), ".local/state"), "relay", "locks", "v2");
+  return join(xdgStateHome || tmpdir(), "relay", "locks", "v2");
 }
 
 function providerWorkloadLockRoot(category, env = process.env) {

--- a/plugins/agy/scripts/lib/review-workload.mjs
+++ b/plugins/agy/scripts/lib/review-workload.mjs
@@ -10,6 +10,15 @@ const SCHEMA_VERSION = 1;
 const DEFAULT_GATE_TIMEOUT_MS = 5_000;
 const GATE_POLL_MS = 25;
 const GATE_OWNER_FILE = "owner.json";
+const LOCK_ROOT_UNWRITABLE_CODES = new Set([
+  "EACCES",
+  "EPERM",
+  "ENOTDIR",
+  "EROFS",
+  "ENOSPC",
+  "EMFILE",
+  "ENFILE",
+]);
 
 function trimEdgeHyphens(value) {
   let start = 0;
@@ -49,6 +58,10 @@ function positiveIntegerEnv(env, name, fallback) {
 
 function gateTimeoutMs(env) {
   return positiveIntegerEnv(env, GATE_TIMEOUT_ENV, DEFAULT_GATE_TIMEOUT_MS);
+}
+
+function isUnwritableLockRootError(error) {
+  return LOCK_ROOT_UNWRITABLE_CODES.has(error?.code);
 }
 
 function sleepSync(ms) {
@@ -109,21 +122,29 @@ function blockResult(capacity, reason = "active_same_provider_job") {
   });
 }
 
+function currentPidInfoWithoutCaptureProof(env, error) {
+  const message = String(error?.message ?? error ?? "");
+  const expectedCaptureFailure = message.startsWith("capture_error")
+    || message.startsWith("process_gone")
+    || message.startsWith("invalid_pid");
+  if (env?.RELAY_WORKLOAD_TEST_MODE && expectedCaptureFailure) {
+    return {
+      pid: process.pid,
+      starttime: `test-mode:${process.pid}`,
+      argv0: process.argv?.[0] || "node",
+    };
+  }
+  // The current process is necessarily live even when a host sandbox denies
+  // /bin/ps or /proc. Store no reuse proof rather than blocking every launch;
+  // stale cleanup then remains conservative until process inspection works.
+  return { pid: process.pid, starttime: null, argv0: null };
+}
+
 function captureCurrentPidInfo(env = process.env, capture = capturePidInfo) {
   try {
     return capture(process.pid);
   } catch (error) {
-    if (env?.RELAY_WORKLOAD_TEST_MODE) {
-      return {
-        pid: process.pid,
-        starttime: `test-mode:${process.pid}`,
-        argv0: process.argv?.[0] || "node",
-      };
-    }
-    // The current process is necessarily live even when a host sandbox denies
-    // /bin/ps or /proc. Store no reuse proof rather than blocking every launch;
-    // stale cleanup then remains conservative until process inspection works.
-    return { pid: process.pid, starttime: null, argv0: null };
+    return currentPidInfoWithoutCaptureProof(env, error);
   }
 }
 
@@ -391,16 +412,12 @@ export function acquireProviderWorkloadLease({
   const gateFile = legacyLockPath(root, slug);
   try {
     mkdirSync(root, { recursive: true, mode: 0o700 });
-  } catch {
+  } catch (error) {
+    if (!isUnwritableLockRootError(error)) throw error;
     return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
   }
 
-  let pidInfo;
-  try {
-    pidInfo = captureCurrentPidInfo(env, capture);
-  } catch {
-    return blockResult({ active_count: 0, limit }, "unverifiable_current_process");
-  }
+  const pidInfo = captureCurrentPidInfo(env, capture);
 
   const payload = Object.freeze({
     schema_version: SCHEMA_VERSION,
@@ -419,9 +436,10 @@ export function acquireProviderWorkloadLease({
   });
 
   for (;;) {
-    const gate = acquireProviderWorkloadGate(gateFile, env, capture, pidInfo);
-    if (!gate.ok) return blockResult({ active_count: limit, limit });
+    let gate;
     try {
+      gate = acquireProviderWorkloadGate(gateFile, env, capture, pidInfo);
+      if (!gate.ok) return blockResult({ active_count: limit, limit });
       const slots = enumerateSlotFiles(root, slug);
       if (!slots) return blockResult({ active_count: limit, limit }, "unreadable_provider_workload_lock_root");
 
@@ -453,8 +471,11 @@ export function acquireProviderWorkloadLease({
       }
       const file = slotPath(root, slug, index);
       if (tryCreateLeaseFile(file, payload)) return acquiredResult(file, payload);
+    } catch (error) {
+      if (!isUnwritableLockRootError(error)) throw error;
+      return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
     } finally {
-      gate.release?.();
+      gate?.release?.();
     }
   }
 }

--- a/plugins/agy/scripts/lib/review-workload.mjs
+++ b/plugins/agy/scripts/lib/review-workload.mjs
@@ -1,4 +1,4 @@
-import { existsSync, linkSync, lstatSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, linkSync, lstatSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import { hostname } from "node:os";
 import { join, dirname } from "node:path";
@@ -10,15 +10,7 @@ const SCHEMA_VERSION = 1;
 const DEFAULT_GATE_TIMEOUT_MS = 5_000;
 const GATE_POLL_MS = 25;
 const GATE_OWNER_FILE = "owner.json";
-const LOCK_ROOT_UNWRITABLE_CODES = new Set([
-  "EACCES",
-  "EPERM",
-  "ENOTDIR",
-  "EROFS",
-  "ENOSPC",
-  "EMFILE",
-  "ENFILE",
-]);
+const LOCK_ROOT_UNUSABLE_CODE = "PROVIDER_WORKLOAD_LOCK_ROOT_UNUSABLE";
 
 function trimEdgeHyphens(value) {
   let start = 0;
@@ -60,8 +52,56 @@ function gateTimeoutMs(env) {
   return positiveIntegerEnv(env, GATE_TIMEOUT_ENV, DEFAULT_GATE_TIMEOUT_MS);
 }
 
-function isUnwritableLockRootError(error) {
-  return LOCK_ROOT_UNWRITABLE_CODES.has(error?.code);
+function isProviderWorkloadFilesystemError(error) {
+  return typeof error?.code === "string";
+}
+
+function unusableLockRootError() {
+  const error = new Error("provider workload lock root is not usable");
+  error.code = LOCK_ROOT_UNUSABLE_CODE;
+  return error;
+}
+
+function currentUid() {
+  const uid = process.getuid?.();
+  return Number.isSafeInteger(uid) && uid >= 0 ? uid : null;
+}
+
+function ensureProviderWorkloadLockRoot(root) {
+  try {
+    mkdirSync(root, { recursive: true, mode: 0o700 });
+  } catch (error) {
+    if (!isProviderWorkloadFilesystemError(error)) throw error;
+    return false;
+  }
+
+  let stat;
+  try {
+    stat = lstatSync(root);
+  } catch (error) {
+    if (!isProviderWorkloadFilesystemError(error)) throw error;
+    return false;
+  }
+  if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
+
+  const uid = currentUid();
+  if (uid != null && typeof stat.uid === "number" && stat.uid !== uid) return false;
+
+  const mode = stat.mode & 0o777;
+  if ((mode & 0o700) !== 0o700) return false;
+  if ((mode & 0o077) !== 0) {
+    try {
+      chmodSync(root, 0o700);
+      stat = lstatSync(root);
+    } catch (error) {
+      if (!isProviderWorkloadFilesystemError(error)) throw error;
+      return false;
+    }
+    if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
+    if ((stat.mode & 0o777) !== 0o700) return false;
+  }
+
+  return true;
 }
 
 function sleepSync(ms) {
@@ -284,7 +324,7 @@ export function acquireProviderWorkloadGate(file, env, capture, pidInfo) {
       // caller-provided lockRoot), recreated rather than an env default so the
       // in-use root — not some other path — is what heals.
       if (error?.code === "ENOENT" && error?.syscall === "mkdir") {
-        try { mkdirSync(dirname(gateDir), { recursive: true, mode: 0o700 }); } catch { /* best effort */ }
+        if (!ensureProviderWorkloadLockRoot(dirname(gateDir))) throw unusableLockRootError();
         sleepSync(GATE_POLL_MS);
         continue;
       }
@@ -410,10 +450,7 @@ export function acquireProviderWorkloadLease({
 
   const root = lockRoot;
   const gateFile = legacyLockPath(root, slug);
-  try {
-    mkdirSync(root, { recursive: true, mode: 0o700 });
-  } catch (error) {
-    if (!isUnwritableLockRootError(error)) throw error;
+  if (!ensureProviderWorkloadLockRoot(root)) {
     return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
   }
 
@@ -472,7 +509,7 @@ export function acquireProviderWorkloadLease({
       const file = slotPath(root, slug, index);
       if (tryCreateLeaseFile(file, payload)) return acquiredResult(file, payload);
     } catch (error) {
-      if (!isUnwritableLockRootError(error)) throw error;
+      if (!isProviderWorkloadFilesystemError(error)) throw error;
       return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
     } finally {
       gate?.release?.();

--- a/plugins/agy/scripts/lib/review-workload.mjs
+++ b/plugins/agy/scripts/lib/review-workload.mjs
@@ -11,6 +11,33 @@ const DEFAULT_GATE_TIMEOUT_MS = 5_000;
 const GATE_POLL_MS = 25;
 const GATE_OWNER_FILE = "owner.json";
 const LOCK_ROOT_UNUSABLE_CODE = "PROVIDER_WORKLOAD_LOCK_ROOT_UNUSABLE";
+const PROVIDER_WORKLOAD_FILESYSTEM_ERROR_CODES = new Set([
+  "EACCES",
+  "EAGAIN",
+  "EBADF",
+  "EBUSY",
+  "EDQUOT",
+  "EEXIST",
+  "EFBIG",
+  "EINTR",
+  "EINVAL",
+  "EIO",
+  "EISDIR",
+  "ELOOP",
+  "EMFILE",
+  "EMLINK",
+  "ENAMETOOLONG",
+  "ENFILE",
+  "ENOENT",
+  "ENOSPC",
+  "ENOTDIR",
+  "ENOTEMPTY",
+  "ENOTSUP",
+  "EOPNOTSUPP",
+  "EPERM",
+  "EROFS",
+  "EXDEV",
+]);
 
 function trimEdgeHyphens(value) {
   let start = 0;
@@ -53,7 +80,9 @@ function gateTimeoutMs(env) {
 }
 
 function isProviderWorkloadFilesystemError(error) {
-  return typeof error?.code === "string";
+  if (error?.code === LOCK_ROOT_UNUSABLE_CODE) return true;
+  if (typeof error?.syscall === "string") return true;
+  return PROVIDER_WORKLOAD_FILESYSTEM_ERROR_CODES.has(error?.code);
 }
 
 function unusableLockRootError() {

--- a/plugins/agy/scripts/lib/review-workload.mjs
+++ b/plugins/agy/scripts/lib/review-workload.mjs
@@ -109,16 +109,21 @@ function blockResult(capacity, reason = "active_same_provider_job") {
   });
 }
 
-function captureCurrentPidInfo(env = process.env) {
+function captureCurrentPidInfo(env = process.env, capture = capturePidInfo) {
   try {
-    return capturePidInfo(process.pid);
+    return capture(process.pid);
   } catch (error) {
-    if (!env?.RELAY_WORKLOAD_TEST_MODE) throw error;
-    return {
-      pid: process.pid,
-      starttime: `test-mode:${process.pid}`,
-      argv0: process.argv?.[0] || "node",
-    };
+    if (env?.RELAY_WORKLOAD_TEST_MODE) {
+      return {
+        pid: process.pid,
+        starttime: `test-mode:${process.pid}`,
+        argv0: process.argv?.[0] || "node",
+      };
+    }
+    // The current process is necessarily live even when a host sandbox denies
+    // /bin/ps or /proc. Store no reuse proof rather than blocking every launch;
+    // stale cleanup then remains conservative until process inspection works.
+    return { pid: process.pid, starttime: null, argv0: null };
   }
 }
 
@@ -384,11 +389,15 @@ export function acquireProviderWorkloadLease({
 
   const root = lockRoot;
   const gateFile = legacyLockPath(root, slug);
-  mkdirSync(root, { recursive: true, mode: 0o700 });
+  try {
+    mkdirSync(root, { recursive: true, mode: 0o700 });
+  } catch {
+    return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
+  }
 
   let pidInfo;
   try {
-    pidInfo = captureCurrentPidInfo(env);
+    pidInfo = captureCurrentPidInfo(env, capture);
   } catch {
     return blockResult({ active_count: 0, limit }, "unverifiable_current_process");
   }

--- a/plugins/api-reviewers/scripts/lib/provider-route-policy.mjs
+++ b/plugins/api-reviewers/scripts/lib/provider-route-policy.mjs
@@ -267,7 +267,10 @@ function defaultProviderWorkloadLockRoot(env = process.env) {
   const xdgStateHome = typeof env?.XDG_STATE_HOME === "string" && env.XDG_STATE_HOME.trim() !== ""
     ? env.XDG_STATE_HOME
     : null;
-  return join(xdgStateHome || tmpdir(), "relay", "locks", "v2");
+  if (xdgStateHome) return join(xdgStateHome, "relay", "locks", "v2");
+  const uid = process.getuid?.();
+  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-${uid}` : "relay-user";
+  return join(tmpdir(), userSegment, "locks", "v2");
 }
 
 function providerWorkloadLockRoot(category, env = process.env) {

--- a/plugins/api-reviewers/scripts/lib/provider-route-policy.mjs
+++ b/plugins/api-reviewers/scripts/lib/provider-route-policy.mjs
@@ -269,8 +269,8 @@ function defaultProviderWorkloadLockRoot(env = process.env) {
     : null;
   if (xdgStateHome) return join(xdgStateHome, "relay", "locks", "v2");
   const uid = process.getuid?.();
-  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-${uid}` : "relay-user";
-  return join(tmpdir(), userSegment, "locks", "v2");
+  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-locks-v2-${uid}` : "relay-locks-v2-user";
+  return join(tmpdir(), userSegment);
 }
 
 function providerWorkloadLockRoot(category, env = process.env) {

--- a/plugins/api-reviewers/scripts/lib/provider-route-policy.mjs
+++ b/plugins/api-reviewers/scripts/lib/provider-route-policy.mjs
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { statSync } from "node:fs";
-import { homedir } from "node:os";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { hasSubstantiveInvalidVerdictReason } from "./external-model-review-quality.mjs";
@@ -267,7 +267,7 @@ function defaultProviderWorkloadLockRoot(env = process.env) {
   const xdgStateHome = typeof env?.XDG_STATE_HOME === "string" && env.XDG_STATE_HOME.trim() !== ""
     ? env.XDG_STATE_HOME
     : null;
-  return join(xdgStateHome || join(homedir(), ".local/state"), "relay", "locks", "v2");
+  return join(xdgStateHome || tmpdir(), "relay", "locks", "v2");
 }
 
 function providerWorkloadLockRoot(category, env = process.env) {

--- a/plugins/api-reviewers/scripts/lib/review-workload.mjs
+++ b/plugins/api-reviewers/scripts/lib/review-workload.mjs
@@ -10,6 +10,15 @@ const SCHEMA_VERSION = 1;
 const DEFAULT_GATE_TIMEOUT_MS = 5_000;
 const GATE_POLL_MS = 25;
 const GATE_OWNER_FILE = "owner.json";
+const LOCK_ROOT_UNWRITABLE_CODES = new Set([
+  "EACCES",
+  "EPERM",
+  "ENOTDIR",
+  "EROFS",
+  "ENOSPC",
+  "EMFILE",
+  "ENFILE",
+]);
 
 function trimEdgeHyphens(value) {
   let start = 0;
@@ -49,6 +58,10 @@ function positiveIntegerEnv(env, name, fallback) {
 
 function gateTimeoutMs(env) {
   return positiveIntegerEnv(env, GATE_TIMEOUT_ENV, DEFAULT_GATE_TIMEOUT_MS);
+}
+
+function isUnwritableLockRootError(error) {
+  return LOCK_ROOT_UNWRITABLE_CODES.has(error?.code);
 }
 
 function sleepSync(ms) {
@@ -109,21 +122,29 @@ function blockResult(capacity, reason = "active_same_provider_job") {
   });
 }
 
+function currentPidInfoWithoutCaptureProof(env, error) {
+  const message = String(error?.message ?? error ?? "");
+  const expectedCaptureFailure = message.startsWith("capture_error")
+    || message.startsWith("process_gone")
+    || message.startsWith("invalid_pid");
+  if (env?.RELAY_WORKLOAD_TEST_MODE && expectedCaptureFailure) {
+    return {
+      pid: process.pid,
+      starttime: `test-mode:${process.pid}`,
+      argv0: process.argv?.[0] || "node",
+    };
+  }
+  // The current process is necessarily live even when a host sandbox denies
+  // /bin/ps or /proc. Store no reuse proof rather than blocking every launch;
+  // stale cleanup then remains conservative until process inspection works.
+  return { pid: process.pid, starttime: null, argv0: null };
+}
+
 function captureCurrentPidInfo(env = process.env, capture = capturePidInfo) {
   try {
     return capture(process.pid);
   } catch (error) {
-    if (env?.RELAY_WORKLOAD_TEST_MODE) {
-      return {
-        pid: process.pid,
-        starttime: `test-mode:${process.pid}`,
-        argv0: process.argv?.[0] || "node",
-      };
-    }
-    // The current process is necessarily live even when a host sandbox denies
-    // /bin/ps or /proc. Store no reuse proof rather than blocking every launch;
-    // stale cleanup then remains conservative until process inspection works.
-    return { pid: process.pid, starttime: null, argv0: null };
+    return currentPidInfoWithoutCaptureProof(env, error);
   }
 }
 
@@ -391,16 +412,12 @@ export function acquireProviderWorkloadLease({
   const gateFile = legacyLockPath(root, slug);
   try {
     mkdirSync(root, { recursive: true, mode: 0o700 });
-  } catch {
+  } catch (error) {
+    if (!isUnwritableLockRootError(error)) throw error;
     return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
   }
 
-  let pidInfo;
-  try {
-    pidInfo = captureCurrentPidInfo(env, capture);
-  } catch {
-    return blockResult({ active_count: 0, limit }, "unverifiable_current_process");
-  }
+  const pidInfo = captureCurrentPidInfo(env, capture);
 
   const payload = Object.freeze({
     schema_version: SCHEMA_VERSION,
@@ -419,9 +436,10 @@ export function acquireProviderWorkloadLease({
   });
 
   for (;;) {
-    const gate = acquireProviderWorkloadGate(gateFile, env, capture, pidInfo);
-    if (!gate.ok) return blockResult({ active_count: limit, limit });
+    let gate;
     try {
+      gate = acquireProviderWorkloadGate(gateFile, env, capture, pidInfo);
+      if (!gate.ok) return blockResult({ active_count: limit, limit });
       const slots = enumerateSlotFiles(root, slug);
       if (!slots) return blockResult({ active_count: limit, limit }, "unreadable_provider_workload_lock_root");
 
@@ -453,8 +471,11 @@ export function acquireProviderWorkloadLease({
       }
       const file = slotPath(root, slug, index);
       if (tryCreateLeaseFile(file, payload)) return acquiredResult(file, payload);
+    } catch (error) {
+      if (!isUnwritableLockRootError(error)) throw error;
+      return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
     } finally {
-      gate.release?.();
+      gate?.release?.();
     }
   }
 }

--- a/plugins/api-reviewers/scripts/lib/review-workload.mjs
+++ b/plugins/api-reviewers/scripts/lib/review-workload.mjs
@@ -1,4 +1,4 @@
-import { existsSync, linkSync, lstatSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, linkSync, lstatSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import { hostname } from "node:os";
 import { join, dirname } from "node:path";
@@ -10,15 +10,7 @@ const SCHEMA_VERSION = 1;
 const DEFAULT_GATE_TIMEOUT_MS = 5_000;
 const GATE_POLL_MS = 25;
 const GATE_OWNER_FILE = "owner.json";
-const LOCK_ROOT_UNWRITABLE_CODES = new Set([
-  "EACCES",
-  "EPERM",
-  "ENOTDIR",
-  "EROFS",
-  "ENOSPC",
-  "EMFILE",
-  "ENFILE",
-]);
+const LOCK_ROOT_UNUSABLE_CODE = "PROVIDER_WORKLOAD_LOCK_ROOT_UNUSABLE";
 
 function trimEdgeHyphens(value) {
   let start = 0;
@@ -60,8 +52,56 @@ function gateTimeoutMs(env) {
   return positiveIntegerEnv(env, GATE_TIMEOUT_ENV, DEFAULT_GATE_TIMEOUT_MS);
 }
 
-function isUnwritableLockRootError(error) {
-  return LOCK_ROOT_UNWRITABLE_CODES.has(error?.code);
+function isProviderWorkloadFilesystemError(error) {
+  return typeof error?.code === "string";
+}
+
+function unusableLockRootError() {
+  const error = new Error("provider workload lock root is not usable");
+  error.code = LOCK_ROOT_UNUSABLE_CODE;
+  return error;
+}
+
+function currentUid() {
+  const uid = process.getuid?.();
+  return Number.isSafeInteger(uid) && uid >= 0 ? uid : null;
+}
+
+function ensureProviderWorkloadLockRoot(root) {
+  try {
+    mkdirSync(root, { recursive: true, mode: 0o700 });
+  } catch (error) {
+    if (!isProviderWorkloadFilesystemError(error)) throw error;
+    return false;
+  }
+
+  let stat;
+  try {
+    stat = lstatSync(root);
+  } catch (error) {
+    if (!isProviderWorkloadFilesystemError(error)) throw error;
+    return false;
+  }
+  if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
+
+  const uid = currentUid();
+  if (uid != null && typeof stat.uid === "number" && stat.uid !== uid) return false;
+
+  const mode = stat.mode & 0o777;
+  if ((mode & 0o700) !== 0o700) return false;
+  if ((mode & 0o077) !== 0) {
+    try {
+      chmodSync(root, 0o700);
+      stat = lstatSync(root);
+    } catch (error) {
+      if (!isProviderWorkloadFilesystemError(error)) throw error;
+      return false;
+    }
+    if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
+    if ((stat.mode & 0o777) !== 0o700) return false;
+  }
+
+  return true;
 }
 
 function sleepSync(ms) {
@@ -284,7 +324,7 @@ export function acquireProviderWorkloadGate(file, env, capture, pidInfo) {
       // caller-provided lockRoot), recreated rather than an env default so the
       // in-use root — not some other path — is what heals.
       if (error?.code === "ENOENT" && error?.syscall === "mkdir") {
-        try { mkdirSync(dirname(gateDir), { recursive: true, mode: 0o700 }); } catch { /* best effort */ }
+        if (!ensureProviderWorkloadLockRoot(dirname(gateDir))) throw unusableLockRootError();
         sleepSync(GATE_POLL_MS);
         continue;
       }
@@ -410,10 +450,7 @@ export function acquireProviderWorkloadLease({
 
   const root = lockRoot;
   const gateFile = legacyLockPath(root, slug);
-  try {
-    mkdirSync(root, { recursive: true, mode: 0o700 });
-  } catch (error) {
-    if (!isUnwritableLockRootError(error)) throw error;
+  if (!ensureProviderWorkloadLockRoot(root)) {
     return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
   }
 
@@ -472,7 +509,7 @@ export function acquireProviderWorkloadLease({
       const file = slotPath(root, slug, index);
       if (tryCreateLeaseFile(file, payload)) return acquiredResult(file, payload);
     } catch (error) {
-      if (!isUnwritableLockRootError(error)) throw error;
+      if (!isProviderWorkloadFilesystemError(error)) throw error;
       return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
     } finally {
       gate?.release?.();

--- a/plugins/api-reviewers/scripts/lib/review-workload.mjs
+++ b/plugins/api-reviewers/scripts/lib/review-workload.mjs
@@ -11,6 +11,33 @@ const DEFAULT_GATE_TIMEOUT_MS = 5_000;
 const GATE_POLL_MS = 25;
 const GATE_OWNER_FILE = "owner.json";
 const LOCK_ROOT_UNUSABLE_CODE = "PROVIDER_WORKLOAD_LOCK_ROOT_UNUSABLE";
+const PROVIDER_WORKLOAD_FILESYSTEM_ERROR_CODES = new Set([
+  "EACCES",
+  "EAGAIN",
+  "EBADF",
+  "EBUSY",
+  "EDQUOT",
+  "EEXIST",
+  "EFBIG",
+  "EINTR",
+  "EINVAL",
+  "EIO",
+  "EISDIR",
+  "ELOOP",
+  "EMFILE",
+  "EMLINK",
+  "ENAMETOOLONG",
+  "ENFILE",
+  "ENOENT",
+  "ENOSPC",
+  "ENOTDIR",
+  "ENOTEMPTY",
+  "ENOTSUP",
+  "EOPNOTSUPP",
+  "EPERM",
+  "EROFS",
+  "EXDEV",
+]);
 
 function trimEdgeHyphens(value) {
   let start = 0;
@@ -53,7 +80,9 @@ function gateTimeoutMs(env) {
 }
 
 function isProviderWorkloadFilesystemError(error) {
-  return typeof error?.code === "string";
+  if (error?.code === LOCK_ROOT_UNUSABLE_CODE) return true;
+  if (typeof error?.syscall === "string") return true;
+  return PROVIDER_WORKLOAD_FILESYSTEM_ERROR_CODES.has(error?.code);
 }
 
 function unusableLockRootError() {

--- a/plugins/api-reviewers/scripts/lib/review-workload.mjs
+++ b/plugins/api-reviewers/scripts/lib/review-workload.mjs
@@ -109,16 +109,21 @@ function blockResult(capacity, reason = "active_same_provider_job") {
   });
 }
 
-function captureCurrentPidInfo(env = process.env) {
+function captureCurrentPidInfo(env = process.env, capture = capturePidInfo) {
   try {
-    return capturePidInfo(process.pid);
+    return capture(process.pid);
   } catch (error) {
-    if (!env?.RELAY_WORKLOAD_TEST_MODE) throw error;
-    return {
-      pid: process.pid,
-      starttime: `test-mode:${process.pid}`,
-      argv0: process.argv?.[0] || "node",
-    };
+    if (env?.RELAY_WORKLOAD_TEST_MODE) {
+      return {
+        pid: process.pid,
+        starttime: `test-mode:${process.pid}`,
+        argv0: process.argv?.[0] || "node",
+      };
+    }
+    // The current process is necessarily live even when a host sandbox denies
+    // /bin/ps or /proc. Store no reuse proof rather than blocking every launch;
+    // stale cleanup then remains conservative until process inspection works.
+    return { pid: process.pid, starttime: null, argv0: null };
   }
 }
 
@@ -384,11 +389,15 @@ export function acquireProviderWorkloadLease({
 
   const root = lockRoot;
   const gateFile = legacyLockPath(root, slug);
-  mkdirSync(root, { recursive: true, mode: 0o700 });
+  try {
+    mkdirSync(root, { recursive: true, mode: 0o700 });
+  } catch {
+    return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
+  }
 
   let pidInfo;
   try {
-    pidInfo = captureCurrentPidInfo(env);
+    pidInfo = captureCurrentPidInfo(env, capture);
   } catch {
     return blockResult({ active_count: 0, limit }, "unverifiable_current_process");
   }

--- a/plugins/claude/scripts/lib/provider-route-policy.mjs
+++ b/plugins/claude/scripts/lib/provider-route-policy.mjs
@@ -267,7 +267,10 @@ function defaultProviderWorkloadLockRoot(env = process.env) {
   const xdgStateHome = typeof env?.XDG_STATE_HOME === "string" && env.XDG_STATE_HOME.trim() !== ""
     ? env.XDG_STATE_HOME
     : null;
-  return join(xdgStateHome || tmpdir(), "relay", "locks", "v2");
+  if (xdgStateHome) return join(xdgStateHome, "relay", "locks", "v2");
+  const uid = process.getuid?.();
+  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-${uid}` : "relay-user";
+  return join(tmpdir(), userSegment, "locks", "v2");
 }
 
 function providerWorkloadLockRoot(category, env = process.env) {

--- a/plugins/claude/scripts/lib/provider-route-policy.mjs
+++ b/plugins/claude/scripts/lib/provider-route-policy.mjs
@@ -269,8 +269,8 @@ function defaultProviderWorkloadLockRoot(env = process.env) {
     : null;
   if (xdgStateHome) return join(xdgStateHome, "relay", "locks", "v2");
   const uid = process.getuid?.();
-  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-${uid}` : "relay-user";
-  return join(tmpdir(), userSegment, "locks", "v2");
+  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-locks-v2-${uid}` : "relay-locks-v2-user";
+  return join(tmpdir(), userSegment);
 }
 
 function providerWorkloadLockRoot(category, env = process.env) {

--- a/plugins/claude/scripts/lib/provider-route-policy.mjs
+++ b/plugins/claude/scripts/lib/provider-route-policy.mjs
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { statSync } from "node:fs";
-import { homedir } from "node:os";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { hasSubstantiveInvalidVerdictReason } from "./external-model-review-quality.mjs";
@@ -267,7 +267,7 @@ function defaultProviderWorkloadLockRoot(env = process.env) {
   const xdgStateHome = typeof env?.XDG_STATE_HOME === "string" && env.XDG_STATE_HOME.trim() !== ""
     ? env.XDG_STATE_HOME
     : null;
-  return join(xdgStateHome || join(homedir(), ".local/state"), "relay", "locks", "v2");
+  return join(xdgStateHome || tmpdir(), "relay", "locks", "v2");
 }
 
 function providerWorkloadLockRoot(category, env = process.env) {

--- a/plugins/claude/scripts/lib/review-workload.mjs
+++ b/plugins/claude/scripts/lib/review-workload.mjs
@@ -10,6 +10,15 @@ const SCHEMA_VERSION = 1;
 const DEFAULT_GATE_TIMEOUT_MS = 5_000;
 const GATE_POLL_MS = 25;
 const GATE_OWNER_FILE = "owner.json";
+const LOCK_ROOT_UNWRITABLE_CODES = new Set([
+  "EACCES",
+  "EPERM",
+  "ENOTDIR",
+  "EROFS",
+  "ENOSPC",
+  "EMFILE",
+  "ENFILE",
+]);
 
 function trimEdgeHyphens(value) {
   let start = 0;
@@ -49,6 +58,10 @@ function positiveIntegerEnv(env, name, fallback) {
 
 function gateTimeoutMs(env) {
   return positiveIntegerEnv(env, GATE_TIMEOUT_ENV, DEFAULT_GATE_TIMEOUT_MS);
+}
+
+function isUnwritableLockRootError(error) {
+  return LOCK_ROOT_UNWRITABLE_CODES.has(error?.code);
 }
 
 function sleepSync(ms) {
@@ -109,21 +122,29 @@ function blockResult(capacity, reason = "active_same_provider_job") {
   });
 }
 
+function currentPidInfoWithoutCaptureProof(env, error) {
+  const message = String(error?.message ?? error ?? "");
+  const expectedCaptureFailure = message.startsWith("capture_error")
+    || message.startsWith("process_gone")
+    || message.startsWith("invalid_pid");
+  if (env?.RELAY_WORKLOAD_TEST_MODE && expectedCaptureFailure) {
+    return {
+      pid: process.pid,
+      starttime: `test-mode:${process.pid}`,
+      argv0: process.argv?.[0] || "node",
+    };
+  }
+  // The current process is necessarily live even when a host sandbox denies
+  // /bin/ps or /proc. Store no reuse proof rather than blocking every launch;
+  // stale cleanup then remains conservative until process inspection works.
+  return { pid: process.pid, starttime: null, argv0: null };
+}
+
 function captureCurrentPidInfo(env = process.env, capture = capturePidInfo) {
   try {
     return capture(process.pid);
   } catch (error) {
-    if (env?.RELAY_WORKLOAD_TEST_MODE) {
-      return {
-        pid: process.pid,
-        starttime: `test-mode:${process.pid}`,
-        argv0: process.argv?.[0] || "node",
-      };
-    }
-    // The current process is necessarily live even when a host sandbox denies
-    // /bin/ps or /proc. Store no reuse proof rather than blocking every launch;
-    // stale cleanup then remains conservative until process inspection works.
-    return { pid: process.pid, starttime: null, argv0: null };
+    return currentPidInfoWithoutCaptureProof(env, error);
   }
 }
 
@@ -391,16 +412,12 @@ export function acquireProviderWorkloadLease({
   const gateFile = legacyLockPath(root, slug);
   try {
     mkdirSync(root, { recursive: true, mode: 0o700 });
-  } catch {
+  } catch (error) {
+    if (!isUnwritableLockRootError(error)) throw error;
     return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
   }
 
-  let pidInfo;
-  try {
-    pidInfo = captureCurrentPidInfo(env, capture);
-  } catch {
-    return blockResult({ active_count: 0, limit }, "unverifiable_current_process");
-  }
+  const pidInfo = captureCurrentPidInfo(env, capture);
 
   const payload = Object.freeze({
     schema_version: SCHEMA_VERSION,
@@ -419,9 +436,10 @@ export function acquireProviderWorkloadLease({
   });
 
   for (;;) {
-    const gate = acquireProviderWorkloadGate(gateFile, env, capture, pidInfo);
-    if (!gate.ok) return blockResult({ active_count: limit, limit });
+    let gate;
     try {
+      gate = acquireProviderWorkloadGate(gateFile, env, capture, pidInfo);
+      if (!gate.ok) return blockResult({ active_count: limit, limit });
       const slots = enumerateSlotFiles(root, slug);
       if (!slots) return blockResult({ active_count: limit, limit }, "unreadable_provider_workload_lock_root");
 
@@ -453,8 +471,11 @@ export function acquireProviderWorkloadLease({
       }
       const file = slotPath(root, slug, index);
       if (tryCreateLeaseFile(file, payload)) return acquiredResult(file, payload);
+    } catch (error) {
+      if (!isUnwritableLockRootError(error)) throw error;
+      return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
     } finally {
-      gate.release?.();
+      gate?.release?.();
     }
   }
 }

--- a/plugins/claude/scripts/lib/review-workload.mjs
+++ b/plugins/claude/scripts/lib/review-workload.mjs
@@ -1,4 +1,4 @@
-import { existsSync, linkSync, lstatSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, linkSync, lstatSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import { hostname } from "node:os";
 import { join, dirname } from "node:path";
@@ -10,15 +10,7 @@ const SCHEMA_VERSION = 1;
 const DEFAULT_GATE_TIMEOUT_MS = 5_000;
 const GATE_POLL_MS = 25;
 const GATE_OWNER_FILE = "owner.json";
-const LOCK_ROOT_UNWRITABLE_CODES = new Set([
-  "EACCES",
-  "EPERM",
-  "ENOTDIR",
-  "EROFS",
-  "ENOSPC",
-  "EMFILE",
-  "ENFILE",
-]);
+const LOCK_ROOT_UNUSABLE_CODE = "PROVIDER_WORKLOAD_LOCK_ROOT_UNUSABLE";
 
 function trimEdgeHyphens(value) {
   let start = 0;
@@ -60,8 +52,56 @@ function gateTimeoutMs(env) {
   return positiveIntegerEnv(env, GATE_TIMEOUT_ENV, DEFAULT_GATE_TIMEOUT_MS);
 }
 
-function isUnwritableLockRootError(error) {
-  return LOCK_ROOT_UNWRITABLE_CODES.has(error?.code);
+function isProviderWorkloadFilesystemError(error) {
+  return typeof error?.code === "string";
+}
+
+function unusableLockRootError() {
+  const error = new Error("provider workload lock root is not usable");
+  error.code = LOCK_ROOT_UNUSABLE_CODE;
+  return error;
+}
+
+function currentUid() {
+  const uid = process.getuid?.();
+  return Number.isSafeInteger(uid) && uid >= 0 ? uid : null;
+}
+
+function ensureProviderWorkloadLockRoot(root) {
+  try {
+    mkdirSync(root, { recursive: true, mode: 0o700 });
+  } catch (error) {
+    if (!isProviderWorkloadFilesystemError(error)) throw error;
+    return false;
+  }
+
+  let stat;
+  try {
+    stat = lstatSync(root);
+  } catch (error) {
+    if (!isProviderWorkloadFilesystemError(error)) throw error;
+    return false;
+  }
+  if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
+
+  const uid = currentUid();
+  if (uid != null && typeof stat.uid === "number" && stat.uid !== uid) return false;
+
+  const mode = stat.mode & 0o777;
+  if ((mode & 0o700) !== 0o700) return false;
+  if ((mode & 0o077) !== 0) {
+    try {
+      chmodSync(root, 0o700);
+      stat = lstatSync(root);
+    } catch (error) {
+      if (!isProviderWorkloadFilesystemError(error)) throw error;
+      return false;
+    }
+    if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
+    if ((stat.mode & 0o777) !== 0o700) return false;
+  }
+
+  return true;
 }
 
 function sleepSync(ms) {
@@ -284,7 +324,7 @@ export function acquireProviderWorkloadGate(file, env, capture, pidInfo) {
       // caller-provided lockRoot), recreated rather than an env default so the
       // in-use root — not some other path — is what heals.
       if (error?.code === "ENOENT" && error?.syscall === "mkdir") {
-        try { mkdirSync(dirname(gateDir), { recursive: true, mode: 0o700 }); } catch { /* best effort */ }
+        if (!ensureProviderWorkloadLockRoot(dirname(gateDir))) throw unusableLockRootError();
         sleepSync(GATE_POLL_MS);
         continue;
       }
@@ -410,10 +450,7 @@ export function acquireProviderWorkloadLease({
 
   const root = lockRoot;
   const gateFile = legacyLockPath(root, slug);
-  try {
-    mkdirSync(root, { recursive: true, mode: 0o700 });
-  } catch (error) {
-    if (!isUnwritableLockRootError(error)) throw error;
+  if (!ensureProviderWorkloadLockRoot(root)) {
     return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
   }
 
@@ -472,7 +509,7 @@ export function acquireProviderWorkloadLease({
       const file = slotPath(root, slug, index);
       if (tryCreateLeaseFile(file, payload)) return acquiredResult(file, payload);
     } catch (error) {
-      if (!isUnwritableLockRootError(error)) throw error;
+      if (!isProviderWorkloadFilesystemError(error)) throw error;
       return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
     } finally {
       gate?.release?.();

--- a/plugins/claude/scripts/lib/review-workload.mjs
+++ b/plugins/claude/scripts/lib/review-workload.mjs
@@ -11,6 +11,33 @@ const DEFAULT_GATE_TIMEOUT_MS = 5_000;
 const GATE_POLL_MS = 25;
 const GATE_OWNER_FILE = "owner.json";
 const LOCK_ROOT_UNUSABLE_CODE = "PROVIDER_WORKLOAD_LOCK_ROOT_UNUSABLE";
+const PROVIDER_WORKLOAD_FILESYSTEM_ERROR_CODES = new Set([
+  "EACCES",
+  "EAGAIN",
+  "EBADF",
+  "EBUSY",
+  "EDQUOT",
+  "EEXIST",
+  "EFBIG",
+  "EINTR",
+  "EINVAL",
+  "EIO",
+  "EISDIR",
+  "ELOOP",
+  "EMFILE",
+  "EMLINK",
+  "ENAMETOOLONG",
+  "ENFILE",
+  "ENOENT",
+  "ENOSPC",
+  "ENOTDIR",
+  "ENOTEMPTY",
+  "ENOTSUP",
+  "EOPNOTSUPP",
+  "EPERM",
+  "EROFS",
+  "EXDEV",
+]);
 
 function trimEdgeHyphens(value) {
   let start = 0;
@@ -53,7 +80,9 @@ function gateTimeoutMs(env) {
 }
 
 function isProviderWorkloadFilesystemError(error) {
-  return typeof error?.code === "string";
+  if (error?.code === LOCK_ROOT_UNUSABLE_CODE) return true;
+  if (typeof error?.syscall === "string") return true;
+  return PROVIDER_WORKLOAD_FILESYSTEM_ERROR_CODES.has(error?.code);
 }
 
 function unusableLockRootError() {

--- a/plugins/claude/scripts/lib/review-workload.mjs
+++ b/plugins/claude/scripts/lib/review-workload.mjs
@@ -109,16 +109,21 @@ function blockResult(capacity, reason = "active_same_provider_job") {
   });
 }
 
-function captureCurrentPidInfo(env = process.env) {
+function captureCurrentPidInfo(env = process.env, capture = capturePidInfo) {
   try {
-    return capturePidInfo(process.pid);
+    return capture(process.pid);
   } catch (error) {
-    if (!env?.RELAY_WORKLOAD_TEST_MODE) throw error;
-    return {
-      pid: process.pid,
-      starttime: `test-mode:${process.pid}`,
-      argv0: process.argv?.[0] || "node",
-    };
+    if (env?.RELAY_WORKLOAD_TEST_MODE) {
+      return {
+        pid: process.pid,
+        starttime: `test-mode:${process.pid}`,
+        argv0: process.argv?.[0] || "node",
+      };
+    }
+    // The current process is necessarily live even when a host sandbox denies
+    // /bin/ps or /proc. Store no reuse proof rather than blocking every launch;
+    // stale cleanup then remains conservative until process inspection works.
+    return { pid: process.pid, starttime: null, argv0: null };
   }
 }
 
@@ -384,11 +389,15 @@ export function acquireProviderWorkloadLease({
 
   const root = lockRoot;
   const gateFile = legacyLockPath(root, slug);
-  mkdirSync(root, { recursive: true, mode: 0o700 });
+  try {
+    mkdirSync(root, { recursive: true, mode: 0o700 });
+  } catch {
+    return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
+  }
 
   let pidInfo;
   try {
-    pidInfo = captureCurrentPidInfo(env);
+    pidInfo = captureCurrentPidInfo(env, capture);
   } catch {
     return blockResult({ active_count: 0, limit }, "unverifiable_current_process");
   }

--- a/plugins/gemini/scripts/lib/provider-route-policy.mjs
+++ b/plugins/gemini/scripts/lib/provider-route-policy.mjs
@@ -267,7 +267,10 @@ function defaultProviderWorkloadLockRoot(env = process.env) {
   const xdgStateHome = typeof env?.XDG_STATE_HOME === "string" && env.XDG_STATE_HOME.trim() !== ""
     ? env.XDG_STATE_HOME
     : null;
-  return join(xdgStateHome || tmpdir(), "relay", "locks", "v2");
+  if (xdgStateHome) return join(xdgStateHome, "relay", "locks", "v2");
+  const uid = process.getuid?.();
+  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-${uid}` : "relay-user";
+  return join(tmpdir(), userSegment, "locks", "v2");
 }
 
 function providerWorkloadLockRoot(category, env = process.env) {

--- a/plugins/gemini/scripts/lib/provider-route-policy.mjs
+++ b/plugins/gemini/scripts/lib/provider-route-policy.mjs
@@ -269,8 +269,8 @@ function defaultProviderWorkloadLockRoot(env = process.env) {
     : null;
   if (xdgStateHome) return join(xdgStateHome, "relay", "locks", "v2");
   const uid = process.getuid?.();
-  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-${uid}` : "relay-user";
-  return join(tmpdir(), userSegment, "locks", "v2");
+  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-locks-v2-${uid}` : "relay-locks-v2-user";
+  return join(tmpdir(), userSegment);
 }
 
 function providerWorkloadLockRoot(category, env = process.env) {

--- a/plugins/gemini/scripts/lib/provider-route-policy.mjs
+++ b/plugins/gemini/scripts/lib/provider-route-policy.mjs
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { statSync } from "node:fs";
-import { homedir } from "node:os";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { hasSubstantiveInvalidVerdictReason } from "./external-model-review-quality.mjs";
@@ -267,7 +267,7 @@ function defaultProviderWorkloadLockRoot(env = process.env) {
   const xdgStateHome = typeof env?.XDG_STATE_HOME === "string" && env.XDG_STATE_HOME.trim() !== ""
     ? env.XDG_STATE_HOME
     : null;
-  return join(xdgStateHome || join(homedir(), ".local/state"), "relay", "locks", "v2");
+  return join(xdgStateHome || tmpdir(), "relay", "locks", "v2");
 }
 
 function providerWorkloadLockRoot(category, env = process.env) {

--- a/plugins/gemini/scripts/lib/review-workload.mjs
+++ b/plugins/gemini/scripts/lib/review-workload.mjs
@@ -10,6 +10,15 @@ const SCHEMA_VERSION = 1;
 const DEFAULT_GATE_TIMEOUT_MS = 5_000;
 const GATE_POLL_MS = 25;
 const GATE_OWNER_FILE = "owner.json";
+const LOCK_ROOT_UNWRITABLE_CODES = new Set([
+  "EACCES",
+  "EPERM",
+  "ENOTDIR",
+  "EROFS",
+  "ENOSPC",
+  "EMFILE",
+  "ENFILE",
+]);
 
 function trimEdgeHyphens(value) {
   let start = 0;
@@ -49,6 +58,10 @@ function positiveIntegerEnv(env, name, fallback) {
 
 function gateTimeoutMs(env) {
   return positiveIntegerEnv(env, GATE_TIMEOUT_ENV, DEFAULT_GATE_TIMEOUT_MS);
+}
+
+function isUnwritableLockRootError(error) {
+  return LOCK_ROOT_UNWRITABLE_CODES.has(error?.code);
 }
 
 function sleepSync(ms) {
@@ -109,21 +122,29 @@ function blockResult(capacity, reason = "active_same_provider_job") {
   });
 }
 
+function currentPidInfoWithoutCaptureProof(env, error) {
+  const message = String(error?.message ?? error ?? "");
+  const expectedCaptureFailure = message.startsWith("capture_error")
+    || message.startsWith("process_gone")
+    || message.startsWith("invalid_pid");
+  if (env?.RELAY_WORKLOAD_TEST_MODE && expectedCaptureFailure) {
+    return {
+      pid: process.pid,
+      starttime: `test-mode:${process.pid}`,
+      argv0: process.argv?.[0] || "node",
+    };
+  }
+  // The current process is necessarily live even when a host sandbox denies
+  // /bin/ps or /proc. Store no reuse proof rather than blocking every launch;
+  // stale cleanup then remains conservative until process inspection works.
+  return { pid: process.pid, starttime: null, argv0: null };
+}
+
 function captureCurrentPidInfo(env = process.env, capture = capturePidInfo) {
   try {
     return capture(process.pid);
   } catch (error) {
-    if (env?.RELAY_WORKLOAD_TEST_MODE) {
-      return {
-        pid: process.pid,
-        starttime: `test-mode:${process.pid}`,
-        argv0: process.argv?.[0] || "node",
-      };
-    }
-    // The current process is necessarily live even when a host sandbox denies
-    // /bin/ps or /proc. Store no reuse proof rather than blocking every launch;
-    // stale cleanup then remains conservative until process inspection works.
-    return { pid: process.pid, starttime: null, argv0: null };
+    return currentPidInfoWithoutCaptureProof(env, error);
   }
 }
 
@@ -391,16 +412,12 @@ export function acquireProviderWorkloadLease({
   const gateFile = legacyLockPath(root, slug);
   try {
     mkdirSync(root, { recursive: true, mode: 0o700 });
-  } catch {
+  } catch (error) {
+    if (!isUnwritableLockRootError(error)) throw error;
     return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
   }
 
-  let pidInfo;
-  try {
-    pidInfo = captureCurrentPidInfo(env, capture);
-  } catch {
-    return blockResult({ active_count: 0, limit }, "unverifiable_current_process");
-  }
+  const pidInfo = captureCurrentPidInfo(env, capture);
 
   const payload = Object.freeze({
     schema_version: SCHEMA_VERSION,
@@ -419,9 +436,10 @@ export function acquireProviderWorkloadLease({
   });
 
   for (;;) {
-    const gate = acquireProviderWorkloadGate(gateFile, env, capture, pidInfo);
-    if (!gate.ok) return blockResult({ active_count: limit, limit });
+    let gate;
     try {
+      gate = acquireProviderWorkloadGate(gateFile, env, capture, pidInfo);
+      if (!gate.ok) return blockResult({ active_count: limit, limit });
       const slots = enumerateSlotFiles(root, slug);
       if (!slots) return blockResult({ active_count: limit, limit }, "unreadable_provider_workload_lock_root");
 
@@ -453,8 +471,11 @@ export function acquireProviderWorkloadLease({
       }
       const file = slotPath(root, slug, index);
       if (tryCreateLeaseFile(file, payload)) return acquiredResult(file, payload);
+    } catch (error) {
+      if (!isUnwritableLockRootError(error)) throw error;
+      return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
     } finally {
-      gate.release?.();
+      gate?.release?.();
     }
   }
 }

--- a/plugins/gemini/scripts/lib/review-workload.mjs
+++ b/plugins/gemini/scripts/lib/review-workload.mjs
@@ -1,4 +1,4 @@
-import { existsSync, linkSync, lstatSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, linkSync, lstatSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import { hostname } from "node:os";
 import { join, dirname } from "node:path";
@@ -10,15 +10,7 @@ const SCHEMA_VERSION = 1;
 const DEFAULT_GATE_TIMEOUT_MS = 5_000;
 const GATE_POLL_MS = 25;
 const GATE_OWNER_FILE = "owner.json";
-const LOCK_ROOT_UNWRITABLE_CODES = new Set([
-  "EACCES",
-  "EPERM",
-  "ENOTDIR",
-  "EROFS",
-  "ENOSPC",
-  "EMFILE",
-  "ENFILE",
-]);
+const LOCK_ROOT_UNUSABLE_CODE = "PROVIDER_WORKLOAD_LOCK_ROOT_UNUSABLE";
 
 function trimEdgeHyphens(value) {
   let start = 0;
@@ -60,8 +52,56 @@ function gateTimeoutMs(env) {
   return positiveIntegerEnv(env, GATE_TIMEOUT_ENV, DEFAULT_GATE_TIMEOUT_MS);
 }
 
-function isUnwritableLockRootError(error) {
-  return LOCK_ROOT_UNWRITABLE_CODES.has(error?.code);
+function isProviderWorkloadFilesystemError(error) {
+  return typeof error?.code === "string";
+}
+
+function unusableLockRootError() {
+  const error = new Error("provider workload lock root is not usable");
+  error.code = LOCK_ROOT_UNUSABLE_CODE;
+  return error;
+}
+
+function currentUid() {
+  const uid = process.getuid?.();
+  return Number.isSafeInteger(uid) && uid >= 0 ? uid : null;
+}
+
+function ensureProviderWorkloadLockRoot(root) {
+  try {
+    mkdirSync(root, { recursive: true, mode: 0o700 });
+  } catch (error) {
+    if (!isProviderWorkloadFilesystemError(error)) throw error;
+    return false;
+  }
+
+  let stat;
+  try {
+    stat = lstatSync(root);
+  } catch (error) {
+    if (!isProviderWorkloadFilesystemError(error)) throw error;
+    return false;
+  }
+  if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
+
+  const uid = currentUid();
+  if (uid != null && typeof stat.uid === "number" && stat.uid !== uid) return false;
+
+  const mode = stat.mode & 0o777;
+  if ((mode & 0o700) !== 0o700) return false;
+  if ((mode & 0o077) !== 0) {
+    try {
+      chmodSync(root, 0o700);
+      stat = lstatSync(root);
+    } catch (error) {
+      if (!isProviderWorkloadFilesystemError(error)) throw error;
+      return false;
+    }
+    if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
+    if ((stat.mode & 0o777) !== 0o700) return false;
+  }
+
+  return true;
 }
 
 function sleepSync(ms) {
@@ -284,7 +324,7 @@ export function acquireProviderWorkloadGate(file, env, capture, pidInfo) {
       // caller-provided lockRoot), recreated rather than an env default so the
       // in-use root — not some other path — is what heals.
       if (error?.code === "ENOENT" && error?.syscall === "mkdir") {
-        try { mkdirSync(dirname(gateDir), { recursive: true, mode: 0o700 }); } catch { /* best effort */ }
+        if (!ensureProviderWorkloadLockRoot(dirname(gateDir))) throw unusableLockRootError();
         sleepSync(GATE_POLL_MS);
         continue;
       }
@@ -410,10 +450,7 @@ export function acquireProviderWorkloadLease({
 
   const root = lockRoot;
   const gateFile = legacyLockPath(root, slug);
-  try {
-    mkdirSync(root, { recursive: true, mode: 0o700 });
-  } catch (error) {
-    if (!isUnwritableLockRootError(error)) throw error;
+  if (!ensureProviderWorkloadLockRoot(root)) {
     return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
   }
 
@@ -472,7 +509,7 @@ export function acquireProviderWorkloadLease({
       const file = slotPath(root, slug, index);
       if (tryCreateLeaseFile(file, payload)) return acquiredResult(file, payload);
     } catch (error) {
-      if (!isUnwritableLockRootError(error)) throw error;
+      if (!isProviderWorkloadFilesystemError(error)) throw error;
       return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
     } finally {
       gate?.release?.();

--- a/plugins/gemini/scripts/lib/review-workload.mjs
+++ b/plugins/gemini/scripts/lib/review-workload.mjs
@@ -11,6 +11,33 @@ const DEFAULT_GATE_TIMEOUT_MS = 5_000;
 const GATE_POLL_MS = 25;
 const GATE_OWNER_FILE = "owner.json";
 const LOCK_ROOT_UNUSABLE_CODE = "PROVIDER_WORKLOAD_LOCK_ROOT_UNUSABLE";
+const PROVIDER_WORKLOAD_FILESYSTEM_ERROR_CODES = new Set([
+  "EACCES",
+  "EAGAIN",
+  "EBADF",
+  "EBUSY",
+  "EDQUOT",
+  "EEXIST",
+  "EFBIG",
+  "EINTR",
+  "EINVAL",
+  "EIO",
+  "EISDIR",
+  "ELOOP",
+  "EMFILE",
+  "EMLINK",
+  "ENAMETOOLONG",
+  "ENFILE",
+  "ENOENT",
+  "ENOSPC",
+  "ENOTDIR",
+  "ENOTEMPTY",
+  "ENOTSUP",
+  "EOPNOTSUPP",
+  "EPERM",
+  "EROFS",
+  "EXDEV",
+]);
 
 function trimEdgeHyphens(value) {
   let start = 0;
@@ -53,7 +80,9 @@ function gateTimeoutMs(env) {
 }
 
 function isProviderWorkloadFilesystemError(error) {
-  return typeof error?.code === "string";
+  if (error?.code === LOCK_ROOT_UNUSABLE_CODE) return true;
+  if (typeof error?.syscall === "string") return true;
+  return PROVIDER_WORKLOAD_FILESYSTEM_ERROR_CODES.has(error?.code);
 }
 
 function unusableLockRootError() {

--- a/plugins/gemini/scripts/lib/review-workload.mjs
+++ b/plugins/gemini/scripts/lib/review-workload.mjs
@@ -109,16 +109,21 @@ function blockResult(capacity, reason = "active_same_provider_job") {
   });
 }
 
-function captureCurrentPidInfo(env = process.env) {
+function captureCurrentPidInfo(env = process.env, capture = capturePidInfo) {
   try {
-    return capturePidInfo(process.pid);
+    return capture(process.pid);
   } catch (error) {
-    if (!env?.RELAY_WORKLOAD_TEST_MODE) throw error;
-    return {
-      pid: process.pid,
-      starttime: `test-mode:${process.pid}`,
-      argv0: process.argv?.[0] || "node",
-    };
+    if (env?.RELAY_WORKLOAD_TEST_MODE) {
+      return {
+        pid: process.pid,
+        starttime: `test-mode:${process.pid}`,
+        argv0: process.argv?.[0] || "node",
+      };
+    }
+    // The current process is necessarily live even when a host sandbox denies
+    // /bin/ps or /proc. Store no reuse proof rather than blocking every launch;
+    // stale cleanup then remains conservative until process inspection works.
+    return { pid: process.pid, starttime: null, argv0: null };
   }
 }
 
@@ -384,11 +389,15 @@ export function acquireProviderWorkloadLease({
 
   const root = lockRoot;
   const gateFile = legacyLockPath(root, slug);
-  mkdirSync(root, { recursive: true, mode: 0o700 });
+  try {
+    mkdirSync(root, { recursive: true, mode: 0o700 });
+  } catch {
+    return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
+  }
 
   let pidInfo;
   try {
-    pidInfo = captureCurrentPidInfo(env);
+    pidInfo = captureCurrentPidInfo(env, capture);
   } catch {
     return blockResult({ active_count: 0, limit }, "unverifiable_current_process");
   }

--- a/plugins/grok/scripts/lib/provider-route-policy.mjs
+++ b/plugins/grok/scripts/lib/provider-route-policy.mjs
@@ -267,7 +267,10 @@ function defaultProviderWorkloadLockRoot(env = process.env) {
   const xdgStateHome = typeof env?.XDG_STATE_HOME === "string" && env.XDG_STATE_HOME.trim() !== ""
     ? env.XDG_STATE_HOME
     : null;
-  return join(xdgStateHome || tmpdir(), "relay", "locks", "v2");
+  if (xdgStateHome) return join(xdgStateHome, "relay", "locks", "v2");
+  const uid = process.getuid?.();
+  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-${uid}` : "relay-user";
+  return join(tmpdir(), userSegment, "locks", "v2");
 }
 
 function providerWorkloadLockRoot(category, env = process.env) {

--- a/plugins/grok/scripts/lib/provider-route-policy.mjs
+++ b/plugins/grok/scripts/lib/provider-route-policy.mjs
@@ -269,8 +269,8 @@ function defaultProviderWorkloadLockRoot(env = process.env) {
     : null;
   if (xdgStateHome) return join(xdgStateHome, "relay", "locks", "v2");
   const uid = process.getuid?.();
-  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-${uid}` : "relay-user";
-  return join(tmpdir(), userSegment, "locks", "v2");
+  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-locks-v2-${uid}` : "relay-locks-v2-user";
+  return join(tmpdir(), userSegment);
 }
 
 function providerWorkloadLockRoot(category, env = process.env) {

--- a/plugins/grok/scripts/lib/provider-route-policy.mjs
+++ b/plugins/grok/scripts/lib/provider-route-policy.mjs
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { statSync } from "node:fs";
-import { homedir } from "node:os";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { hasSubstantiveInvalidVerdictReason } from "./external-model-review-quality.mjs";
@@ -267,7 +267,7 @@ function defaultProviderWorkloadLockRoot(env = process.env) {
   const xdgStateHome = typeof env?.XDG_STATE_HOME === "string" && env.XDG_STATE_HOME.trim() !== ""
     ? env.XDG_STATE_HOME
     : null;
-  return join(xdgStateHome || join(homedir(), ".local/state"), "relay", "locks", "v2");
+  return join(xdgStateHome || tmpdir(), "relay", "locks", "v2");
 }
 
 function providerWorkloadLockRoot(category, env = process.env) {

--- a/plugins/grok/scripts/lib/review-workload.mjs
+++ b/plugins/grok/scripts/lib/review-workload.mjs
@@ -10,6 +10,15 @@ const SCHEMA_VERSION = 1;
 const DEFAULT_GATE_TIMEOUT_MS = 5_000;
 const GATE_POLL_MS = 25;
 const GATE_OWNER_FILE = "owner.json";
+const LOCK_ROOT_UNWRITABLE_CODES = new Set([
+  "EACCES",
+  "EPERM",
+  "ENOTDIR",
+  "EROFS",
+  "ENOSPC",
+  "EMFILE",
+  "ENFILE",
+]);
 
 function trimEdgeHyphens(value) {
   let start = 0;
@@ -49,6 +58,10 @@ function positiveIntegerEnv(env, name, fallback) {
 
 function gateTimeoutMs(env) {
   return positiveIntegerEnv(env, GATE_TIMEOUT_ENV, DEFAULT_GATE_TIMEOUT_MS);
+}
+
+function isUnwritableLockRootError(error) {
+  return LOCK_ROOT_UNWRITABLE_CODES.has(error?.code);
 }
 
 function sleepSync(ms) {
@@ -109,21 +122,29 @@ function blockResult(capacity, reason = "active_same_provider_job") {
   });
 }
 
+function currentPidInfoWithoutCaptureProof(env, error) {
+  const message = String(error?.message ?? error ?? "");
+  const expectedCaptureFailure = message.startsWith("capture_error")
+    || message.startsWith("process_gone")
+    || message.startsWith("invalid_pid");
+  if (env?.RELAY_WORKLOAD_TEST_MODE && expectedCaptureFailure) {
+    return {
+      pid: process.pid,
+      starttime: `test-mode:${process.pid}`,
+      argv0: process.argv?.[0] || "node",
+    };
+  }
+  // The current process is necessarily live even when a host sandbox denies
+  // /bin/ps or /proc. Store no reuse proof rather than blocking every launch;
+  // stale cleanup then remains conservative until process inspection works.
+  return { pid: process.pid, starttime: null, argv0: null };
+}
+
 function captureCurrentPidInfo(env = process.env, capture = capturePidInfo) {
   try {
     return capture(process.pid);
   } catch (error) {
-    if (env?.RELAY_WORKLOAD_TEST_MODE) {
-      return {
-        pid: process.pid,
-        starttime: `test-mode:${process.pid}`,
-        argv0: process.argv?.[0] || "node",
-      };
-    }
-    // The current process is necessarily live even when a host sandbox denies
-    // /bin/ps or /proc. Store no reuse proof rather than blocking every launch;
-    // stale cleanup then remains conservative until process inspection works.
-    return { pid: process.pid, starttime: null, argv0: null };
+    return currentPidInfoWithoutCaptureProof(env, error);
   }
 }
 
@@ -391,16 +412,12 @@ export function acquireProviderWorkloadLease({
   const gateFile = legacyLockPath(root, slug);
   try {
     mkdirSync(root, { recursive: true, mode: 0o700 });
-  } catch {
+  } catch (error) {
+    if (!isUnwritableLockRootError(error)) throw error;
     return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
   }
 
-  let pidInfo;
-  try {
-    pidInfo = captureCurrentPidInfo(env, capture);
-  } catch {
-    return blockResult({ active_count: 0, limit }, "unverifiable_current_process");
-  }
+  const pidInfo = captureCurrentPidInfo(env, capture);
 
   const payload = Object.freeze({
     schema_version: SCHEMA_VERSION,
@@ -419,9 +436,10 @@ export function acquireProviderWorkloadLease({
   });
 
   for (;;) {
-    const gate = acquireProviderWorkloadGate(gateFile, env, capture, pidInfo);
-    if (!gate.ok) return blockResult({ active_count: limit, limit });
+    let gate;
     try {
+      gate = acquireProviderWorkloadGate(gateFile, env, capture, pidInfo);
+      if (!gate.ok) return blockResult({ active_count: limit, limit });
       const slots = enumerateSlotFiles(root, slug);
       if (!slots) return blockResult({ active_count: limit, limit }, "unreadable_provider_workload_lock_root");
 
@@ -453,8 +471,11 @@ export function acquireProviderWorkloadLease({
       }
       const file = slotPath(root, slug, index);
       if (tryCreateLeaseFile(file, payload)) return acquiredResult(file, payload);
+    } catch (error) {
+      if (!isUnwritableLockRootError(error)) throw error;
+      return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
     } finally {
-      gate.release?.();
+      gate?.release?.();
     }
   }
 }

--- a/plugins/grok/scripts/lib/review-workload.mjs
+++ b/plugins/grok/scripts/lib/review-workload.mjs
@@ -1,4 +1,4 @@
-import { existsSync, linkSync, lstatSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, linkSync, lstatSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import { hostname } from "node:os";
 import { join, dirname } from "node:path";
@@ -10,15 +10,7 @@ const SCHEMA_VERSION = 1;
 const DEFAULT_GATE_TIMEOUT_MS = 5_000;
 const GATE_POLL_MS = 25;
 const GATE_OWNER_FILE = "owner.json";
-const LOCK_ROOT_UNWRITABLE_CODES = new Set([
-  "EACCES",
-  "EPERM",
-  "ENOTDIR",
-  "EROFS",
-  "ENOSPC",
-  "EMFILE",
-  "ENFILE",
-]);
+const LOCK_ROOT_UNUSABLE_CODE = "PROVIDER_WORKLOAD_LOCK_ROOT_UNUSABLE";
 
 function trimEdgeHyphens(value) {
   let start = 0;
@@ -60,8 +52,56 @@ function gateTimeoutMs(env) {
   return positiveIntegerEnv(env, GATE_TIMEOUT_ENV, DEFAULT_GATE_TIMEOUT_MS);
 }
 
-function isUnwritableLockRootError(error) {
-  return LOCK_ROOT_UNWRITABLE_CODES.has(error?.code);
+function isProviderWorkloadFilesystemError(error) {
+  return typeof error?.code === "string";
+}
+
+function unusableLockRootError() {
+  const error = new Error("provider workload lock root is not usable");
+  error.code = LOCK_ROOT_UNUSABLE_CODE;
+  return error;
+}
+
+function currentUid() {
+  const uid = process.getuid?.();
+  return Number.isSafeInteger(uid) && uid >= 0 ? uid : null;
+}
+
+function ensureProviderWorkloadLockRoot(root) {
+  try {
+    mkdirSync(root, { recursive: true, mode: 0o700 });
+  } catch (error) {
+    if (!isProviderWorkloadFilesystemError(error)) throw error;
+    return false;
+  }
+
+  let stat;
+  try {
+    stat = lstatSync(root);
+  } catch (error) {
+    if (!isProviderWorkloadFilesystemError(error)) throw error;
+    return false;
+  }
+  if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
+
+  const uid = currentUid();
+  if (uid != null && typeof stat.uid === "number" && stat.uid !== uid) return false;
+
+  const mode = stat.mode & 0o777;
+  if ((mode & 0o700) !== 0o700) return false;
+  if ((mode & 0o077) !== 0) {
+    try {
+      chmodSync(root, 0o700);
+      stat = lstatSync(root);
+    } catch (error) {
+      if (!isProviderWorkloadFilesystemError(error)) throw error;
+      return false;
+    }
+    if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
+    if ((stat.mode & 0o777) !== 0o700) return false;
+  }
+
+  return true;
 }
 
 function sleepSync(ms) {
@@ -284,7 +324,7 @@ export function acquireProviderWorkloadGate(file, env, capture, pidInfo) {
       // caller-provided lockRoot), recreated rather than an env default so the
       // in-use root — not some other path — is what heals.
       if (error?.code === "ENOENT" && error?.syscall === "mkdir") {
-        try { mkdirSync(dirname(gateDir), { recursive: true, mode: 0o700 }); } catch { /* best effort */ }
+        if (!ensureProviderWorkloadLockRoot(dirname(gateDir))) throw unusableLockRootError();
         sleepSync(GATE_POLL_MS);
         continue;
       }
@@ -410,10 +450,7 @@ export function acquireProviderWorkloadLease({
 
   const root = lockRoot;
   const gateFile = legacyLockPath(root, slug);
-  try {
-    mkdirSync(root, { recursive: true, mode: 0o700 });
-  } catch (error) {
-    if (!isUnwritableLockRootError(error)) throw error;
+  if (!ensureProviderWorkloadLockRoot(root)) {
     return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
   }
 
@@ -472,7 +509,7 @@ export function acquireProviderWorkloadLease({
       const file = slotPath(root, slug, index);
       if (tryCreateLeaseFile(file, payload)) return acquiredResult(file, payload);
     } catch (error) {
-      if (!isUnwritableLockRootError(error)) throw error;
+      if (!isProviderWorkloadFilesystemError(error)) throw error;
       return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
     } finally {
       gate?.release?.();

--- a/plugins/grok/scripts/lib/review-workload.mjs
+++ b/plugins/grok/scripts/lib/review-workload.mjs
@@ -11,6 +11,33 @@ const DEFAULT_GATE_TIMEOUT_MS = 5_000;
 const GATE_POLL_MS = 25;
 const GATE_OWNER_FILE = "owner.json";
 const LOCK_ROOT_UNUSABLE_CODE = "PROVIDER_WORKLOAD_LOCK_ROOT_UNUSABLE";
+const PROVIDER_WORKLOAD_FILESYSTEM_ERROR_CODES = new Set([
+  "EACCES",
+  "EAGAIN",
+  "EBADF",
+  "EBUSY",
+  "EDQUOT",
+  "EEXIST",
+  "EFBIG",
+  "EINTR",
+  "EINVAL",
+  "EIO",
+  "EISDIR",
+  "ELOOP",
+  "EMFILE",
+  "EMLINK",
+  "ENAMETOOLONG",
+  "ENFILE",
+  "ENOENT",
+  "ENOSPC",
+  "ENOTDIR",
+  "ENOTEMPTY",
+  "ENOTSUP",
+  "EOPNOTSUPP",
+  "EPERM",
+  "EROFS",
+  "EXDEV",
+]);
 
 function trimEdgeHyphens(value) {
   let start = 0;
@@ -53,7 +80,9 @@ function gateTimeoutMs(env) {
 }
 
 function isProviderWorkloadFilesystemError(error) {
-  return typeof error?.code === "string";
+  if (error?.code === LOCK_ROOT_UNUSABLE_CODE) return true;
+  if (typeof error?.syscall === "string") return true;
+  return PROVIDER_WORKLOAD_FILESYSTEM_ERROR_CODES.has(error?.code);
 }
 
 function unusableLockRootError() {

--- a/plugins/grok/scripts/lib/review-workload.mjs
+++ b/plugins/grok/scripts/lib/review-workload.mjs
@@ -109,16 +109,21 @@ function blockResult(capacity, reason = "active_same_provider_job") {
   });
 }
 
-function captureCurrentPidInfo(env = process.env) {
+function captureCurrentPidInfo(env = process.env, capture = capturePidInfo) {
   try {
-    return capturePidInfo(process.pid);
+    return capture(process.pid);
   } catch (error) {
-    if (!env?.RELAY_WORKLOAD_TEST_MODE) throw error;
-    return {
-      pid: process.pid,
-      starttime: `test-mode:${process.pid}`,
-      argv0: process.argv?.[0] || "node",
-    };
+    if (env?.RELAY_WORKLOAD_TEST_MODE) {
+      return {
+        pid: process.pid,
+        starttime: `test-mode:${process.pid}`,
+        argv0: process.argv?.[0] || "node",
+      };
+    }
+    // The current process is necessarily live even when a host sandbox denies
+    // /bin/ps or /proc. Store no reuse proof rather than blocking every launch;
+    // stale cleanup then remains conservative until process inspection works.
+    return { pid: process.pid, starttime: null, argv0: null };
   }
 }
 
@@ -384,11 +389,15 @@ export function acquireProviderWorkloadLease({
 
   const root = lockRoot;
   const gateFile = legacyLockPath(root, slug);
-  mkdirSync(root, { recursive: true, mode: 0o700 });
+  try {
+    mkdirSync(root, { recursive: true, mode: 0o700 });
+  } catch {
+    return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
+  }
 
   let pidInfo;
   try {
-    pidInfo = captureCurrentPidInfo(env);
+    pidInfo = captureCurrentPidInfo(env, capture);
   } catch {
     return blockResult({ active_count: 0, limit }, "unverifiable_current_process");
   }

--- a/plugins/kimi/scripts/lib/provider-route-policy.mjs
+++ b/plugins/kimi/scripts/lib/provider-route-policy.mjs
@@ -267,7 +267,10 @@ function defaultProviderWorkloadLockRoot(env = process.env) {
   const xdgStateHome = typeof env?.XDG_STATE_HOME === "string" && env.XDG_STATE_HOME.trim() !== ""
     ? env.XDG_STATE_HOME
     : null;
-  return join(xdgStateHome || tmpdir(), "relay", "locks", "v2");
+  if (xdgStateHome) return join(xdgStateHome, "relay", "locks", "v2");
+  const uid = process.getuid?.();
+  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-${uid}` : "relay-user";
+  return join(tmpdir(), userSegment, "locks", "v2");
 }
 
 function providerWorkloadLockRoot(category, env = process.env) {

--- a/plugins/kimi/scripts/lib/provider-route-policy.mjs
+++ b/plugins/kimi/scripts/lib/provider-route-policy.mjs
@@ -269,8 +269,8 @@ function defaultProviderWorkloadLockRoot(env = process.env) {
     : null;
   if (xdgStateHome) return join(xdgStateHome, "relay", "locks", "v2");
   const uid = process.getuid?.();
-  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-${uid}` : "relay-user";
-  return join(tmpdir(), userSegment, "locks", "v2");
+  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-locks-v2-${uid}` : "relay-locks-v2-user";
+  return join(tmpdir(), userSegment);
 }
 
 function providerWorkloadLockRoot(category, env = process.env) {

--- a/plugins/kimi/scripts/lib/provider-route-policy.mjs
+++ b/plugins/kimi/scripts/lib/provider-route-policy.mjs
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { statSync } from "node:fs";
-import { homedir } from "node:os";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { hasSubstantiveInvalidVerdictReason } from "./external-model-review-quality.mjs";
@@ -267,7 +267,7 @@ function defaultProviderWorkloadLockRoot(env = process.env) {
   const xdgStateHome = typeof env?.XDG_STATE_HOME === "string" && env.XDG_STATE_HOME.trim() !== ""
     ? env.XDG_STATE_HOME
     : null;
-  return join(xdgStateHome || join(homedir(), ".local/state"), "relay", "locks", "v2");
+  return join(xdgStateHome || tmpdir(), "relay", "locks", "v2");
 }
 
 function providerWorkloadLockRoot(category, env = process.env) {

--- a/plugins/kimi/scripts/lib/review-workload.mjs
+++ b/plugins/kimi/scripts/lib/review-workload.mjs
@@ -10,6 +10,15 @@ const SCHEMA_VERSION = 1;
 const DEFAULT_GATE_TIMEOUT_MS = 5_000;
 const GATE_POLL_MS = 25;
 const GATE_OWNER_FILE = "owner.json";
+const LOCK_ROOT_UNWRITABLE_CODES = new Set([
+  "EACCES",
+  "EPERM",
+  "ENOTDIR",
+  "EROFS",
+  "ENOSPC",
+  "EMFILE",
+  "ENFILE",
+]);
 
 function trimEdgeHyphens(value) {
   let start = 0;
@@ -49,6 +58,10 @@ function positiveIntegerEnv(env, name, fallback) {
 
 function gateTimeoutMs(env) {
   return positiveIntegerEnv(env, GATE_TIMEOUT_ENV, DEFAULT_GATE_TIMEOUT_MS);
+}
+
+function isUnwritableLockRootError(error) {
+  return LOCK_ROOT_UNWRITABLE_CODES.has(error?.code);
 }
 
 function sleepSync(ms) {
@@ -109,21 +122,29 @@ function blockResult(capacity, reason = "active_same_provider_job") {
   });
 }
 
+function currentPidInfoWithoutCaptureProof(env, error) {
+  const message = String(error?.message ?? error ?? "");
+  const expectedCaptureFailure = message.startsWith("capture_error")
+    || message.startsWith("process_gone")
+    || message.startsWith("invalid_pid");
+  if (env?.RELAY_WORKLOAD_TEST_MODE && expectedCaptureFailure) {
+    return {
+      pid: process.pid,
+      starttime: `test-mode:${process.pid}`,
+      argv0: process.argv?.[0] || "node",
+    };
+  }
+  // The current process is necessarily live even when a host sandbox denies
+  // /bin/ps or /proc. Store no reuse proof rather than blocking every launch;
+  // stale cleanup then remains conservative until process inspection works.
+  return { pid: process.pid, starttime: null, argv0: null };
+}
+
 function captureCurrentPidInfo(env = process.env, capture = capturePidInfo) {
   try {
     return capture(process.pid);
   } catch (error) {
-    if (env?.RELAY_WORKLOAD_TEST_MODE) {
-      return {
-        pid: process.pid,
-        starttime: `test-mode:${process.pid}`,
-        argv0: process.argv?.[0] || "node",
-      };
-    }
-    // The current process is necessarily live even when a host sandbox denies
-    // /bin/ps or /proc. Store no reuse proof rather than blocking every launch;
-    // stale cleanup then remains conservative until process inspection works.
-    return { pid: process.pid, starttime: null, argv0: null };
+    return currentPidInfoWithoutCaptureProof(env, error);
   }
 }
 
@@ -391,16 +412,12 @@ export function acquireProviderWorkloadLease({
   const gateFile = legacyLockPath(root, slug);
   try {
     mkdirSync(root, { recursive: true, mode: 0o700 });
-  } catch {
+  } catch (error) {
+    if (!isUnwritableLockRootError(error)) throw error;
     return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
   }
 
-  let pidInfo;
-  try {
-    pidInfo = captureCurrentPidInfo(env, capture);
-  } catch {
-    return blockResult({ active_count: 0, limit }, "unverifiable_current_process");
-  }
+  const pidInfo = captureCurrentPidInfo(env, capture);
 
   const payload = Object.freeze({
     schema_version: SCHEMA_VERSION,
@@ -419,9 +436,10 @@ export function acquireProviderWorkloadLease({
   });
 
   for (;;) {
-    const gate = acquireProviderWorkloadGate(gateFile, env, capture, pidInfo);
-    if (!gate.ok) return blockResult({ active_count: limit, limit });
+    let gate;
     try {
+      gate = acquireProviderWorkloadGate(gateFile, env, capture, pidInfo);
+      if (!gate.ok) return blockResult({ active_count: limit, limit });
       const slots = enumerateSlotFiles(root, slug);
       if (!slots) return blockResult({ active_count: limit, limit }, "unreadable_provider_workload_lock_root");
 
@@ -453,8 +471,11 @@ export function acquireProviderWorkloadLease({
       }
       const file = slotPath(root, slug, index);
       if (tryCreateLeaseFile(file, payload)) return acquiredResult(file, payload);
+    } catch (error) {
+      if (!isUnwritableLockRootError(error)) throw error;
+      return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
     } finally {
-      gate.release?.();
+      gate?.release?.();
     }
   }
 }

--- a/plugins/kimi/scripts/lib/review-workload.mjs
+++ b/plugins/kimi/scripts/lib/review-workload.mjs
@@ -1,4 +1,4 @@
-import { existsSync, linkSync, lstatSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, linkSync, lstatSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import { hostname } from "node:os";
 import { join, dirname } from "node:path";
@@ -10,15 +10,7 @@ const SCHEMA_VERSION = 1;
 const DEFAULT_GATE_TIMEOUT_MS = 5_000;
 const GATE_POLL_MS = 25;
 const GATE_OWNER_FILE = "owner.json";
-const LOCK_ROOT_UNWRITABLE_CODES = new Set([
-  "EACCES",
-  "EPERM",
-  "ENOTDIR",
-  "EROFS",
-  "ENOSPC",
-  "EMFILE",
-  "ENFILE",
-]);
+const LOCK_ROOT_UNUSABLE_CODE = "PROVIDER_WORKLOAD_LOCK_ROOT_UNUSABLE";
 
 function trimEdgeHyphens(value) {
   let start = 0;
@@ -60,8 +52,56 @@ function gateTimeoutMs(env) {
   return positiveIntegerEnv(env, GATE_TIMEOUT_ENV, DEFAULT_GATE_TIMEOUT_MS);
 }
 
-function isUnwritableLockRootError(error) {
-  return LOCK_ROOT_UNWRITABLE_CODES.has(error?.code);
+function isProviderWorkloadFilesystemError(error) {
+  return typeof error?.code === "string";
+}
+
+function unusableLockRootError() {
+  const error = new Error("provider workload lock root is not usable");
+  error.code = LOCK_ROOT_UNUSABLE_CODE;
+  return error;
+}
+
+function currentUid() {
+  const uid = process.getuid?.();
+  return Number.isSafeInteger(uid) && uid >= 0 ? uid : null;
+}
+
+function ensureProviderWorkloadLockRoot(root) {
+  try {
+    mkdirSync(root, { recursive: true, mode: 0o700 });
+  } catch (error) {
+    if (!isProviderWorkloadFilesystemError(error)) throw error;
+    return false;
+  }
+
+  let stat;
+  try {
+    stat = lstatSync(root);
+  } catch (error) {
+    if (!isProviderWorkloadFilesystemError(error)) throw error;
+    return false;
+  }
+  if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
+
+  const uid = currentUid();
+  if (uid != null && typeof stat.uid === "number" && stat.uid !== uid) return false;
+
+  const mode = stat.mode & 0o777;
+  if ((mode & 0o700) !== 0o700) return false;
+  if ((mode & 0o077) !== 0) {
+    try {
+      chmodSync(root, 0o700);
+      stat = lstatSync(root);
+    } catch (error) {
+      if (!isProviderWorkloadFilesystemError(error)) throw error;
+      return false;
+    }
+    if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
+    if ((stat.mode & 0o777) !== 0o700) return false;
+  }
+
+  return true;
 }
 
 function sleepSync(ms) {
@@ -284,7 +324,7 @@ export function acquireProviderWorkloadGate(file, env, capture, pidInfo) {
       // caller-provided lockRoot), recreated rather than an env default so the
       // in-use root — not some other path — is what heals.
       if (error?.code === "ENOENT" && error?.syscall === "mkdir") {
-        try { mkdirSync(dirname(gateDir), { recursive: true, mode: 0o700 }); } catch { /* best effort */ }
+        if (!ensureProviderWorkloadLockRoot(dirname(gateDir))) throw unusableLockRootError();
         sleepSync(GATE_POLL_MS);
         continue;
       }
@@ -410,10 +450,7 @@ export function acquireProviderWorkloadLease({
 
   const root = lockRoot;
   const gateFile = legacyLockPath(root, slug);
-  try {
-    mkdirSync(root, { recursive: true, mode: 0o700 });
-  } catch (error) {
-    if (!isUnwritableLockRootError(error)) throw error;
+  if (!ensureProviderWorkloadLockRoot(root)) {
     return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
   }
 
@@ -472,7 +509,7 @@ export function acquireProviderWorkloadLease({
       const file = slotPath(root, slug, index);
       if (tryCreateLeaseFile(file, payload)) return acquiredResult(file, payload);
     } catch (error) {
-      if (!isUnwritableLockRootError(error)) throw error;
+      if (!isProviderWorkloadFilesystemError(error)) throw error;
       return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
     } finally {
       gate?.release?.();

--- a/plugins/kimi/scripts/lib/review-workload.mjs
+++ b/plugins/kimi/scripts/lib/review-workload.mjs
@@ -11,6 +11,33 @@ const DEFAULT_GATE_TIMEOUT_MS = 5_000;
 const GATE_POLL_MS = 25;
 const GATE_OWNER_FILE = "owner.json";
 const LOCK_ROOT_UNUSABLE_CODE = "PROVIDER_WORKLOAD_LOCK_ROOT_UNUSABLE";
+const PROVIDER_WORKLOAD_FILESYSTEM_ERROR_CODES = new Set([
+  "EACCES",
+  "EAGAIN",
+  "EBADF",
+  "EBUSY",
+  "EDQUOT",
+  "EEXIST",
+  "EFBIG",
+  "EINTR",
+  "EINVAL",
+  "EIO",
+  "EISDIR",
+  "ELOOP",
+  "EMFILE",
+  "EMLINK",
+  "ENAMETOOLONG",
+  "ENFILE",
+  "ENOENT",
+  "ENOSPC",
+  "ENOTDIR",
+  "ENOTEMPTY",
+  "ENOTSUP",
+  "EOPNOTSUPP",
+  "EPERM",
+  "EROFS",
+  "EXDEV",
+]);
 
 function trimEdgeHyphens(value) {
   let start = 0;
@@ -53,7 +80,9 @@ function gateTimeoutMs(env) {
 }
 
 function isProviderWorkloadFilesystemError(error) {
-  return typeof error?.code === "string";
+  if (error?.code === LOCK_ROOT_UNUSABLE_CODE) return true;
+  if (typeof error?.syscall === "string") return true;
+  return PROVIDER_WORKLOAD_FILESYSTEM_ERROR_CODES.has(error?.code);
 }
 
 function unusableLockRootError() {

--- a/plugins/kimi/scripts/lib/review-workload.mjs
+++ b/plugins/kimi/scripts/lib/review-workload.mjs
@@ -109,16 +109,21 @@ function blockResult(capacity, reason = "active_same_provider_job") {
   });
 }
 
-function captureCurrentPidInfo(env = process.env) {
+function captureCurrentPidInfo(env = process.env, capture = capturePidInfo) {
   try {
-    return capturePidInfo(process.pid);
+    return capture(process.pid);
   } catch (error) {
-    if (!env?.RELAY_WORKLOAD_TEST_MODE) throw error;
-    return {
-      pid: process.pid,
-      starttime: `test-mode:${process.pid}`,
-      argv0: process.argv?.[0] || "node",
-    };
+    if (env?.RELAY_WORKLOAD_TEST_MODE) {
+      return {
+        pid: process.pid,
+        starttime: `test-mode:${process.pid}`,
+        argv0: process.argv?.[0] || "node",
+      };
+    }
+    // The current process is necessarily live even when a host sandbox denies
+    // /bin/ps or /proc. Store no reuse proof rather than blocking every launch;
+    // stale cleanup then remains conservative until process inspection works.
+    return { pid: process.pid, starttime: null, argv0: null };
   }
 }
 
@@ -384,11 +389,15 @@ export function acquireProviderWorkloadLease({
 
   const root = lockRoot;
   const gateFile = legacyLockPath(root, slug);
-  mkdirSync(root, { recursive: true, mode: 0o700 });
+  try {
+    mkdirSync(root, { recursive: true, mode: 0o700 });
+  } catch {
+    return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
+  }
 
   let pidInfo;
   try {
-    pidInfo = captureCurrentPidInfo(env);
+    pidInfo = captureCurrentPidInfo(env, capture);
   } catch {
     return blockResult({ active_count: 0, limit }, "unverifiable_current_process");
   }

--- a/relay/relay-agy/scripts/lib/provider-route-policy.mjs
+++ b/relay/relay-agy/scripts/lib/provider-route-policy.mjs
@@ -267,7 +267,10 @@ function defaultProviderWorkloadLockRoot(env = process.env) {
   const xdgStateHome = typeof env?.XDG_STATE_HOME === "string" && env.XDG_STATE_HOME.trim() !== ""
     ? env.XDG_STATE_HOME
     : null;
-  return join(xdgStateHome || tmpdir(), "relay", "locks", "v2");
+  if (xdgStateHome) return join(xdgStateHome, "relay", "locks", "v2");
+  const uid = process.getuid?.();
+  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-${uid}` : "relay-user";
+  return join(tmpdir(), userSegment, "locks", "v2");
 }
 
 function providerWorkloadLockRoot(category, env = process.env) {

--- a/relay/relay-agy/scripts/lib/provider-route-policy.mjs
+++ b/relay/relay-agy/scripts/lib/provider-route-policy.mjs
@@ -269,8 +269,8 @@ function defaultProviderWorkloadLockRoot(env = process.env) {
     : null;
   if (xdgStateHome) return join(xdgStateHome, "relay", "locks", "v2");
   const uid = process.getuid?.();
-  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-${uid}` : "relay-user";
-  return join(tmpdir(), userSegment, "locks", "v2");
+  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-locks-v2-${uid}` : "relay-locks-v2-user";
+  return join(tmpdir(), userSegment);
 }
 
 function providerWorkloadLockRoot(category, env = process.env) {

--- a/relay/relay-agy/scripts/lib/provider-route-policy.mjs
+++ b/relay/relay-agy/scripts/lib/provider-route-policy.mjs
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { statSync } from "node:fs";
-import { homedir } from "node:os";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { hasSubstantiveInvalidVerdictReason } from "./external-model-review-quality.mjs";
@@ -267,7 +267,7 @@ function defaultProviderWorkloadLockRoot(env = process.env) {
   const xdgStateHome = typeof env?.XDG_STATE_HOME === "string" && env.XDG_STATE_HOME.trim() !== ""
     ? env.XDG_STATE_HOME
     : null;
-  return join(xdgStateHome || join(homedir(), ".local/state"), "relay", "locks", "v2");
+  return join(xdgStateHome || tmpdir(), "relay", "locks", "v2");
 }
 
 function providerWorkloadLockRoot(category, env = process.env) {

--- a/relay/relay-agy/scripts/lib/review-workload.mjs
+++ b/relay/relay-agy/scripts/lib/review-workload.mjs
@@ -10,6 +10,15 @@ const SCHEMA_VERSION = 1;
 const DEFAULT_GATE_TIMEOUT_MS = 5_000;
 const GATE_POLL_MS = 25;
 const GATE_OWNER_FILE = "owner.json";
+const LOCK_ROOT_UNWRITABLE_CODES = new Set([
+  "EACCES",
+  "EPERM",
+  "ENOTDIR",
+  "EROFS",
+  "ENOSPC",
+  "EMFILE",
+  "ENFILE",
+]);
 
 function trimEdgeHyphens(value) {
   let start = 0;
@@ -49,6 +58,10 @@ function positiveIntegerEnv(env, name, fallback) {
 
 function gateTimeoutMs(env) {
   return positiveIntegerEnv(env, GATE_TIMEOUT_ENV, DEFAULT_GATE_TIMEOUT_MS);
+}
+
+function isUnwritableLockRootError(error) {
+  return LOCK_ROOT_UNWRITABLE_CODES.has(error?.code);
 }
 
 function sleepSync(ms) {
@@ -109,21 +122,29 @@ function blockResult(capacity, reason = "active_same_provider_job") {
   });
 }
 
+function currentPidInfoWithoutCaptureProof(env, error) {
+  const message = String(error?.message ?? error ?? "");
+  const expectedCaptureFailure = message.startsWith("capture_error")
+    || message.startsWith("process_gone")
+    || message.startsWith("invalid_pid");
+  if (env?.RELAY_WORKLOAD_TEST_MODE && expectedCaptureFailure) {
+    return {
+      pid: process.pid,
+      starttime: `test-mode:${process.pid}`,
+      argv0: process.argv?.[0] || "node",
+    };
+  }
+  // The current process is necessarily live even when a host sandbox denies
+  // /bin/ps or /proc. Store no reuse proof rather than blocking every launch;
+  // stale cleanup then remains conservative until process inspection works.
+  return { pid: process.pid, starttime: null, argv0: null };
+}
+
 function captureCurrentPidInfo(env = process.env, capture = capturePidInfo) {
   try {
     return capture(process.pid);
   } catch (error) {
-    if (env?.RELAY_WORKLOAD_TEST_MODE) {
-      return {
-        pid: process.pid,
-        starttime: `test-mode:${process.pid}`,
-        argv0: process.argv?.[0] || "node",
-      };
-    }
-    // The current process is necessarily live even when a host sandbox denies
-    // /bin/ps or /proc. Store no reuse proof rather than blocking every launch;
-    // stale cleanup then remains conservative until process inspection works.
-    return { pid: process.pid, starttime: null, argv0: null };
+    return currentPidInfoWithoutCaptureProof(env, error);
   }
 }
 
@@ -391,16 +412,12 @@ export function acquireProviderWorkloadLease({
   const gateFile = legacyLockPath(root, slug);
   try {
     mkdirSync(root, { recursive: true, mode: 0o700 });
-  } catch {
+  } catch (error) {
+    if (!isUnwritableLockRootError(error)) throw error;
     return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
   }
 
-  let pidInfo;
-  try {
-    pidInfo = captureCurrentPidInfo(env, capture);
-  } catch {
-    return blockResult({ active_count: 0, limit }, "unverifiable_current_process");
-  }
+  const pidInfo = captureCurrentPidInfo(env, capture);
 
   const payload = Object.freeze({
     schema_version: SCHEMA_VERSION,
@@ -419,9 +436,10 @@ export function acquireProviderWorkloadLease({
   });
 
   for (;;) {
-    const gate = acquireProviderWorkloadGate(gateFile, env, capture, pidInfo);
-    if (!gate.ok) return blockResult({ active_count: limit, limit });
+    let gate;
     try {
+      gate = acquireProviderWorkloadGate(gateFile, env, capture, pidInfo);
+      if (!gate.ok) return blockResult({ active_count: limit, limit });
       const slots = enumerateSlotFiles(root, slug);
       if (!slots) return blockResult({ active_count: limit, limit }, "unreadable_provider_workload_lock_root");
 
@@ -453,8 +471,11 @@ export function acquireProviderWorkloadLease({
       }
       const file = slotPath(root, slug, index);
       if (tryCreateLeaseFile(file, payload)) return acquiredResult(file, payload);
+    } catch (error) {
+      if (!isUnwritableLockRootError(error)) throw error;
+      return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
     } finally {
-      gate.release?.();
+      gate?.release?.();
     }
   }
 }

--- a/relay/relay-agy/scripts/lib/review-workload.mjs
+++ b/relay/relay-agy/scripts/lib/review-workload.mjs
@@ -1,4 +1,4 @@
-import { existsSync, linkSync, lstatSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, linkSync, lstatSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import { hostname } from "node:os";
 import { join, dirname } from "node:path";
@@ -10,15 +10,7 @@ const SCHEMA_VERSION = 1;
 const DEFAULT_GATE_TIMEOUT_MS = 5_000;
 const GATE_POLL_MS = 25;
 const GATE_OWNER_FILE = "owner.json";
-const LOCK_ROOT_UNWRITABLE_CODES = new Set([
-  "EACCES",
-  "EPERM",
-  "ENOTDIR",
-  "EROFS",
-  "ENOSPC",
-  "EMFILE",
-  "ENFILE",
-]);
+const LOCK_ROOT_UNUSABLE_CODE = "PROVIDER_WORKLOAD_LOCK_ROOT_UNUSABLE";
 
 function trimEdgeHyphens(value) {
   let start = 0;
@@ -60,8 +52,56 @@ function gateTimeoutMs(env) {
   return positiveIntegerEnv(env, GATE_TIMEOUT_ENV, DEFAULT_GATE_TIMEOUT_MS);
 }
 
-function isUnwritableLockRootError(error) {
-  return LOCK_ROOT_UNWRITABLE_CODES.has(error?.code);
+function isProviderWorkloadFilesystemError(error) {
+  return typeof error?.code === "string";
+}
+
+function unusableLockRootError() {
+  const error = new Error("provider workload lock root is not usable");
+  error.code = LOCK_ROOT_UNUSABLE_CODE;
+  return error;
+}
+
+function currentUid() {
+  const uid = process.getuid?.();
+  return Number.isSafeInteger(uid) && uid >= 0 ? uid : null;
+}
+
+function ensureProviderWorkloadLockRoot(root) {
+  try {
+    mkdirSync(root, { recursive: true, mode: 0o700 });
+  } catch (error) {
+    if (!isProviderWorkloadFilesystemError(error)) throw error;
+    return false;
+  }
+
+  let stat;
+  try {
+    stat = lstatSync(root);
+  } catch (error) {
+    if (!isProviderWorkloadFilesystemError(error)) throw error;
+    return false;
+  }
+  if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
+
+  const uid = currentUid();
+  if (uid != null && typeof stat.uid === "number" && stat.uid !== uid) return false;
+
+  const mode = stat.mode & 0o777;
+  if ((mode & 0o700) !== 0o700) return false;
+  if ((mode & 0o077) !== 0) {
+    try {
+      chmodSync(root, 0o700);
+      stat = lstatSync(root);
+    } catch (error) {
+      if (!isProviderWorkloadFilesystemError(error)) throw error;
+      return false;
+    }
+    if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
+    if ((stat.mode & 0o777) !== 0o700) return false;
+  }
+
+  return true;
 }
 
 function sleepSync(ms) {
@@ -284,7 +324,7 @@ export function acquireProviderWorkloadGate(file, env, capture, pidInfo) {
       // caller-provided lockRoot), recreated rather than an env default so the
       // in-use root — not some other path — is what heals.
       if (error?.code === "ENOENT" && error?.syscall === "mkdir") {
-        try { mkdirSync(dirname(gateDir), { recursive: true, mode: 0o700 }); } catch { /* best effort */ }
+        if (!ensureProviderWorkloadLockRoot(dirname(gateDir))) throw unusableLockRootError();
         sleepSync(GATE_POLL_MS);
         continue;
       }
@@ -410,10 +450,7 @@ export function acquireProviderWorkloadLease({
 
   const root = lockRoot;
   const gateFile = legacyLockPath(root, slug);
-  try {
-    mkdirSync(root, { recursive: true, mode: 0o700 });
-  } catch (error) {
-    if (!isUnwritableLockRootError(error)) throw error;
+  if (!ensureProviderWorkloadLockRoot(root)) {
     return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
   }
 
@@ -472,7 +509,7 @@ export function acquireProviderWorkloadLease({
       const file = slotPath(root, slug, index);
       if (tryCreateLeaseFile(file, payload)) return acquiredResult(file, payload);
     } catch (error) {
-      if (!isUnwritableLockRootError(error)) throw error;
+      if (!isProviderWorkloadFilesystemError(error)) throw error;
       return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
     } finally {
       gate?.release?.();

--- a/relay/relay-agy/scripts/lib/review-workload.mjs
+++ b/relay/relay-agy/scripts/lib/review-workload.mjs
@@ -11,6 +11,33 @@ const DEFAULT_GATE_TIMEOUT_MS = 5_000;
 const GATE_POLL_MS = 25;
 const GATE_OWNER_FILE = "owner.json";
 const LOCK_ROOT_UNUSABLE_CODE = "PROVIDER_WORKLOAD_LOCK_ROOT_UNUSABLE";
+const PROVIDER_WORKLOAD_FILESYSTEM_ERROR_CODES = new Set([
+  "EACCES",
+  "EAGAIN",
+  "EBADF",
+  "EBUSY",
+  "EDQUOT",
+  "EEXIST",
+  "EFBIG",
+  "EINTR",
+  "EINVAL",
+  "EIO",
+  "EISDIR",
+  "ELOOP",
+  "EMFILE",
+  "EMLINK",
+  "ENAMETOOLONG",
+  "ENFILE",
+  "ENOENT",
+  "ENOSPC",
+  "ENOTDIR",
+  "ENOTEMPTY",
+  "ENOTSUP",
+  "EOPNOTSUPP",
+  "EPERM",
+  "EROFS",
+  "EXDEV",
+]);
 
 function trimEdgeHyphens(value) {
   let start = 0;
@@ -53,7 +80,9 @@ function gateTimeoutMs(env) {
 }
 
 function isProviderWorkloadFilesystemError(error) {
-  return typeof error?.code === "string";
+  if (error?.code === LOCK_ROOT_UNUSABLE_CODE) return true;
+  if (typeof error?.syscall === "string") return true;
+  return PROVIDER_WORKLOAD_FILESYSTEM_ERROR_CODES.has(error?.code);
 }
 
 function unusableLockRootError() {

--- a/relay/relay-agy/scripts/lib/review-workload.mjs
+++ b/relay/relay-agy/scripts/lib/review-workload.mjs
@@ -109,16 +109,21 @@ function blockResult(capacity, reason = "active_same_provider_job") {
   });
 }
 
-function captureCurrentPidInfo(env = process.env) {
+function captureCurrentPidInfo(env = process.env, capture = capturePidInfo) {
   try {
-    return capturePidInfo(process.pid);
+    return capture(process.pid);
   } catch (error) {
-    if (!env?.RELAY_WORKLOAD_TEST_MODE) throw error;
-    return {
-      pid: process.pid,
-      starttime: `test-mode:${process.pid}`,
-      argv0: process.argv?.[0] || "node",
-    };
+    if (env?.RELAY_WORKLOAD_TEST_MODE) {
+      return {
+        pid: process.pid,
+        starttime: `test-mode:${process.pid}`,
+        argv0: process.argv?.[0] || "node",
+      };
+    }
+    // The current process is necessarily live even when a host sandbox denies
+    // /bin/ps or /proc. Store no reuse proof rather than blocking every launch;
+    // stale cleanup then remains conservative until process inspection works.
+    return { pid: process.pid, starttime: null, argv0: null };
   }
 }
 
@@ -384,11 +389,15 @@ export function acquireProviderWorkloadLease({
 
   const root = lockRoot;
   const gateFile = legacyLockPath(root, slug);
-  mkdirSync(root, { recursive: true, mode: 0o700 });
+  try {
+    mkdirSync(root, { recursive: true, mode: 0o700 });
+  } catch {
+    return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
+  }
 
   let pidInfo;
   try {
-    pidInfo = captureCurrentPidInfo(env);
+    pidInfo = captureCurrentPidInfo(env, capture);
   } catch {
     return blockResult({ active_count: 0, limit }, "unverifiable_current_process");
   }

--- a/relay/relay-gemini/scripts/lib/provider-route-policy.mjs
+++ b/relay/relay-gemini/scripts/lib/provider-route-policy.mjs
@@ -267,7 +267,10 @@ function defaultProviderWorkloadLockRoot(env = process.env) {
   const xdgStateHome = typeof env?.XDG_STATE_HOME === "string" && env.XDG_STATE_HOME.trim() !== ""
     ? env.XDG_STATE_HOME
     : null;
-  return join(xdgStateHome || tmpdir(), "relay", "locks", "v2");
+  if (xdgStateHome) return join(xdgStateHome, "relay", "locks", "v2");
+  const uid = process.getuid?.();
+  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-${uid}` : "relay-user";
+  return join(tmpdir(), userSegment, "locks", "v2");
 }
 
 function providerWorkloadLockRoot(category, env = process.env) {

--- a/relay/relay-gemini/scripts/lib/provider-route-policy.mjs
+++ b/relay/relay-gemini/scripts/lib/provider-route-policy.mjs
@@ -269,8 +269,8 @@ function defaultProviderWorkloadLockRoot(env = process.env) {
     : null;
   if (xdgStateHome) return join(xdgStateHome, "relay", "locks", "v2");
   const uid = process.getuid?.();
-  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-${uid}` : "relay-user";
-  return join(tmpdir(), userSegment, "locks", "v2");
+  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-locks-v2-${uid}` : "relay-locks-v2-user";
+  return join(tmpdir(), userSegment);
 }
 
 function providerWorkloadLockRoot(category, env = process.env) {

--- a/relay/relay-gemini/scripts/lib/provider-route-policy.mjs
+++ b/relay/relay-gemini/scripts/lib/provider-route-policy.mjs
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { statSync } from "node:fs";
-import { homedir } from "node:os";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { hasSubstantiveInvalidVerdictReason } from "./external-model-review-quality.mjs";
@@ -267,7 +267,7 @@ function defaultProviderWorkloadLockRoot(env = process.env) {
   const xdgStateHome = typeof env?.XDG_STATE_HOME === "string" && env.XDG_STATE_HOME.trim() !== ""
     ? env.XDG_STATE_HOME
     : null;
-  return join(xdgStateHome || join(homedir(), ".local/state"), "relay", "locks", "v2");
+  return join(xdgStateHome || tmpdir(), "relay", "locks", "v2");
 }
 
 function providerWorkloadLockRoot(category, env = process.env) {

--- a/relay/relay-gemini/scripts/lib/review-workload.mjs
+++ b/relay/relay-gemini/scripts/lib/review-workload.mjs
@@ -10,6 +10,15 @@ const SCHEMA_VERSION = 1;
 const DEFAULT_GATE_TIMEOUT_MS = 5_000;
 const GATE_POLL_MS = 25;
 const GATE_OWNER_FILE = "owner.json";
+const LOCK_ROOT_UNWRITABLE_CODES = new Set([
+  "EACCES",
+  "EPERM",
+  "ENOTDIR",
+  "EROFS",
+  "ENOSPC",
+  "EMFILE",
+  "ENFILE",
+]);
 
 function trimEdgeHyphens(value) {
   let start = 0;
@@ -49,6 +58,10 @@ function positiveIntegerEnv(env, name, fallback) {
 
 function gateTimeoutMs(env) {
   return positiveIntegerEnv(env, GATE_TIMEOUT_ENV, DEFAULT_GATE_TIMEOUT_MS);
+}
+
+function isUnwritableLockRootError(error) {
+  return LOCK_ROOT_UNWRITABLE_CODES.has(error?.code);
 }
 
 function sleepSync(ms) {
@@ -109,21 +122,29 @@ function blockResult(capacity, reason = "active_same_provider_job") {
   });
 }
 
+function currentPidInfoWithoutCaptureProof(env, error) {
+  const message = String(error?.message ?? error ?? "");
+  const expectedCaptureFailure = message.startsWith("capture_error")
+    || message.startsWith("process_gone")
+    || message.startsWith("invalid_pid");
+  if (env?.RELAY_WORKLOAD_TEST_MODE && expectedCaptureFailure) {
+    return {
+      pid: process.pid,
+      starttime: `test-mode:${process.pid}`,
+      argv0: process.argv?.[0] || "node",
+    };
+  }
+  // The current process is necessarily live even when a host sandbox denies
+  // /bin/ps or /proc. Store no reuse proof rather than blocking every launch;
+  // stale cleanup then remains conservative until process inspection works.
+  return { pid: process.pid, starttime: null, argv0: null };
+}
+
 function captureCurrentPidInfo(env = process.env, capture = capturePidInfo) {
   try {
     return capture(process.pid);
   } catch (error) {
-    if (env?.RELAY_WORKLOAD_TEST_MODE) {
-      return {
-        pid: process.pid,
-        starttime: `test-mode:${process.pid}`,
-        argv0: process.argv?.[0] || "node",
-      };
-    }
-    // The current process is necessarily live even when a host sandbox denies
-    // /bin/ps or /proc. Store no reuse proof rather than blocking every launch;
-    // stale cleanup then remains conservative until process inspection works.
-    return { pid: process.pid, starttime: null, argv0: null };
+    return currentPidInfoWithoutCaptureProof(env, error);
   }
 }
 
@@ -391,16 +412,12 @@ export function acquireProviderWorkloadLease({
   const gateFile = legacyLockPath(root, slug);
   try {
     mkdirSync(root, { recursive: true, mode: 0o700 });
-  } catch {
+  } catch (error) {
+    if (!isUnwritableLockRootError(error)) throw error;
     return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
   }
 
-  let pidInfo;
-  try {
-    pidInfo = captureCurrentPidInfo(env, capture);
-  } catch {
-    return blockResult({ active_count: 0, limit }, "unverifiable_current_process");
-  }
+  const pidInfo = captureCurrentPidInfo(env, capture);
 
   const payload = Object.freeze({
     schema_version: SCHEMA_VERSION,
@@ -419,9 +436,10 @@ export function acquireProviderWorkloadLease({
   });
 
   for (;;) {
-    const gate = acquireProviderWorkloadGate(gateFile, env, capture, pidInfo);
-    if (!gate.ok) return blockResult({ active_count: limit, limit });
+    let gate;
     try {
+      gate = acquireProviderWorkloadGate(gateFile, env, capture, pidInfo);
+      if (!gate.ok) return blockResult({ active_count: limit, limit });
       const slots = enumerateSlotFiles(root, slug);
       if (!slots) return blockResult({ active_count: limit, limit }, "unreadable_provider_workload_lock_root");
 
@@ -453,8 +471,11 @@ export function acquireProviderWorkloadLease({
       }
       const file = slotPath(root, slug, index);
       if (tryCreateLeaseFile(file, payload)) return acquiredResult(file, payload);
+    } catch (error) {
+      if (!isUnwritableLockRootError(error)) throw error;
+      return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
     } finally {
-      gate.release?.();
+      gate?.release?.();
     }
   }
 }

--- a/relay/relay-gemini/scripts/lib/review-workload.mjs
+++ b/relay/relay-gemini/scripts/lib/review-workload.mjs
@@ -1,4 +1,4 @@
-import { existsSync, linkSync, lstatSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, linkSync, lstatSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import { hostname } from "node:os";
 import { join, dirname } from "node:path";
@@ -10,15 +10,7 @@ const SCHEMA_VERSION = 1;
 const DEFAULT_GATE_TIMEOUT_MS = 5_000;
 const GATE_POLL_MS = 25;
 const GATE_OWNER_FILE = "owner.json";
-const LOCK_ROOT_UNWRITABLE_CODES = new Set([
-  "EACCES",
-  "EPERM",
-  "ENOTDIR",
-  "EROFS",
-  "ENOSPC",
-  "EMFILE",
-  "ENFILE",
-]);
+const LOCK_ROOT_UNUSABLE_CODE = "PROVIDER_WORKLOAD_LOCK_ROOT_UNUSABLE";
 
 function trimEdgeHyphens(value) {
   let start = 0;
@@ -60,8 +52,56 @@ function gateTimeoutMs(env) {
   return positiveIntegerEnv(env, GATE_TIMEOUT_ENV, DEFAULT_GATE_TIMEOUT_MS);
 }
 
-function isUnwritableLockRootError(error) {
-  return LOCK_ROOT_UNWRITABLE_CODES.has(error?.code);
+function isProviderWorkloadFilesystemError(error) {
+  return typeof error?.code === "string";
+}
+
+function unusableLockRootError() {
+  const error = new Error("provider workload lock root is not usable");
+  error.code = LOCK_ROOT_UNUSABLE_CODE;
+  return error;
+}
+
+function currentUid() {
+  const uid = process.getuid?.();
+  return Number.isSafeInteger(uid) && uid >= 0 ? uid : null;
+}
+
+function ensureProviderWorkloadLockRoot(root) {
+  try {
+    mkdirSync(root, { recursive: true, mode: 0o700 });
+  } catch (error) {
+    if (!isProviderWorkloadFilesystemError(error)) throw error;
+    return false;
+  }
+
+  let stat;
+  try {
+    stat = lstatSync(root);
+  } catch (error) {
+    if (!isProviderWorkloadFilesystemError(error)) throw error;
+    return false;
+  }
+  if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
+
+  const uid = currentUid();
+  if (uid != null && typeof stat.uid === "number" && stat.uid !== uid) return false;
+
+  const mode = stat.mode & 0o777;
+  if ((mode & 0o700) !== 0o700) return false;
+  if ((mode & 0o077) !== 0) {
+    try {
+      chmodSync(root, 0o700);
+      stat = lstatSync(root);
+    } catch (error) {
+      if (!isProviderWorkloadFilesystemError(error)) throw error;
+      return false;
+    }
+    if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
+    if ((stat.mode & 0o777) !== 0o700) return false;
+  }
+
+  return true;
 }
 
 function sleepSync(ms) {
@@ -284,7 +324,7 @@ export function acquireProviderWorkloadGate(file, env, capture, pidInfo) {
       // caller-provided lockRoot), recreated rather than an env default so the
       // in-use root — not some other path — is what heals.
       if (error?.code === "ENOENT" && error?.syscall === "mkdir") {
-        try { mkdirSync(dirname(gateDir), { recursive: true, mode: 0o700 }); } catch { /* best effort */ }
+        if (!ensureProviderWorkloadLockRoot(dirname(gateDir))) throw unusableLockRootError();
         sleepSync(GATE_POLL_MS);
         continue;
       }
@@ -410,10 +450,7 @@ export function acquireProviderWorkloadLease({
 
   const root = lockRoot;
   const gateFile = legacyLockPath(root, slug);
-  try {
-    mkdirSync(root, { recursive: true, mode: 0o700 });
-  } catch (error) {
-    if (!isUnwritableLockRootError(error)) throw error;
+  if (!ensureProviderWorkloadLockRoot(root)) {
     return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
   }
 
@@ -472,7 +509,7 @@ export function acquireProviderWorkloadLease({
       const file = slotPath(root, slug, index);
       if (tryCreateLeaseFile(file, payload)) return acquiredResult(file, payload);
     } catch (error) {
-      if (!isUnwritableLockRootError(error)) throw error;
+      if (!isProviderWorkloadFilesystemError(error)) throw error;
       return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
     } finally {
       gate?.release?.();

--- a/relay/relay-gemini/scripts/lib/review-workload.mjs
+++ b/relay/relay-gemini/scripts/lib/review-workload.mjs
@@ -11,6 +11,33 @@ const DEFAULT_GATE_TIMEOUT_MS = 5_000;
 const GATE_POLL_MS = 25;
 const GATE_OWNER_FILE = "owner.json";
 const LOCK_ROOT_UNUSABLE_CODE = "PROVIDER_WORKLOAD_LOCK_ROOT_UNUSABLE";
+const PROVIDER_WORKLOAD_FILESYSTEM_ERROR_CODES = new Set([
+  "EACCES",
+  "EAGAIN",
+  "EBADF",
+  "EBUSY",
+  "EDQUOT",
+  "EEXIST",
+  "EFBIG",
+  "EINTR",
+  "EINVAL",
+  "EIO",
+  "EISDIR",
+  "ELOOP",
+  "EMFILE",
+  "EMLINK",
+  "ENAMETOOLONG",
+  "ENFILE",
+  "ENOENT",
+  "ENOSPC",
+  "ENOTDIR",
+  "ENOTEMPTY",
+  "ENOTSUP",
+  "EOPNOTSUPP",
+  "EPERM",
+  "EROFS",
+  "EXDEV",
+]);
 
 function trimEdgeHyphens(value) {
   let start = 0;
@@ -53,7 +80,9 @@ function gateTimeoutMs(env) {
 }
 
 function isProviderWorkloadFilesystemError(error) {
-  return typeof error?.code === "string";
+  if (error?.code === LOCK_ROOT_UNUSABLE_CODE) return true;
+  if (typeof error?.syscall === "string") return true;
+  return PROVIDER_WORKLOAD_FILESYSTEM_ERROR_CODES.has(error?.code);
 }
 
 function unusableLockRootError() {

--- a/relay/relay-gemini/scripts/lib/review-workload.mjs
+++ b/relay/relay-gemini/scripts/lib/review-workload.mjs
@@ -109,16 +109,21 @@ function blockResult(capacity, reason = "active_same_provider_job") {
   });
 }
 
-function captureCurrentPidInfo(env = process.env) {
+function captureCurrentPidInfo(env = process.env, capture = capturePidInfo) {
   try {
-    return capturePidInfo(process.pid);
+    return capture(process.pid);
   } catch (error) {
-    if (!env?.RELAY_WORKLOAD_TEST_MODE) throw error;
-    return {
-      pid: process.pid,
-      starttime: `test-mode:${process.pid}`,
-      argv0: process.argv?.[0] || "node",
-    };
+    if (env?.RELAY_WORKLOAD_TEST_MODE) {
+      return {
+        pid: process.pid,
+        starttime: `test-mode:${process.pid}`,
+        argv0: process.argv?.[0] || "node",
+      };
+    }
+    // The current process is necessarily live even when a host sandbox denies
+    // /bin/ps or /proc. Store no reuse proof rather than blocking every launch;
+    // stale cleanup then remains conservative until process inspection works.
+    return { pid: process.pid, starttime: null, argv0: null };
   }
 }
 
@@ -384,11 +389,15 @@ export function acquireProviderWorkloadLease({
 
   const root = lockRoot;
   const gateFile = legacyLockPath(root, slug);
-  mkdirSync(root, { recursive: true, mode: 0o700 });
+  try {
+    mkdirSync(root, { recursive: true, mode: 0o700 });
+  } catch {
+    return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
+  }
 
   let pidInfo;
   try {
-    pidInfo = captureCurrentPidInfo(env);
+    pidInfo = captureCurrentPidInfo(env, capture);
   } catch {
     return blockResult({ active_count: 0, limit }, "unverifiable_current_process");
   }

--- a/relay/relay-grok/scripts/lib/provider-route-policy.mjs
+++ b/relay/relay-grok/scripts/lib/provider-route-policy.mjs
@@ -267,7 +267,10 @@ function defaultProviderWorkloadLockRoot(env = process.env) {
   const xdgStateHome = typeof env?.XDG_STATE_HOME === "string" && env.XDG_STATE_HOME.trim() !== ""
     ? env.XDG_STATE_HOME
     : null;
-  return join(xdgStateHome || tmpdir(), "relay", "locks", "v2");
+  if (xdgStateHome) return join(xdgStateHome, "relay", "locks", "v2");
+  const uid = process.getuid?.();
+  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-${uid}` : "relay-user";
+  return join(tmpdir(), userSegment, "locks", "v2");
 }
 
 function providerWorkloadLockRoot(category, env = process.env) {

--- a/relay/relay-grok/scripts/lib/provider-route-policy.mjs
+++ b/relay/relay-grok/scripts/lib/provider-route-policy.mjs
@@ -269,8 +269,8 @@ function defaultProviderWorkloadLockRoot(env = process.env) {
     : null;
   if (xdgStateHome) return join(xdgStateHome, "relay", "locks", "v2");
   const uid = process.getuid?.();
-  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-${uid}` : "relay-user";
-  return join(tmpdir(), userSegment, "locks", "v2");
+  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-locks-v2-${uid}` : "relay-locks-v2-user";
+  return join(tmpdir(), userSegment);
 }
 
 function providerWorkloadLockRoot(category, env = process.env) {

--- a/relay/relay-grok/scripts/lib/provider-route-policy.mjs
+++ b/relay/relay-grok/scripts/lib/provider-route-policy.mjs
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { statSync } from "node:fs";
-import { homedir } from "node:os";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { hasSubstantiveInvalidVerdictReason } from "./external-model-review-quality.mjs";
@@ -267,7 +267,7 @@ function defaultProviderWorkloadLockRoot(env = process.env) {
   const xdgStateHome = typeof env?.XDG_STATE_HOME === "string" && env.XDG_STATE_HOME.trim() !== ""
     ? env.XDG_STATE_HOME
     : null;
-  return join(xdgStateHome || join(homedir(), ".local/state"), "relay", "locks", "v2");
+  return join(xdgStateHome || tmpdir(), "relay", "locks", "v2");
 }
 
 function providerWorkloadLockRoot(category, env = process.env) {

--- a/relay/relay-grok/scripts/lib/review-workload.mjs
+++ b/relay/relay-grok/scripts/lib/review-workload.mjs
@@ -10,6 +10,15 @@ const SCHEMA_VERSION = 1;
 const DEFAULT_GATE_TIMEOUT_MS = 5_000;
 const GATE_POLL_MS = 25;
 const GATE_OWNER_FILE = "owner.json";
+const LOCK_ROOT_UNWRITABLE_CODES = new Set([
+  "EACCES",
+  "EPERM",
+  "ENOTDIR",
+  "EROFS",
+  "ENOSPC",
+  "EMFILE",
+  "ENFILE",
+]);
 
 function trimEdgeHyphens(value) {
   let start = 0;
@@ -49,6 +58,10 @@ function positiveIntegerEnv(env, name, fallback) {
 
 function gateTimeoutMs(env) {
   return positiveIntegerEnv(env, GATE_TIMEOUT_ENV, DEFAULT_GATE_TIMEOUT_MS);
+}
+
+function isUnwritableLockRootError(error) {
+  return LOCK_ROOT_UNWRITABLE_CODES.has(error?.code);
 }
 
 function sleepSync(ms) {
@@ -109,21 +122,29 @@ function blockResult(capacity, reason = "active_same_provider_job") {
   });
 }
 
+function currentPidInfoWithoutCaptureProof(env, error) {
+  const message = String(error?.message ?? error ?? "");
+  const expectedCaptureFailure = message.startsWith("capture_error")
+    || message.startsWith("process_gone")
+    || message.startsWith("invalid_pid");
+  if (env?.RELAY_WORKLOAD_TEST_MODE && expectedCaptureFailure) {
+    return {
+      pid: process.pid,
+      starttime: `test-mode:${process.pid}`,
+      argv0: process.argv?.[0] || "node",
+    };
+  }
+  // The current process is necessarily live even when a host sandbox denies
+  // /bin/ps or /proc. Store no reuse proof rather than blocking every launch;
+  // stale cleanup then remains conservative until process inspection works.
+  return { pid: process.pid, starttime: null, argv0: null };
+}
+
 function captureCurrentPidInfo(env = process.env, capture = capturePidInfo) {
   try {
     return capture(process.pid);
   } catch (error) {
-    if (env?.RELAY_WORKLOAD_TEST_MODE) {
-      return {
-        pid: process.pid,
-        starttime: `test-mode:${process.pid}`,
-        argv0: process.argv?.[0] || "node",
-      };
-    }
-    // The current process is necessarily live even when a host sandbox denies
-    // /bin/ps or /proc. Store no reuse proof rather than blocking every launch;
-    // stale cleanup then remains conservative until process inspection works.
-    return { pid: process.pid, starttime: null, argv0: null };
+    return currentPidInfoWithoutCaptureProof(env, error);
   }
 }
 
@@ -391,16 +412,12 @@ export function acquireProviderWorkloadLease({
   const gateFile = legacyLockPath(root, slug);
   try {
     mkdirSync(root, { recursive: true, mode: 0o700 });
-  } catch {
+  } catch (error) {
+    if (!isUnwritableLockRootError(error)) throw error;
     return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
   }
 
-  let pidInfo;
-  try {
-    pidInfo = captureCurrentPidInfo(env, capture);
-  } catch {
-    return blockResult({ active_count: 0, limit }, "unverifiable_current_process");
-  }
+  const pidInfo = captureCurrentPidInfo(env, capture);
 
   const payload = Object.freeze({
     schema_version: SCHEMA_VERSION,
@@ -419,9 +436,10 @@ export function acquireProviderWorkloadLease({
   });
 
   for (;;) {
-    const gate = acquireProviderWorkloadGate(gateFile, env, capture, pidInfo);
-    if (!gate.ok) return blockResult({ active_count: limit, limit });
+    let gate;
     try {
+      gate = acquireProviderWorkloadGate(gateFile, env, capture, pidInfo);
+      if (!gate.ok) return blockResult({ active_count: limit, limit });
       const slots = enumerateSlotFiles(root, slug);
       if (!slots) return blockResult({ active_count: limit, limit }, "unreadable_provider_workload_lock_root");
 
@@ -453,8 +471,11 @@ export function acquireProviderWorkloadLease({
       }
       const file = slotPath(root, slug, index);
       if (tryCreateLeaseFile(file, payload)) return acquiredResult(file, payload);
+    } catch (error) {
+      if (!isUnwritableLockRootError(error)) throw error;
+      return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
     } finally {
-      gate.release?.();
+      gate?.release?.();
     }
   }
 }

--- a/relay/relay-grok/scripts/lib/review-workload.mjs
+++ b/relay/relay-grok/scripts/lib/review-workload.mjs
@@ -1,4 +1,4 @@
-import { existsSync, linkSync, lstatSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, linkSync, lstatSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import { hostname } from "node:os";
 import { join, dirname } from "node:path";
@@ -10,15 +10,7 @@ const SCHEMA_VERSION = 1;
 const DEFAULT_GATE_TIMEOUT_MS = 5_000;
 const GATE_POLL_MS = 25;
 const GATE_OWNER_FILE = "owner.json";
-const LOCK_ROOT_UNWRITABLE_CODES = new Set([
-  "EACCES",
-  "EPERM",
-  "ENOTDIR",
-  "EROFS",
-  "ENOSPC",
-  "EMFILE",
-  "ENFILE",
-]);
+const LOCK_ROOT_UNUSABLE_CODE = "PROVIDER_WORKLOAD_LOCK_ROOT_UNUSABLE";
 
 function trimEdgeHyphens(value) {
   let start = 0;
@@ -60,8 +52,56 @@ function gateTimeoutMs(env) {
   return positiveIntegerEnv(env, GATE_TIMEOUT_ENV, DEFAULT_GATE_TIMEOUT_MS);
 }
 
-function isUnwritableLockRootError(error) {
-  return LOCK_ROOT_UNWRITABLE_CODES.has(error?.code);
+function isProviderWorkloadFilesystemError(error) {
+  return typeof error?.code === "string";
+}
+
+function unusableLockRootError() {
+  const error = new Error("provider workload lock root is not usable");
+  error.code = LOCK_ROOT_UNUSABLE_CODE;
+  return error;
+}
+
+function currentUid() {
+  const uid = process.getuid?.();
+  return Number.isSafeInteger(uid) && uid >= 0 ? uid : null;
+}
+
+function ensureProviderWorkloadLockRoot(root) {
+  try {
+    mkdirSync(root, { recursive: true, mode: 0o700 });
+  } catch (error) {
+    if (!isProviderWorkloadFilesystemError(error)) throw error;
+    return false;
+  }
+
+  let stat;
+  try {
+    stat = lstatSync(root);
+  } catch (error) {
+    if (!isProviderWorkloadFilesystemError(error)) throw error;
+    return false;
+  }
+  if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
+
+  const uid = currentUid();
+  if (uid != null && typeof stat.uid === "number" && stat.uid !== uid) return false;
+
+  const mode = stat.mode & 0o777;
+  if ((mode & 0o700) !== 0o700) return false;
+  if ((mode & 0o077) !== 0) {
+    try {
+      chmodSync(root, 0o700);
+      stat = lstatSync(root);
+    } catch (error) {
+      if (!isProviderWorkloadFilesystemError(error)) throw error;
+      return false;
+    }
+    if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
+    if ((stat.mode & 0o777) !== 0o700) return false;
+  }
+
+  return true;
 }
 
 function sleepSync(ms) {
@@ -284,7 +324,7 @@ export function acquireProviderWorkloadGate(file, env, capture, pidInfo) {
       // caller-provided lockRoot), recreated rather than an env default so the
       // in-use root — not some other path — is what heals.
       if (error?.code === "ENOENT" && error?.syscall === "mkdir") {
-        try { mkdirSync(dirname(gateDir), { recursive: true, mode: 0o700 }); } catch { /* best effort */ }
+        if (!ensureProviderWorkloadLockRoot(dirname(gateDir))) throw unusableLockRootError();
         sleepSync(GATE_POLL_MS);
         continue;
       }
@@ -410,10 +450,7 @@ export function acquireProviderWorkloadLease({
 
   const root = lockRoot;
   const gateFile = legacyLockPath(root, slug);
-  try {
-    mkdirSync(root, { recursive: true, mode: 0o700 });
-  } catch (error) {
-    if (!isUnwritableLockRootError(error)) throw error;
+  if (!ensureProviderWorkloadLockRoot(root)) {
     return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
   }
 
@@ -472,7 +509,7 @@ export function acquireProviderWorkloadLease({
       const file = slotPath(root, slug, index);
       if (tryCreateLeaseFile(file, payload)) return acquiredResult(file, payload);
     } catch (error) {
-      if (!isUnwritableLockRootError(error)) throw error;
+      if (!isProviderWorkloadFilesystemError(error)) throw error;
       return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
     } finally {
       gate?.release?.();

--- a/relay/relay-grok/scripts/lib/review-workload.mjs
+++ b/relay/relay-grok/scripts/lib/review-workload.mjs
@@ -11,6 +11,33 @@ const DEFAULT_GATE_TIMEOUT_MS = 5_000;
 const GATE_POLL_MS = 25;
 const GATE_OWNER_FILE = "owner.json";
 const LOCK_ROOT_UNUSABLE_CODE = "PROVIDER_WORKLOAD_LOCK_ROOT_UNUSABLE";
+const PROVIDER_WORKLOAD_FILESYSTEM_ERROR_CODES = new Set([
+  "EACCES",
+  "EAGAIN",
+  "EBADF",
+  "EBUSY",
+  "EDQUOT",
+  "EEXIST",
+  "EFBIG",
+  "EINTR",
+  "EINVAL",
+  "EIO",
+  "EISDIR",
+  "ELOOP",
+  "EMFILE",
+  "EMLINK",
+  "ENAMETOOLONG",
+  "ENFILE",
+  "ENOENT",
+  "ENOSPC",
+  "ENOTDIR",
+  "ENOTEMPTY",
+  "ENOTSUP",
+  "EOPNOTSUPP",
+  "EPERM",
+  "EROFS",
+  "EXDEV",
+]);
 
 function trimEdgeHyphens(value) {
   let start = 0;
@@ -53,7 +80,9 @@ function gateTimeoutMs(env) {
 }
 
 function isProviderWorkloadFilesystemError(error) {
-  return typeof error?.code === "string";
+  if (error?.code === LOCK_ROOT_UNUSABLE_CODE) return true;
+  if (typeof error?.syscall === "string") return true;
+  return PROVIDER_WORKLOAD_FILESYSTEM_ERROR_CODES.has(error?.code);
 }
 
 function unusableLockRootError() {

--- a/relay/relay-grok/scripts/lib/review-workload.mjs
+++ b/relay/relay-grok/scripts/lib/review-workload.mjs
@@ -109,16 +109,21 @@ function blockResult(capacity, reason = "active_same_provider_job") {
   });
 }
 
-function captureCurrentPidInfo(env = process.env) {
+function captureCurrentPidInfo(env = process.env, capture = capturePidInfo) {
   try {
-    return capturePidInfo(process.pid);
+    return capture(process.pid);
   } catch (error) {
-    if (!env?.RELAY_WORKLOAD_TEST_MODE) throw error;
-    return {
-      pid: process.pid,
-      starttime: `test-mode:${process.pid}`,
-      argv0: process.argv?.[0] || "node",
-    };
+    if (env?.RELAY_WORKLOAD_TEST_MODE) {
+      return {
+        pid: process.pid,
+        starttime: `test-mode:${process.pid}`,
+        argv0: process.argv?.[0] || "node",
+      };
+    }
+    // The current process is necessarily live even when a host sandbox denies
+    // /bin/ps or /proc. Store no reuse proof rather than blocking every launch;
+    // stale cleanup then remains conservative until process inspection works.
+    return { pid: process.pid, starttime: null, argv0: null };
   }
 }
 
@@ -384,11 +389,15 @@ export function acquireProviderWorkloadLease({
 
   const root = lockRoot;
   const gateFile = legacyLockPath(root, slug);
-  mkdirSync(root, { recursive: true, mode: 0o700 });
+  try {
+    mkdirSync(root, { recursive: true, mode: 0o700 });
+  } catch {
+    return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
+  }
 
   let pidInfo;
   try {
-    pidInfo = captureCurrentPidInfo(env);
+    pidInfo = captureCurrentPidInfo(env, capture);
   } catch {
     return blockResult({ active_count: 0, limit }, "unverifiable_current_process");
   }

--- a/relay/relay-kimi/scripts/lib/provider-route-policy.mjs
+++ b/relay/relay-kimi/scripts/lib/provider-route-policy.mjs
@@ -267,7 +267,10 @@ function defaultProviderWorkloadLockRoot(env = process.env) {
   const xdgStateHome = typeof env?.XDG_STATE_HOME === "string" && env.XDG_STATE_HOME.trim() !== ""
     ? env.XDG_STATE_HOME
     : null;
-  return join(xdgStateHome || tmpdir(), "relay", "locks", "v2");
+  if (xdgStateHome) return join(xdgStateHome, "relay", "locks", "v2");
+  const uid = process.getuid?.();
+  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-${uid}` : "relay-user";
+  return join(tmpdir(), userSegment, "locks", "v2");
 }
 
 function providerWorkloadLockRoot(category, env = process.env) {

--- a/relay/relay-kimi/scripts/lib/provider-route-policy.mjs
+++ b/relay/relay-kimi/scripts/lib/provider-route-policy.mjs
@@ -269,8 +269,8 @@ function defaultProviderWorkloadLockRoot(env = process.env) {
     : null;
   if (xdgStateHome) return join(xdgStateHome, "relay", "locks", "v2");
   const uid = process.getuid?.();
-  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-${uid}` : "relay-user";
-  return join(tmpdir(), userSegment, "locks", "v2");
+  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-locks-v2-${uid}` : "relay-locks-v2-user";
+  return join(tmpdir(), userSegment);
 }
 
 function providerWorkloadLockRoot(category, env = process.env) {

--- a/relay/relay-kimi/scripts/lib/provider-route-policy.mjs
+++ b/relay/relay-kimi/scripts/lib/provider-route-policy.mjs
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { statSync } from "node:fs";
-import { homedir } from "node:os";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { hasSubstantiveInvalidVerdictReason } from "./external-model-review-quality.mjs";
@@ -267,7 +267,7 @@ function defaultProviderWorkloadLockRoot(env = process.env) {
   const xdgStateHome = typeof env?.XDG_STATE_HOME === "string" && env.XDG_STATE_HOME.trim() !== ""
     ? env.XDG_STATE_HOME
     : null;
-  return join(xdgStateHome || join(homedir(), ".local/state"), "relay", "locks", "v2");
+  return join(xdgStateHome || tmpdir(), "relay", "locks", "v2");
 }
 
 function providerWorkloadLockRoot(category, env = process.env) {

--- a/relay/relay-kimi/scripts/lib/review-workload.mjs
+++ b/relay/relay-kimi/scripts/lib/review-workload.mjs
@@ -10,6 +10,15 @@ const SCHEMA_VERSION = 1;
 const DEFAULT_GATE_TIMEOUT_MS = 5_000;
 const GATE_POLL_MS = 25;
 const GATE_OWNER_FILE = "owner.json";
+const LOCK_ROOT_UNWRITABLE_CODES = new Set([
+  "EACCES",
+  "EPERM",
+  "ENOTDIR",
+  "EROFS",
+  "ENOSPC",
+  "EMFILE",
+  "ENFILE",
+]);
 
 function trimEdgeHyphens(value) {
   let start = 0;
@@ -49,6 +58,10 @@ function positiveIntegerEnv(env, name, fallback) {
 
 function gateTimeoutMs(env) {
   return positiveIntegerEnv(env, GATE_TIMEOUT_ENV, DEFAULT_GATE_TIMEOUT_MS);
+}
+
+function isUnwritableLockRootError(error) {
+  return LOCK_ROOT_UNWRITABLE_CODES.has(error?.code);
 }
 
 function sleepSync(ms) {
@@ -109,21 +122,29 @@ function blockResult(capacity, reason = "active_same_provider_job") {
   });
 }
 
+function currentPidInfoWithoutCaptureProof(env, error) {
+  const message = String(error?.message ?? error ?? "");
+  const expectedCaptureFailure = message.startsWith("capture_error")
+    || message.startsWith("process_gone")
+    || message.startsWith("invalid_pid");
+  if (env?.RELAY_WORKLOAD_TEST_MODE && expectedCaptureFailure) {
+    return {
+      pid: process.pid,
+      starttime: `test-mode:${process.pid}`,
+      argv0: process.argv?.[0] || "node",
+    };
+  }
+  // The current process is necessarily live even when a host sandbox denies
+  // /bin/ps or /proc. Store no reuse proof rather than blocking every launch;
+  // stale cleanup then remains conservative until process inspection works.
+  return { pid: process.pid, starttime: null, argv0: null };
+}
+
 function captureCurrentPidInfo(env = process.env, capture = capturePidInfo) {
   try {
     return capture(process.pid);
   } catch (error) {
-    if (env?.RELAY_WORKLOAD_TEST_MODE) {
-      return {
-        pid: process.pid,
-        starttime: `test-mode:${process.pid}`,
-        argv0: process.argv?.[0] || "node",
-      };
-    }
-    // The current process is necessarily live even when a host sandbox denies
-    // /bin/ps or /proc. Store no reuse proof rather than blocking every launch;
-    // stale cleanup then remains conservative until process inspection works.
-    return { pid: process.pid, starttime: null, argv0: null };
+    return currentPidInfoWithoutCaptureProof(env, error);
   }
 }
 
@@ -391,16 +412,12 @@ export function acquireProviderWorkloadLease({
   const gateFile = legacyLockPath(root, slug);
   try {
     mkdirSync(root, { recursive: true, mode: 0o700 });
-  } catch {
+  } catch (error) {
+    if (!isUnwritableLockRootError(error)) throw error;
     return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
   }
 
-  let pidInfo;
-  try {
-    pidInfo = captureCurrentPidInfo(env, capture);
-  } catch {
-    return blockResult({ active_count: 0, limit }, "unverifiable_current_process");
-  }
+  const pidInfo = captureCurrentPidInfo(env, capture);
 
   const payload = Object.freeze({
     schema_version: SCHEMA_VERSION,
@@ -419,9 +436,10 @@ export function acquireProviderWorkloadLease({
   });
 
   for (;;) {
-    const gate = acquireProviderWorkloadGate(gateFile, env, capture, pidInfo);
-    if (!gate.ok) return blockResult({ active_count: limit, limit });
+    let gate;
     try {
+      gate = acquireProviderWorkloadGate(gateFile, env, capture, pidInfo);
+      if (!gate.ok) return blockResult({ active_count: limit, limit });
       const slots = enumerateSlotFiles(root, slug);
       if (!slots) return blockResult({ active_count: limit, limit }, "unreadable_provider_workload_lock_root");
 
@@ -453,8 +471,11 @@ export function acquireProviderWorkloadLease({
       }
       const file = slotPath(root, slug, index);
       if (tryCreateLeaseFile(file, payload)) return acquiredResult(file, payload);
+    } catch (error) {
+      if (!isUnwritableLockRootError(error)) throw error;
+      return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
     } finally {
-      gate.release?.();
+      gate?.release?.();
     }
   }
 }

--- a/relay/relay-kimi/scripts/lib/review-workload.mjs
+++ b/relay/relay-kimi/scripts/lib/review-workload.mjs
@@ -1,4 +1,4 @@
-import { existsSync, linkSync, lstatSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, linkSync, lstatSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import { hostname } from "node:os";
 import { join, dirname } from "node:path";
@@ -10,15 +10,7 @@ const SCHEMA_VERSION = 1;
 const DEFAULT_GATE_TIMEOUT_MS = 5_000;
 const GATE_POLL_MS = 25;
 const GATE_OWNER_FILE = "owner.json";
-const LOCK_ROOT_UNWRITABLE_CODES = new Set([
-  "EACCES",
-  "EPERM",
-  "ENOTDIR",
-  "EROFS",
-  "ENOSPC",
-  "EMFILE",
-  "ENFILE",
-]);
+const LOCK_ROOT_UNUSABLE_CODE = "PROVIDER_WORKLOAD_LOCK_ROOT_UNUSABLE";
 
 function trimEdgeHyphens(value) {
   let start = 0;
@@ -60,8 +52,56 @@ function gateTimeoutMs(env) {
   return positiveIntegerEnv(env, GATE_TIMEOUT_ENV, DEFAULT_GATE_TIMEOUT_MS);
 }
 
-function isUnwritableLockRootError(error) {
-  return LOCK_ROOT_UNWRITABLE_CODES.has(error?.code);
+function isProviderWorkloadFilesystemError(error) {
+  return typeof error?.code === "string";
+}
+
+function unusableLockRootError() {
+  const error = new Error("provider workload lock root is not usable");
+  error.code = LOCK_ROOT_UNUSABLE_CODE;
+  return error;
+}
+
+function currentUid() {
+  const uid = process.getuid?.();
+  return Number.isSafeInteger(uid) && uid >= 0 ? uid : null;
+}
+
+function ensureProviderWorkloadLockRoot(root) {
+  try {
+    mkdirSync(root, { recursive: true, mode: 0o700 });
+  } catch (error) {
+    if (!isProviderWorkloadFilesystemError(error)) throw error;
+    return false;
+  }
+
+  let stat;
+  try {
+    stat = lstatSync(root);
+  } catch (error) {
+    if (!isProviderWorkloadFilesystemError(error)) throw error;
+    return false;
+  }
+  if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
+
+  const uid = currentUid();
+  if (uid != null && typeof stat.uid === "number" && stat.uid !== uid) return false;
+
+  const mode = stat.mode & 0o777;
+  if ((mode & 0o700) !== 0o700) return false;
+  if ((mode & 0o077) !== 0) {
+    try {
+      chmodSync(root, 0o700);
+      stat = lstatSync(root);
+    } catch (error) {
+      if (!isProviderWorkloadFilesystemError(error)) throw error;
+      return false;
+    }
+    if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
+    if ((stat.mode & 0o777) !== 0o700) return false;
+  }
+
+  return true;
 }
 
 function sleepSync(ms) {
@@ -284,7 +324,7 @@ export function acquireProviderWorkloadGate(file, env, capture, pidInfo) {
       // caller-provided lockRoot), recreated rather than an env default so the
       // in-use root — not some other path — is what heals.
       if (error?.code === "ENOENT" && error?.syscall === "mkdir") {
-        try { mkdirSync(dirname(gateDir), { recursive: true, mode: 0o700 }); } catch { /* best effort */ }
+        if (!ensureProviderWorkloadLockRoot(dirname(gateDir))) throw unusableLockRootError();
         sleepSync(GATE_POLL_MS);
         continue;
       }
@@ -410,10 +450,7 @@ export function acquireProviderWorkloadLease({
 
   const root = lockRoot;
   const gateFile = legacyLockPath(root, slug);
-  try {
-    mkdirSync(root, { recursive: true, mode: 0o700 });
-  } catch (error) {
-    if (!isUnwritableLockRootError(error)) throw error;
+  if (!ensureProviderWorkloadLockRoot(root)) {
     return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
   }
 
@@ -472,7 +509,7 @@ export function acquireProviderWorkloadLease({
       const file = slotPath(root, slug, index);
       if (tryCreateLeaseFile(file, payload)) return acquiredResult(file, payload);
     } catch (error) {
-      if (!isUnwritableLockRootError(error)) throw error;
+      if (!isProviderWorkloadFilesystemError(error)) throw error;
       return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
     } finally {
       gate?.release?.();

--- a/relay/relay-kimi/scripts/lib/review-workload.mjs
+++ b/relay/relay-kimi/scripts/lib/review-workload.mjs
@@ -11,6 +11,33 @@ const DEFAULT_GATE_TIMEOUT_MS = 5_000;
 const GATE_POLL_MS = 25;
 const GATE_OWNER_FILE = "owner.json";
 const LOCK_ROOT_UNUSABLE_CODE = "PROVIDER_WORKLOAD_LOCK_ROOT_UNUSABLE";
+const PROVIDER_WORKLOAD_FILESYSTEM_ERROR_CODES = new Set([
+  "EACCES",
+  "EAGAIN",
+  "EBADF",
+  "EBUSY",
+  "EDQUOT",
+  "EEXIST",
+  "EFBIG",
+  "EINTR",
+  "EINVAL",
+  "EIO",
+  "EISDIR",
+  "ELOOP",
+  "EMFILE",
+  "EMLINK",
+  "ENAMETOOLONG",
+  "ENFILE",
+  "ENOENT",
+  "ENOSPC",
+  "ENOTDIR",
+  "ENOTEMPTY",
+  "ENOTSUP",
+  "EOPNOTSUPP",
+  "EPERM",
+  "EROFS",
+  "EXDEV",
+]);
 
 function trimEdgeHyphens(value) {
   let start = 0;
@@ -53,7 +80,9 @@ function gateTimeoutMs(env) {
 }
 
 function isProviderWorkloadFilesystemError(error) {
-  return typeof error?.code === "string";
+  if (error?.code === LOCK_ROOT_UNUSABLE_CODE) return true;
+  if (typeof error?.syscall === "string") return true;
+  return PROVIDER_WORKLOAD_FILESYSTEM_ERROR_CODES.has(error?.code);
 }
 
 function unusableLockRootError() {

--- a/relay/relay-kimi/scripts/lib/review-workload.mjs
+++ b/relay/relay-kimi/scripts/lib/review-workload.mjs
@@ -109,16 +109,21 @@ function blockResult(capacity, reason = "active_same_provider_job") {
   });
 }
 
-function captureCurrentPidInfo(env = process.env) {
+function captureCurrentPidInfo(env = process.env, capture = capturePidInfo) {
   try {
-    return capturePidInfo(process.pid);
+    return capture(process.pid);
   } catch (error) {
-    if (!env?.RELAY_WORKLOAD_TEST_MODE) throw error;
-    return {
-      pid: process.pid,
-      starttime: `test-mode:${process.pid}`,
-      argv0: process.argv?.[0] || "node",
-    };
+    if (env?.RELAY_WORKLOAD_TEST_MODE) {
+      return {
+        pid: process.pid,
+        starttime: `test-mode:${process.pid}`,
+        argv0: process.argv?.[0] || "node",
+      };
+    }
+    // The current process is necessarily live even when a host sandbox denies
+    // /bin/ps or /proc. Store no reuse proof rather than blocking every launch;
+    // stale cleanup then remains conservative until process inspection works.
+    return { pid: process.pid, starttime: null, argv0: null };
   }
 }
 
@@ -384,11 +389,15 @@ export function acquireProviderWorkloadLease({
 
   const root = lockRoot;
   const gateFile = legacyLockPath(root, slug);
-  mkdirSync(root, { recursive: true, mode: 0o700 });
+  try {
+    mkdirSync(root, { recursive: true, mode: 0o700 });
+  } catch {
+    return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
+  }
 
   let pidInfo;
   try {
-    pidInfo = captureCurrentPidInfo(env);
+    pidInfo = captureCurrentPidInfo(env, capture);
   } catch {
     return blockResult({ active_count: 0, limit }, "unverifiable_current_process");
   }

--- a/scripts/ab/verify/P8-wl1-cross-host-lease.mjs
+++ b/scripts/ab/verify/P8-wl1-cross-host-lease.mjs
@@ -25,6 +25,7 @@ const SLUG = "agy";
 const LIMIT = 1;
 const DEAD_PID = 999999; // not a live process on this host
 const ANCIENT_EPOCH_S = 1; // ~1970, far past any timeout
+const FOREIGN_HOST = process.env.P8_WL1_FOREIGN_HOST || "other-host-totally-different";
 
 function captureScriptedDeadPid(pid) {
   if (pid === DEAD_PID) throw new Error(`process_gone: scripted dead pid ${pid}`);
@@ -115,7 +116,7 @@ function runArm(label, host) {
 
 console.log(`BLOCK CODE constant: ${PROVIDER_WORKLOAD_BLOCKED_CODE}`);
 
-const foreign = runArm("foreign-host", "other-host-totally-different");
+const foreign = runArm("foreign-host", FOREIGN_HOST);
 const local = runArm("control-local", hostname());
 
 console.log(`\n=== VERDICT ===`);
@@ -128,3 +129,4 @@ const pinned =
 
 console.log(`\nPINNED (foreign blocks + no reclaim, local control reclaims): ${pinned}`);
 if (foreign.reclaimed) console.log("REFUTED: foreign-host lease was reclaimed.");
+if (!pinned) process.exitCode = 1;

--- a/scripts/ab/verify/P8-wl1-cross-host-lease.mjs
+++ b/scripts/ab/verify/P8-wl1-cross-host-lease.mjs
@@ -5,10 +5,10 @@
 // reclaimed (stale-local path uses pidAlive()).
 //
 // Strategy: drive the REAL acquireProviderWorkloadLease() against a real on-disk
-// lease file at the real lease path. Point the lock dir at an isolated tmp dir via
-// the documented RELAY_PROVIDER_WORKLOAD_LOCK_DIR env so we never touch the shared
-// default. Plant a lease with hostname=other-host / dead pid / ancient mtime, then
-// observe whether acquire is blocked and whether the lease is reclaimed on retry.
+// lease file at the legacy lease path, with an isolated temp lockRoot so we never
+// touch the shared default. Plant a lease with hostname=other-host / dead pid /
+// ancient mtime, then observe whether acquire is blocked and whether the lease is
+// reclaimed on retry.
 
 import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, utimesSync, rmSync } from "node:fs";
 import { hostname, tmpdir } from "node:os";
@@ -20,9 +20,16 @@ import {
 } from "../../lib/review-workload.mjs";
 
 const PROVIDER = "agy";
+const CONCURRENCY_KEY = "agy";
 const SLUG = "agy";
+const LIMIT = 1;
 const DEAD_PID = 999999; // not a live process on this host
 const ANCIENT_EPOCH_S = 1; // ~1970, far past any timeout
+
+function captureScriptedDeadPid(pid) {
+  if (pid === DEAD_PID) throw new Error(`process_gone: scripted dead pid ${pid}`);
+  return { pid, starttime: `scripted-start-${pid}`, argv0: `scripted-argv-${pid}` };
+}
 
 function plantLease(lockDir, host) {
   mkdirSync(lockDir, { recursive: true, mode: 0o700 });
@@ -30,7 +37,8 @@ function plantLease(lockDir, host) {
   const payload = {
     schema_version: 1,
     provider: PROVIDER,
-    provider_slug: SLUG,
+    concurrency_key: CONCURRENCY_KEY,
+    key_slug: SLUG,
     job_id: "stale-job-from-elsewhere",
     pid: DEAD_PID,
     hostname: host,
@@ -46,16 +54,32 @@ function plantLease(lockDir, host) {
 
 function runArm(label, host) {
   const lockDir = mkdtempSync(join(tmpdir(), `p8wl1-${label}-`));
-  const env = { ...process.env, RELAY_PROVIDER_WORKLOAD_LOCK_DIR: lockDir };
+  const env = { ...process.env, RELAY_BOOT_ID: "P8-WL1-BOOT" };
   const leaseFile = plantLease(lockDir, host);
 
   const acquired = [];
   let res1, res2;
   try {
-    res1 = acquireProviderWorkloadLease({ provider: PROVIDER, jobId: "live-job-1", env });
+    res1 = acquireProviderWorkloadLease({
+      provider: PROVIDER,
+      concurrencyKey: CONCURRENCY_KEY,
+      limit: LIMIT,
+      lockRoot: lockDir,
+      jobId: "live-job-1",
+      env,
+      capture: captureScriptedDeadPid,
+    });
     if (res1?.ok) acquired.push(res1.lease);
     // retry to test "still blocked / no liveness fallback"
-    res2 = acquireProviderWorkloadLease({ provider: PROVIDER, jobId: "live-job-2", env });
+    res2 = acquireProviderWorkloadLease({
+      provider: PROVIDER,
+      concurrencyKey: CONCURRENCY_KEY,
+      limit: LIMIT,
+      lockRoot: lockDir,
+      jobId: "live-job-2",
+      env,
+      capture: captureScriptedDeadPid,
+    });
     if (res2?.ok) acquired.push(res2.lease);
   } finally {
     // do not call releaseProviderWorkloadLease — we want to inspect raw disk state first

--- a/scripts/lib/provider-route-policy.mjs
+++ b/scripts/lib/provider-route-policy.mjs
@@ -267,7 +267,10 @@ function defaultProviderWorkloadLockRoot(env = process.env) {
   const xdgStateHome = typeof env?.XDG_STATE_HOME === "string" && env.XDG_STATE_HOME.trim() !== ""
     ? env.XDG_STATE_HOME
     : null;
-  return join(xdgStateHome || tmpdir(), "relay", "locks", "v2");
+  if (xdgStateHome) return join(xdgStateHome, "relay", "locks", "v2");
+  const uid = process.getuid?.();
+  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-${uid}` : "relay-user";
+  return join(tmpdir(), userSegment, "locks", "v2");
 }
 
 function providerWorkloadLockRoot(category, env = process.env) {

--- a/scripts/lib/provider-route-policy.mjs
+++ b/scripts/lib/provider-route-policy.mjs
@@ -269,8 +269,8 @@ function defaultProviderWorkloadLockRoot(env = process.env) {
     : null;
   if (xdgStateHome) return join(xdgStateHome, "relay", "locks", "v2");
   const uid = process.getuid?.();
-  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-${uid}` : "relay-user";
-  return join(tmpdir(), userSegment, "locks", "v2");
+  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-locks-v2-${uid}` : "relay-locks-v2-user";
+  return join(tmpdir(), userSegment);
 }
 
 function providerWorkloadLockRoot(category, env = process.env) {

--- a/scripts/lib/provider-route-policy.mjs
+++ b/scripts/lib/provider-route-policy.mjs
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { statSync } from "node:fs";
-import { homedir } from "node:os";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { hasSubstantiveInvalidVerdictReason } from "./external-model-review-quality.mjs";
@@ -267,7 +267,7 @@ function defaultProviderWorkloadLockRoot(env = process.env) {
   const xdgStateHome = typeof env?.XDG_STATE_HOME === "string" && env.XDG_STATE_HOME.trim() !== ""
     ? env.XDG_STATE_HOME
     : null;
-  return join(xdgStateHome || join(homedir(), ".local/state"), "relay", "locks", "v2");
+  return join(xdgStateHome || tmpdir(), "relay", "locks", "v2");
 }
 
 function providerWorkloadLockRoot(category, env = process.env) {

--- a/scripts/lib/review-workload.mjs
+++ b/scripts/lib/review-workload.mjs
@@ -10,6 +10,15 @@ const SCHEMA_VERSION = 1;
 const DEFAULT_GATE_TIMEOUT_MS = 5_000;
 const GATE_POLL_MS = 25;
 const GATE_OWNER_FILE = "owner.json";
+const LOCK_ROOT_UNWRITABLE_CODES = new Set([
+  "EACCES",
+  "EPERM",
+  "ENOTDIR",
+  "EROFS",
+  "ENOSPC",
+  "EMFILE",
+  "ENFILE",
+]);
 
 function trimEdgeHyphens(value) {
   let start = 0;
@@ -49,6 +58,10 @@ function positiveIntegerEnv(env, name, fallback) {
 
 function gateTimeoutMs(env) {
   return positiveIntegerEnv(env, GATE_TIMEOUT_ENV, DEFAULT_GATE_TIMEOUT_MS);
+}
+
+function isUnwritableLockRootError(error) {
+  return LOCK_ROOT_UNWRITABLE_CODES.has(error?.code);
 }
 
 function sleepSync(ms) {
@@ -109,21 +122,29 @@ function blockResult(capacity, reason = "active_same_provider_job") {
   });
 }
 
+function currentPidInfoWithoutCaptureProof(env, error) {
+  const message = String(error?.message ?? error ?? "");
+  const expectedCaptureFailure = message.startsWith("capture_error")
+    || message.startsWith("process_gone")
+    || message.startsWith("invalid_pid");
+  if (env?.RELAY_WORKLOAD_TEST_MODE && expectedCaptureFailure) {
+    return {
+      pid: process.pid,
+      starttime: `test-mode:${process.pid}`,
+      argv0: process.argv?.[0] || "node",
+    };
+  }
+  // The current process is necessarily live even when a host sandbox denies
+  // /bin/ps or /proc. Store no reuse proof rather than blocking every launch;
+  // stale cleanup then remains conservative until process inspection works.
+  return { pid: process.pid, starttime: null, argv0: null };
+}
+
 function captureCurrentPidInfo(env = process.env, capture = capturePidInfo) {
   try {
     return capture(process.pid);
   } catch (error) {
-    if (env?.RELAY_WORKLOAD_TEST_MODE) {
-      return {
-        pid: process.pid,
-        starttime: `test-mode:${process.pid}`,
-        argv0: process.argv?.[0] || "node",
-      };
-    }
-    // The current process is necessarily live even when a host sandbox denies
-    // /bin/ps or /proc. Store no reuse proof rather than blocking every launch;
-    // stale cleanup then remains conservative until process inspection works.
-    return { pid: process.pid, starttime: null, argv0: null };
+    return currentPidInfoWithoutCaptureProof(env, error);
   }
 }
 
@@ -391,16 +412,12 @@ export function acquireProviderWorkloadLease({
   const gateFile = legacyLockPath(root, slug);
   try {
     mkdirSync(root, { recursive: true, mode: 0o700 });
-  } catch {
+  } catch (error) {
+    if (!isUnwritableLockRootError(error)) throw error;
     return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
   }
 
-  let pidInfo;
-  try {
-    pidInfo = captureCurrentPidInfo(env, capture);
-  } catch {
-    return blockResult({ active_count: 0, limit }, "unverifiable_current_process");
-  }
+  const pidInfo = captureCurrentPidInfo(env, capture);
 
   const payload = Object.freeze({
     schema_version: SCHEMA_VERSION,
@@ -419,9 +436,10 @@ export function acquireProviderWorkloadLease({
   });
 
   for (;;) {
-    const gate = acquireProviderWorkloadGate(gateFile, env, capture, pidInfo);
-    if (!gate.ok) return blockResult({ active_count: limit, limit });
+    let gate;
     try {
+      gate = acquireProviderWorkloadGate(gateFile, env, capture, pidInfo);
+      if (!gate.ok) return blockResult({ active_count: limit, limit });
       const slots = enumerateSlotFiles(root, slug);
       if (!slots) return blockResult({ active_count: limit, limit }, "unreadable_provider_workload_lock_root");
 
@@ -453,8 +471,11 @@ export function acquireProviderWorkloadLease({
       }
       const file = slotPath(root, slug, index);
       if (tryCreateLeaseFile(file, payload)) return acquiredResult(file, payload);
+    } catch (error) {
+      if (!isUnwritableLockRootError(error)) throw error;
+      return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
     } finally {
-      gate.release?.();
+      gate?.release?.();
     }
   }
 }

--- a/scripts/lib/review-workload.mjs
+++ b/scripts/lib/review-workload.mjs
@@ -1,4 +1,4 @@
-import { existsSync, linkSync, lstatSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, linkSync, lstatSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import { hostname } from "node:os";
 import { join, dirname } from "node:path";
@@ -10,15 +10,7 @@ const SCHEMA_VERSION = 1;
 const DEFAULT_GATE_TIMEOUT_MS = 5_000;
 const GATE_POLL_MS = 25;
 const GATE_OWNER_FILE = "owner.json";
-const LOCK_ROOT_UNWRITABLE_CODES = new Set([
-  "EACCES",
-  "EPERM",
-  "ENOTDIR",
-  "EROFS",
-  "ENOSPC",
-  "EMFILE",
-  "ENFILE",
-]);
+const LOCK_ROOT_UNUSABLE_CODE = "PROVIDER_WORKLOAD_LOCK_ROOT_UNUSABLE";
 
 function trimEdgeHyphens(value) {
   let start = 0;
@@ -60,8 +52,56 @@ function gateTimeoutMs(env) {
   return positiveIntegerEnv(env, GATE_TIMEOUT_ENV, DEFAULT_GATE_TIMEOUT_MS);
 }
 
-function isUnwritableLockRootError(error) {
-  return LOCK_ROOT_UNWRITABLE_CODES.has(error?.code);
+function isProviderWorkloadFilesystemError(error) {
+  return typeof error?.code === "string";
+}
+
+function unusableLockRootError() {
+  const error = new Error("provider workload lock root is not usable");
+  error.code = LOCK_ROOT_UNUSABLE_CODE;
+  return error;
+}
+
+function currentUid() {
+  const uid = process.getuid?.();
+  return Number.isSafeInteger(uid) && uid >= 0 ? uid : null;
+}
+
+function ensureProviderWorkloadLockRoot(root) {
+  try {
+    mkdirSync(root, { recursive: true, mode: 0o700 });
+  } catch (error) {
+    if (!isProviderWorkloadFilesystemError(error)) throw error;
+    return false;
+  }
+
+  let stat;
+  try {
+    stat = lstatSync(root);
+  } catch (error) {
+    if (!isProviderWorkloadFilesystemError(error)) throw error;
+    return false;
+  }
+  if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
+
+  const uid = currentUid();
+  if (uid != null && typeof stat.uid === "number" && stat.uid !== uid) return false;
+
+  const mode = stat.mode & 0o777;
+  if ((mode & 0o700) !== 0o700) return false;
+  if ((mode & 0o077) !== 0) {
+    try {
+      chmodSync(root, 0o700);
+      stat = lstatSync(root);
+    } catch (error) {
+      if (!isProviderWorkloadFilesystemError(error)) throw error;
+      return false;
+    }
+    if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
+    if ((stat.mode & 0o777) !== 0o700) return false;
+  }
+
+  return true;
 }
 
 function sleepSync(ms) {
@@ -284,7 +324,7 @@ export function acquireProviderWorkloadGate(file, env, capture, pidInfo) {
       // caller-provided lockRoot), recreated rather than an env default so the
       // in-use root — not some other path — is what heals.
       if (error?.code === "ENOENT" && error?.syscall === "mkdir") {
-        try { mkdirSync(dirname(gateDir), { recursive: true, mode: 0o700 }); } catch { /* best effort */ }
+        if (!ensureProviderWorkloadLockRoot(dirname(gateDir))) throw unusableLockRootError();
         sleepSync(GATE_POLL_MS);
         continue;
       }
@@ -410,10 +450,7 @@ export function acquireProviderWorkloadLease({
 
   const root = lockRoot;
   const gateFile = legacyLockPath(root, slug);
-  try {
-    mkdirSync(root, { recursive: true, mode: 0o700 });
-  } catch (error) {
-    if (!isUnwritableLockRootError(error)) throw error;
+  if (!ensureProviderWorkloadLockRoot(root)) {
     return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
   }
 
@@ -472,7 +509,7 @@ export function acquireProviderWorkloadLease({
       const file = slotPath(root, slug, index);
       if (tryCreateLeaseFile(file, payload)) return acquiredResult(file, payload);
     } catch (error) {
-      if (!isUnwritableLockRootError(error)) throw error;
+      if (!isProviderWorkloadFilesystemError(error)) throw error;
       return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
     } finally {
       gate?.release?.();

--- a/scripts/lib/review-workload.mjs
+++ b/scripts/lib/review-workload.mjs
@@ -11,6 +11,33 @@ const DEFAULT_GATE_TIMEOUT_MS = 5_000;
 const GATE_POLL_MS = 25;
 const GATE_OWNER_FILE = "owner.json";
 const LOCK_ROOT_UNUSABLE_CODE = "PROVIDER_WORKLOAD_LOCK_ROOT_UNUSABLE";
+const PROVIDER_WORKLOAD_FILESYSTEM_ERROR_CODES = new Set([
+  "EACCES",
+  "EAGAIN",
+  "EBADF",
+  "EBUSY",
+  "EDQUOT",
+  "EEXIST",
+  "EFBIG",
+  "EINTR",
+  "EINVAL",
+  "EIO",
+  "EISDIR",
+  "ELOOP",
+  "EMFILE",
+  "EMLINK",
+  "ENAMETOOLONG",
+  "ENFILE",
+  "ENOENT",
+  "ENOSPC",
+  "ENOTDIR",
+  "ENOTEMPTY",
+  "ENOTSUP",
+  "EOPNOTSUPP",
+  "EPERM",
+  "EROFS",
+  "EXDEV",
+]);
 
 function trimEdgeHyphens(value) {
   let start = 0;
@@ -53,7 +80,9 @@ function gateTimeoutMs(env) {
 }
 
 function isProviderWorkloadFilesystemError(error) {
-  return typeof error?.code === "string";
+  if (error?.code === LOCK_ROOT_UNUSABLE_CODE) return true;
+  if (typeof error?.syscall === "string") return true;
+  return PROVIDER_WORKLOAD_FILESYSTEM_ERROR_CODES.has(error?.code);
 }
 
 function unusableLockRootError() {

--- a/scripts/lib/review-workload.mjs
+++ b/scripts/lib/review-workload.mjs
@@ -109,16 +109,21 @@ function blockResult(capacity, reason = "active_same_provider_job") {
   });
 }
 
-function captureCurrentPidInfo(env = process.env) {
+function captureCurrentPidInfo(env = process.env, capture = capturePidInfo) {
   try {
-    return capturePidInfo(process.pid);
+    return capture(process.pid);
   } catch (error) {
-    if (!env?.RELAY_WORKLOAD_TEST_MODE) throw error;
-    return {
-      pid: process.pid,
-      starttime: `test-mode:${process.pid}`,
-      argv0: process.argv?.[0] || "node",
-    };
+    if (env?.RELAY_WORKLOAD_TEST_MODE) {
+      return {
+        pid: process.pid,
+        starttime: `test-mode:${process.pid}`,
+        argv0: process.argv?.[0] || "node",
+      };
+    }
+    // The current process is necessarily live even when a host sandbox denies
+    // /bin/ps or /proc. Store no reuse proof rather than blocking every launch;
+    // stale cleanup then remains conservative until process inspection works.
+    return { pid: process.pid, starttime: null, argv0: null };
   }
 }
 
@@ -384,11 +389,15 @@ export function acquireProviderWorkloadLease({
 
   const root = lockRoot;
   const gateFile = legacyLockPath(root, slug);
-  mkdirSync(root, { recursive: true, mode: 0o700 });
+  try {
+    mkdirSync(root, { recursive: true, mode: 0o700 });
+  } catch {
+    return blockResult({ active_count: 0, limit }, "unwritable_provider_workload_lock_root");
+  }
 
   let pidInfo;
   try {
-    pidInfo = captureCurrentPidInfo(env);
+    pidInfo = captureCurrentPidInfo(env, capture);
   } catch {
     return blockResult({ active_count: 0, limit }, "unverifiable_current_process");
   }

--- a/tests/unit/ab-verifiers.test.mjs
+++ b/tests/unit/ab-verifiers.test.mjs
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+test("P8 cross-host workload lease verifier exits cleanly", () => {
+  const result = spawnSync(process.execPath, ["scripts/ab/verify/P8-wl1-cross-host-lease.mjs"], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    timeout: 10_000,
+  });
+
+  assert.equal(
+    result.status,
+    0,
+    `verifier should exit 0\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+  assert.match(result.stdout, /PINNED .*: true/);
+});

--- a/tests/unit/ab-verifiers.test.mjs
+++ b/tests/unit/ab-verifiers.test.mjs
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import { hostname } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -19,4 +20,17 @@ test("P8 cross-host workload lease verifier exits cleanly", () => {
     `verifier should exit 0\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
   );
   assert.match(result.stdout, /PINNED .*: true/);
+});
+
+test("P8 cross-host workload lease verifier exits nonzero when refuted", () => {
+  const result = spawnSync(process.execPath, ["scripts/ab/verify/P8-wl1-cross-host-lease.mjs"], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    env: { ...process.env, P8_WL1_FOREIGN_HOST: hostname() },
+    timeout: 10_000,
+  });
+
+  assert.notEqual(result.status, 0, `verifier should fail when refuted\nstdout:\n${result.stdout}`);
+  assert.match(result.stdout, /PINNED .*: false/);
+  assert.match(result.stdout, /REFUTED:/);
 });

--- a/tests/unit/provider-route-policy.test.mjs
+++ b/tests/unit/provider-route-policy.test.mjs
@@ -2149,7 +2149,7 @@ test("shared_state concurrency admission ignores lock root override outside test
   assert.equal(admission.lockRoot, path.join(tmpdir(), "relay-policy-state", "relay", "locks", "v2"));
 });
 
-test("shared_state concurrency admission defaults lock root to per-user tmpdir when XDG_STATE_HOME is absent", (t) => {
+test("shared_state concurrency admission defaults lock root to a private per-user tmpdir leaf when XDG_STATE_HOME is absent", (t) => {
   const sharedStateDir = mkdtempSync(path.join(tmpdir(), "relay-policy-shared-state-"));
   t.after(() => rmSync(sharedStateDir, { recursive: true, force: true }));
 
@@ -2163,8 +2163,9 @@ test("shared_state concurrency admission defaults lock root to per-user tmpdir w
   });
 
   const uid = process.getuid?.();
-  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-${uid}` : "relay-user";
-  assert.equal(admission.lockRoot, path.join(tmpdir(), userSegment, "locks", "v2"));
+  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-locks-v2-${uid}` : "relay-locks-v2-user";
+  assert.equal(path.dirname(admission.lockRoot), tmpdir());
+  assert.equal(admission.lockRoot, path.join(tmpdir(), userSegment));
 });
 
 test("stateless concurrency admission honors lock root override", () => {

--- a/tests/unit/provider-route-policy.test.mjs
+++ b/tests/unit/provider-route-policy.test.mjs
@@ -2149,6 +2149,22 @@ test("shared_state concurrency admission ignores lock root override outside test
   assert.equal(admission.lockRoot, path.join(tmpdir(), "relay-policy-state", "relay", "locks", "v2"));
 });
 
+test("shared_state concurrency admission defaults lock root to tmpdir when XDG_STATE_HOME is absent", (t) => {
+  const sharedStateDir = mkdtempSync(path.join(tmpdir(), "relay-policy-shared-state-"));
+  t.after(() => rmSync(sharedStateDir, { recursive: true, force: true }));
+
+  const admission = resolveConcurrencyAdmission({
+    category: "shared_state",
+    declaredLimit: 1,
+    sharedStateIdentity: sharedStateDir,
+    provider: "kimi",
+    route: "subscription",
+    env: {},
+  });
+
+  assert.equal(admission.lockRoot, path.join(tmpdir(), "relay", "locks", "v2"));
+});
+
 test("stateless concurrency admission honors lock root override", () => {
   const admission = resolveConcurrencyAdmission({
     category: "stateless",

--- a/tests/unit/provider-route-policy.test.mjs
+++ b/tests/unit/provider-route-policy.test.mjs
@@ -2149,7 +2149,7 @@ test("shared_state concurrency admission ignores lock root override outside test
   assert.equal(admission.lockRoot, path.join(tmpdir(), "relay-policy-state", "relay", "locks", "v2"));
 });
 
-test("shared_state concurrency admission defaults lock root to tmpdir when XDG_STATE_HOME is absent", (t) => {
+test("shared_state concurrency admission defaults lock root to per-user tmpdir when XDG_STATE_HOME is absent", (t) => {
   const sharedStateDir = mkdtempSync(path.join(tmpdir(), "relay-policy-shared-state-"));
   t.after(() => rmSync(sharedStateDir, { recursive: true, force: true }));
 
@@ -2162,7 +2162,9 @@ test("shared_state concurrency admission defaults lock root to tmpdir when XDG_S
     env: {},
   });
 
-  assert.equal(admission.lockRoot, path.join(tmpdir(), "relay", "locks", "v2"));
+  const uid = process.getuid?.();
+  const userSegment = Number.isSafeInteger(uid) && uid >= 0 ? `relay-${uid}` : "relay-user";
+  assert.equal(admission.lockRoot, path.join(tmpdir(), userSegment, "locks", "v2"));
 });
 
 test("stateless concurrency admission honors lock root override", () => {

--- a/tests/unit/review-workload-multiprocess.test.mjs
+++ b/tests/unit/review-workload-multiprocess.test.mjs
@@ -20,8 +20,8 @@ const WORKLOAD_LIB = fileURLToPath(new URL("../../scripts/lib/review-workload.mj
 
 // These two tests spawn real child processes that take the REAL liveness-capture
 // acquire path (no RELAY_WORKLOAD_TEST_MODE). On a macOS sandbox that denies
-// /bin/ps, every child blocks on `unverifiable_current_process`, so the children
-// never acquire and the assertions hard-fail rather than proving anything. Skip
+// /bin/ps, child liveness capture cannot prove real process identities, so the
+// assertions hard-fail rather than proving anything. Skip
 // when the current process cannot capture its own identity (same guard used by
 // review-workload.test.mjs). Linux CI has /proc, so it still runs there; the
 // boot-id reclaim test below uses an injected capture and is unaffected.

--- a/tests/unit/review-workload.test.mjs
+++ b/tests/unit/review-workload.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { hostname, tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -68,6 +68,55 @@ test("provider workload lease test mode can acquire when current process proof i
   } finally {
     if (lease.lease) releaseProviderWorkloadLease(lease.lease);
     rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("provider workload lease admits current process when liveness capture is sandboxed", () => {
+  const { root, env } = tempEnv();
+  const captureDenied = () => { throw new Error("capture_error: injected process table denial"); };
+  const lease = acquireProviderWorkloadLease({
+    concurrencyKey: "sandboxed-current-process",
+    limit: 1,
+    lockRoot: root,
+    jobId: "job-sandboxed-current",
+    cwd: "/tmp/w",
+    sourceBearing: true,
+    env,
+    capture: captureDenied,
+  });
+  try {
+    assert.equal(lease.ok, true);
+    assert.ok(lease.lease);
+    const holder = JSON.parse(readFileSync(lease.lease.file, "utf8"));
+    assert.equal(holder.pid, process.pid);
+    assert.equal(holder.starttime, null);
+    assert.equal(holder.argv0, null);
+  } finally {
+    if (lease.lease) releaseProviderWorkloadLease(lease.lease);
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("provider workload lease fails closed when lock root cannot be created", () => {
+  const parent = mkdtempSync(join(tmpdir(), "provider-workload-unwritable-"));
+  chmodSync(parent, 0o500);
+  try {
+    const result = acquireProviderWorkloadLease({
+      concurrencyKey: "unwritable-lock-root",
+      limit: 1,
+      lockRoot: join(parent, "locks"),
+      jobId: "job-unwritable-lock-root",
+      cwd: "/tmp/w",
+      sourceBearing: true,
+      env: { RELAY_WORKLOAD_TEST_MODE: "1" },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.error_code, PROVIDER_WORKLOAD_BLOCKED_CODE);
+    assert.equal(result.reason, "unwritable_provider_workload_lock_root");
+    assert.deepEqual(result.capacity, { active_count: 0, limit: 1 });
+  } finally {
+    chmodSync(parent, 0o700);
+    rmSync(parent, { recursive: true, force: true });
   }
 });
 

--- a/tests/unit/review-workload.test.mjs
+++ b/tests/unit/review-workload.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { chmodSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, symlinkSync, utimesSync, writeFileSync } from "node:fs";
 import { hostname, tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -183,6 +183,79 @@ test("provider workload lease fails closed when existing lock root is not writab
     assert.equal(result.reason, "unwritable_provider_workload_lock_root");
     assert.deepEqual(result.capacity, { active_count: 0, limit: 1 });
   } finally {
+    chmodSync(root, 0o700);
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("provider workload lease fails closed when lock root path is a file", () => {
+  const parent = mkdtempSync(join(tmpdir(), "provider-workload-file-root-"));
+  const root = join(parent, "locks");
+  writeFileSync(root, "not a directory");
+  const result = acquireProviderWorkloadLease({
+    concurrencyKey: "file-lock-root",
+    limit: 1,
+    lockRoot: root,
+    jobId: "job-file-lock-root",
+    cwd: "/tmp/w",
+    sourceBearing: true,
+    env: { RELAY_WORKLOAD_TEST_MODE: "1" },
+  });
+  try {
+    assert.equal(result.ok, false);
+    assert.equal(result.error_code, PROVIDER_WORKLOAD_BLOCKED_CODE);
+    assert.equal(result.reason, "unwritable_provider_workload_lock_root");
+    assert.deepEqual(result.capacity, { active_count: 0, limit: 1 });
+  } finally {
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+test("provider workload lease refuses a symlinked lock root", (t) => {
+  if (process.platform === "win32") return t.skip("directory symlinks require elevated privileges on some Windows hosts");
+  const parent = mkdtempSync(join(tmpdir(), "provider-workload-symlink-root-"));
+  const target = join(parent, "target");
+  const root = join(parent, "locks");
+  mkdirSync(target);
+  symlinkSync(target, root, "dir");
+  let result;
+  try {
+    result = acquireProviderWorkloadLease({
+      concurrencyKey: "symlink-lock-root",
+      limit: 1,
+      lockRoot: root,
+      jobId: "job-symlink-lock-root",
+      cwd: "/tmp/w",
+      sourceBearing: true,
+      env: { RELAY_WORKLOAD_TEST_MODE: "1" },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.error_code, PROVIDER_WORKLOAD_BLOCKED_CODE);
+    assert.equal(result.reason, "unwritable_provider_workload_lock_root");
+    assert.deepEqual(result.capacity, { active_count: 0, limit: 1 });
+  } finally {
+    if (result?.lease) releaseProviderWorkloadLease(result.lease);
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+test("provider workload lease makes an existing lock root private before use", () => {
+  const root = mkdtempSync(join(tmpdir(), "provider-workload-public-root-"));
+  chmodSync(root, 0o755);
+  const result = acquireProviderWorkloadLease({
+    concurrencyKey: "public-lock-root",
+    limit: 1,
+    lockRoot: root,
+    jobId: "job-public-lock-root",
+    cwd: "/tmp/w",
+    sourceBearing: true,
+    env: { RELAY_WORKLOAD_TEST_MODE: "1" },
+  });
+  try {
+    assert.equal(result.ok, true);
+    assert.equal(lstatSync(root).mode & 0o777, 0o700);
+  } finally {
+    if (result.lease) releaseProviderWorkloadLease(result.lease);
     chmodSync(root, 0o700);
     rmSync(root, { recursive: true, force: true });
   }
@@ -445,6 +518,7 @@ test("provider workload gate retries when owner write loses the gate directory r
     writeFileSync(shimPath, `
 import * as fs from "node:fs";
 
+export const chmodSync = fs.chmodSync;
 export const existsSync = fs.existsSync;
 export const linkSync = fs.linkSync;
 export const lstatSync = fs.lstatSync;
@@ -518,6 +592,7 @@ test("provider workload gate recovers when the lock root vanishes mid-acquire in
     writeFileSync(shimPath, `
 import * as fs from "node:fs";
 
+export const chmodSync = fs.chmodSync;
 export const existsSync = fs.existsSync;
 export const linkSync = fs.linkSync;
 export const lstatSync = fs.lstatSync;

--- a/tests/unit/review-workload.test.mjs
+++ b/tests/unit/review-workload.test.mjs
@@ -239,6 +239,67 @@ test("provider workload lease refuses a symlinked lock root", (t) => {
   }
 });
 
+test("provider workload lease rethrows non-filesystem coded errors from lock-root setup", async () => {
+  const moduleRoot = mkdtempSync(join(tmpdir(), "provider-workload-non-fs-error-module-"));
+  try {
+    const source = readFileSync(new URL("../../scripts/lib/review-workload.mjs", import.meta.url), "utf8");
+    const shimPath = join(moduleRoot, "fs-non-filesystem-error-shim.mjs");
+    const modulePath = join(moduleRoot, "review-workload-non-filesystem-error.mjs");
+    writeFileSync(shimPath, `
+import * as fs from "node:fs";
+
+export const chmodSync = fs.chmodSync;
+export const existsSync = fs.existsSync;
+export const linkSync = fs.linkSync;
+export const lstatSync = fs.lstatSync;
+export const readFileSync = fs.readFileSync;
+export const readdirSync = fs.readdirSync;
+export const renameSync = fs.renameSync;
+export const rmSync = fs.rmSync;
+export const unlinkSync = fs.unlinkSync;
+export const writeFileSync = fs.writeFileSync;
+
+export function mkdirSync(path, options) {
+  if (String(path).endsWith("non-fs-coded-root")) {
+    const error = new Error("injected non-filesystem coded failure");
+    error.code = "ERR_INVALID_ARG_TYPE";
+    throw error;
+  }
+  return fs.mkdirSync(path, options);
+}
+`, "utf8");
+    writeFileSync(
+      modulePath,
+      source
+        .replace(
+          'from "node:fs";',
+          `from ${JSON.stringify(pathToFileURL(shimPath).href)};`,
+        )
+        .replace(
+          'from "./process-identity.mjs";',
+          `from ${JSON.stringify(new URL("../../scripts/lib/process-identity.mjs", import.meta.url).href)};`,
+        ),
+      "utf8",
+    );
+
+    const workload = await import(pathToFileURL(modulePath).href);
+    assert.throws(
+      () => workload.acquireProviderWorkloadLease({
+        concurrencyKey: "non-fs-coded",
+        limit: 1,
+        lockRoot: join(moduleRoot, "non-fs-coded-root"),
+        jobId: "job-non-fs-coded",
+        cwd: "/tmp/w",
+        sourceBearing: true,
+        env: { RELAY_WORKLOAD_TEST_MODE: "1" },
+      }),
+      /injected non-filesystem coded failure/,
+    );
+  } finally {
+    rmSync(moduleRoot, { recursive: true, force: true });
+  }
+});
+
 test("provider workload lease makes an existing lock root private before use", () => {
   const root = mkdtempSync(join(tmpdir(), "provider-workload-public-root-"));
   chmodSync(root, 0o755);

--- a/tests/unit/review-workload.test.mjs
+++ b/tests/unit/review-workload.test.mjs
@@ -41,6 +41,12 @@ function workloadTest(name, fn) {
   test(name, SKIP_WORKLOAD_ACQUIRE_UNDER_DARWIN_SANDBOX, fn);
 }
 
+const SKIP_UNWRITABLE_PERMISSION_TEST_UNDER_ROOT = {
+  skip: process.getuid?.() === 0
+    ? "root can bypass chmod-based write denial"
+    : false,
+};
+
 // Gate timeout for tests that assert a reclaim SUCCEEDS (ok:true). The production
 // loop checks the deadline before it attempts reclaim (review-workload.mjs: the
 // `Date.now() >= deadline` guard sits above the recreate/reclaim branches), so the
@@ -97,7 +103,46 @@ test("provider workload lease admits current process when liveness capture is sa
   }
 });
 
-test("provider workload lease fails closed when lock root cannot be created", () => {
+test("provider workload lease treats a null-proof holder as occupied", () => {
+  const { root, env } = tempEnv();
+  const captureDenied = () => { throw new Error("capture_error: injected process table denial"); };
+  const captureDifferentIdentity = () => ({
+    pid: process.pid,
+    starttime: "different-starttime",
+    argv0: "different-argv0",
+  });
+  const first = acquireProviderWorkloadLease({
+    concurrencyKey: "null-proof-current-process",
+    limit: 1,
+    lockRoot: root,
+    jobId: "job-null-proof-current",
+    cwd: "/tmp/w",
+    sourceBearing: true,
+    env,
+    capture: captureDenied,
+  });
+  try {
+    assert.equal(first.ok, true);
+    const second = acquireProviderWorkloadLease({
+      concurrencyKey: "null-proof-current-process",
+      limit: 1,
+      lockRoot: root,
+      jobId: "job-null-proof-second",
+      cwd: "/tmp/w",
+      sourceBearing: true,
+      env,
+      capture: captureDifferentIdentity,
+    });
+    assert.equal(second.ok, false);
+    assert.equal(second.reason, "active_same_provider_job");
+    assert.deepEqual(second.capacity, { active_count: 1, limit: 1 });
+  } finally {
+    if (first.lease) releaseProviderWorkloadLease(first.lease);
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("provider workload lease fails closed when lock root cannot be created", SKIP_UNWRITABLE_PERMISSION_TEST_UNDER_ROOT, () => {
   const parent = mkdtempSync(join(tmpdir(), "provider-workload-unwritable-"));
   chmodSync(parent, 0o500);
   try {
@@ -117,6 +162,29 @@ test("provider workload lease fails closed when lock root cannot be created", ()
   } finally {
     chmodSync(parent, 0o700);
     rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+test("provider workload lease fails closed when existing lock root is not writable", SKIP_UNWRITABLE_PERMISSION_TEST_UNDER_ROOT, () => {
+  const root = mkdtempSync(join(tmpdir(), "provider-workload-unwritable-root-"));
+  chmodSync(root, 0o500);
+  try {
+    const result = acquireProviderWorkloadLease({
+      concurrencyKey: "existing-unwritable-lock-root",
+      limit: 1,
+      lockRoot: root,
+      jobId: "job-existing-unwritable-lock-root",
+      cwd: "/tmp/w",
+      sourceBearing: true,
+      env: { RELAY_WORKLOAD_TEST_MODE: "1" },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.error_code, PROVIDER_WORKLOAD_BLOCKED_CODE);
+    assert.equal(result.reason, "unwritable_provider_workload_lock_root");
+    assert.deepEqual(result.capacity, { active_count: 0, limit: 1 });
+  } finally {
+    chmodSync(root, 0o700);
+    rmSync(root, { recursive: true, force: true });
   }
 });
 
@@ -359,7 +427,7 @@ test("provider workload lease serializes stale reclaim before removing inactive 
   const source = readFileSync(new URL("../../scripts/lib/review-workload.mjs", import.meta.url), "utf8");
   assert.match(source, /function acquireProviderWorkloadGate\(/,
     "stale reclaim must be protected by a provider-local gate");
-  assert.match(source, /const gate = acquireProviderWorkloadGate\([^,]+, env, capture, pidInfo\);/,
+  assert.match(source, /gate = acquireProviderWorkloadGate\([^,]+, env, capture, pidInfo\);/,
     "lease acquisition must hold the gate before inspecting or removing an inactive holder");
   assert.match(source, /removeInactiveHolder\([^,]+, holder\)/,
     "inactive-holder removal must be bound to the holder inspected while the gate is held");


### PR DESCRIPTION
## Summary

- Admit the current Relay workload process when sandboxed process inspection denies `/bin/ps` or `/proc`, while preserving conservative stale-lock cleanup.
- Default shared-state workload locks to `os.tmpdir()` when `XDG_STATE_HOME` is absent so Codex sandbox runs have a writable lock root.
- Fail closed with structured `provider_workload_blocked` diagnostics when the workload lock root cannot be created.
- Sync provider copies and generated relay marketplace artifacts.

## Root Cause

Relay's workload gate assumed it could inspect the current process and create locks under the user state directory. In Codex sandboxed execution, current-process inspection can be denied and `~/.local/state` can be unwritable, causing Claude/Gemini/Kimi/Grok reviews to stop with `provider_workload_blocked` before source transmission.

## Validation

- `npm run build:codex-relay`
- `npm run build:relay`
- `npm run lint:sync`
- `npm test` — 2,923 tests, 2,893 passed, 30 skipped, 0 failed
- Local installed-cache probes for Claude, Gemini, Kimi, and Grok workload admission

No source-bearing provider review was launched during validation.