### PR TITLE
[codex] Fix cache doctor plugin parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,16 +370,21 @@ SHA-256 checks for bundled `commands/`, `skills/`, `scripts/`, and `config/`
 files. `relay-for-codex` is both the marketplace identifier and the Codex cache
 namespace used by installed plugin paths. In default mode the checked plugin
 set is derived from marketplace manifests, repo manifests, enabled
-`config.toml` entries, and installed cache directories, so stale marketplace
-clones cannot hide enabled plugins. The doctor also checks the
+`config.toml` entries, installed cache directories, and a small built-in
+fallback list, so stale marketplace clones cannot hide enabled plugins. A
+marketplace is treated as present only when its installed `marketplace.json`
+manifest is present; an empty marketplace directory falls back to this repo's
+manifest/source tree. The doctor also checks the
 `api-reviewers` internal runtime when it is required by an enabled dependent
 (`relay-glm` or `relay-deepseek`), pulled in by an explicit
 `--plugin relay-glm` or `--plugin relay-deepseek` check, explicitly enabled in
 `config.toml`, or explicitly requested with `--plugin api-reviewers`.
 It reports `missing_files`, `extra_files`, `changed_files`,
 `repo_changed_files`, `configured_enabled`, `required_by_enabled_plugin`, and
-`required_for_ok`. For single-plugin checks, `summary_plugin` names the plugin
-described by top-level summary fields; use `ok` as the aggregate health result.
+`required_for_ok`, plus source diagnostics such as `source_present`,
+`source_manifest_present`, and `listed_in_marketplace_manifest`. For
+single-plugin checks, `summary_plugin` names the plugin described by top-level
+summary fields; use `ok` as the aggregate health result.
 `cache_in_sync: true` with
 `repo_cache_in_sync: false` means new Codex sessions will still run stale
 installed plugin code. For Git marketplace installs, start with:

--- a/README.md
+++ b/README.md
@@ -381,10 +381,13 @@ manifest/source tree. The doctor also checks the
 `config.toml`, or explicitly requested with `--plugin api-reviewers`.
 It reports `missing_files`, `extra_files`, `changed_files`,
 `repo_changed_files`, `configured_enabled`, `required_by_enabled_plugin`, and
-`required_for_ok`, plus source diagnostics such as `source_present`,
-`source_manifest_present`, and `listed_in_marketplace_manifest`. For
-single-plugin checks, `summary_plugin` names the plugin described by top-level
-summary fields; use `ok` as the aggregate health result.
+`required_for_ok` and `cache_version`, plus source diagnostics such as
+`source_present`, `source_manifest_present`, and
+`listed_in_marketplace_manifest`. The top-level `marketplace` block describes
+the primary `--codex-home`; `marketplaces.primary` and `marketplaces.second`
+describe each inspected profile. For single-plugin checks, `summary_plugin`
+names the plugin described by top-level summary fields; use `ok` as the
+aggregate health result.
 `cache_in_sync: true` with
 `repo_cache_in_sync: false` means new Codex sessions will still run stale
 installed plugin code. For Git marketplace installs, start with:

--- a/README.md
+++ b/README.md
@@ -368,13 +368,19 @@ The report compares both marketplace/plugin files and this repo's `plugins/`
 tree against `plugins/cache/relay-for-codex/<plugin>/<version>`, including
 SHA-256 checks for bundled `commands/`, `skills/`, `scripts/`, and `config/`
 files. `relay-for-codex` is both the marketplace identifier and the Codex cache
-namespace used by installed plugin paths. The doctor also checks the
-default-installed `api-reviewers` runtime required by `relay-glm` and
-`relay-deepseek`, without requiring that internal runtime to be enabled in
-`config.toml`.
-It reports `missing_files`, `extra_files`, `changed_files`, and
-`repo_changed_files`, checks whether each plugin is enabled in `config.toml`,
-and prints next actions. `cache_in_sync: true` with
+namespace used by installed plugin paths. In default mode the checked plugin
+set is derived from marketplace manifests, repo manifests, enabled
+`config.toml` entries, and installed cache directories, so stale marketplace
+clones cannot hide enabled plugins. The doctor also checks the
+`api-reviewers` internal runtime when it is required by an enabled dependent
+(`relay-glm` or `relay-deepseek`), pulled in by an explicit
+`--plugin relay-glm` or `--plugin relay-deepseek` check, explicitly enabled in
+`config.toml`, or explicitly requested with `--plugin api-reviewers`.
+It reports `missing_files`, `extra_files`, `changed_files`,
+`repo_changed_files`, `configured_enabled`, `required_by_enabled_plugin`, and
+`required_for_ok`. For single-plugin checks, `summary_plugin` names the plugin
+described by top-level summary fields; use `ok` as the aggregate health result.
+`cache_in_sync: true` with
 `repo_cache_in_sync: false` means new Codex sessions will still run stale
 installed plugin code. For Git marketplace installs, start with:
 

--- a/README.md
+++ b/README.md
@@ -381,8 +381,8 @@ manifest/source tree. The doctor also checks the
 `config.toml`, or explicitly requested with `--plugin api-reviewers`.
 It reports `missing_files`, `extra_files`, `changed_files`,
 `repo_changed_files`, `configured_enabled`, `required_by_enabled_plugin`, and
-`required_for_ok` and `cache_version`, plus source diagnostics such as
-`source_present`, `source_manifest_present`, and
+`required_for_ok`, `cache_version`, and `marketplace_manifest_version`, plus
+source diagnostics such as `source_present`, `source_manifest_present`, and
 `listed_in_marketplace_manifest`. The top-level `marketplace` block describes
 the primary `--codex-home`; `marketplaces.primary` and `marketplaces.second`
 describe each inspected profile. For single-plugin checks, `summary_plugin`

--- a/scripts/codex-plugin-cache-doctor.mjs
+++ b/scripts/codex-plugin-cache-doctor.mjs
@@ -12,6 +12,16 @@ const PLUGIN_DEPENDENCIES = new Map([
   ["relay-deepseek", ["api-reviewers"]],
   ["relay-glm", ["api-reviewers"]],
 ]);
+const FALLBACK_SOURCE_PATHS = new Map([
+  ["relay-claude", "plugins/claude"],
+  ["relay-gemini", "plugins/gemini"],
+  ["relay-kimi", "plugins/kimi"],
+  ["relay-agy", "plugins/agy"],
+  ["relay-grok", "plugins/grok"],
+  ["relay-glm", "plugins/relay-glm"],
+  ["relay-deepseek", "plugins/relay-deepseek"],
+  ["api-reviewers", "plugins/api-reviewers"],
+]);
 const FALLBACK_DEFAULT_PLUGINS = [
   "relay-claude",
   "relay-gemini",
@@ -83,8 +93,16 @@ function normalizeSourcePath(sourcePath) {
   return normalized || ".";
 }
 
+function fallbackSourcePath(plugin) {
+  return FALLBACK_SOURCE_PATHS.get(plugin) ?? join("plugins", plugin);
+}
+
+function marketplaceManifestPath(root) {
+  return join(root, ".agents", "plugins", "marketplace.json");
+}
+
 function readMarketplaceSourcePaths(root) {
-  const file = join(root, ".agents", "plugins", "marketplace.json");
+  const file = marketplaceManifestPath(root);
   const paths = new Map();
   if (!existsSync(file)) return paths;
 
@@ -92,14 +110,14 @@ function readMarketplaceSourcePaths(root) {
   if (!Array.isArray(marketplace.plugins)) return paths;
   for (const plugin of marketplace.plugins) {
     if (typeof plugin?.name !== "string") continue;
-    const sourcePath = typeof plugin.source?.path === "string" ? plugin.source.path : join("plugins", plugin.name);
+    const sourcePath = typeof plugin.source?.path === "string" ? plugin.source.path : fallbackSourcePath(plugin.name);
     paths.set(plugin.name, normalizeSourcePath(sourcePath));
   }
   return paths;
 }
 
 function pluginSourcePath(paths, plugin, fallbackPaths = new Map()) {
-  return paths.get(plugin) ?? fallbackPaths.get(plugin) ?? join("plugins", plugin);
+  return paths.get(plugin) ?? fallbackPaths.get(plugin) ?? fallbackSourcePath(plugin);
 }
 
 function comparablePluginFile(rel) {
@@ -148,15 +166,55 @@ function compareFileHashes(expected, cached) {
   };
 }
 
+function stripTomlComment(line) {
+  let quote = null;
+  let escaped = false;
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (quote) {
+      if (quote === "\"" && ch === "\\") {
+        escaped = true;
+        continue;
+      }
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === "\"" || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (ch === "#") return line.slice(0, i);
+  }
+  return line;
+}
+
 function pluginConfigEntries(home) {
   const config = join(home, "config.toml");
   const entries = new Map();
   if (!existsSync(config)) return entries;
   const text = readFileSync(config, "utf8");
   const escapedMarketplace = escapeRegExp(MARKETPLACE);
-  const sectionPattern = new RegExp(`\\[plugins\\."([^"\\n]+)@${escapedMarketplace}"\\]([\\s\\S]*?)(?=\\n\\[|$)`, "g");
-  for (const match of text.matchAll(sectionPattern)) {
-    entries.set(match[1], /\benabled\s*=\s*true\b/.test(match[2]));
+  const sectionPattern = new RegExp(`^\\[\\s*plugins\\s*\\.\\s*"([^"\\n]+)@${escapedMarketplace}"\\s*\\]\\s*$`);
+  let currentPlugin = null;
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = stripTomlComment(rawLine).trim();
+    const section = sectionPattern.exec(line);
+    if (section) {
+      currentPlugin = section[1];
+      if (!entries.has(currentPlugin)) entries.set(currentPlugin, false);
+      continue;
+    }
+    if (/^\[.*\]$/.test(line)) {
+      currentPlugin = null;
+      continue;
+    }
+    if (!currentPlugin) continue;
+    const enabled = /^enabled\s*=\s*(true|false)\s*$/.exec(line);
+    if (enabled) entries.set(currentPlugin, enabled[1] === "true");
   }
   return entries;
 }
@@ -188,6 +246,36 @@ function installedCachePluginNames(home) {
     .map((entry) => entry.name);
 }
 
+function cacheVersionNames(home, plugin) {
+  const root = join(home, "plugins", "cache", CACHE_NAMESPACE, plugin);
+  if (!existsSync(root)) return [];
+  return readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort(comparePathStrings);
+}
+
+function readPluginVersion(pluginRoot) {
+  for (const rel of [".codex-plugin/plugin.json", "package.json"]) {
+    const file = join(pluginRoot, rel);
+    if (!existsSync(file)) continue;
+    try {
+      const parsed = JSON.parse(readFileSync(file, "utf8"));
+      if (typeof parsed.version === "string" && parsed.version.length > 0) return parsed.version;
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+function pluginCacheVersion(home, plugin, sourcePluginRoot, repoPluginRoot) {
+  return readPluginVersion(sourcePluginRoot)
+    ?? readPluginVersion(repoPluginRoot)
+    ?? cacheVersionNames(home, plugin)[0]
+    ?? "0.1.0";
+}
+
 function defaultPluginNames(...nameLists) {
   const names = new Set(FALLBACK_DEFAULT_PLUGINS);
   for (const nameList of nameLists) {
@@ -203,18 +291,36 @@ function requiredByEnabledPlugin(configEntries, plugin) {
   return false;
 }
 
-function profileReport(name, home, plugins, { sourceBaseRoot, sourcePaths, repoBaseRoot, repoSourcePaths, requireAllPlugins, summaryPlugin }) {
+function sourceInfoForHome(home, repo, repoSourcePaths) {
+  const marketplaceRoot = join(home, ".tmp", "marketplaces", MARKETPLACE);
+  const manifestPath = marketplaceManifestPath(marketplaceRoot);
+  const marketplacePresent = existsSync(manifestPath);
+  const marketplaceSourcePaths = marketplacePresent ? readMarketplaceSourcePaths(marketplaceRoot) : new Map();
+  return {
+    marketplaceRoot,
+    marketplaceManifestPath: manifestPath,
+    marketplacePresent,
+    marketplaceSourcePaths,
+    sourceBaseRoot: marketplacePresent ? marketplaceRoot : repo,
+    sourcePaths: marketplacePresent ? marketplaceSourcePaths : repoSourcePaths,
+  };
+}
+
+function profileReport(name, home, plugins, { sourceInfo, repoBaseRoot, repoSourcePaths, requireAllPlugins, summaryPlugin }) {
   const pluginReports = {};
   const configEntries = pluginConfigEntries(home);
   let ok = true;
   for (const plugin of plugins) {
-    const sourcePath = pluginSourcePath(sourcePaths, plugin, repoSourcePaths);
+    const sourcePath = pluginSourcePath(sourceInfo.sourcePaths, plugin, repoSourcePaths);
     const repoSourcePath = pluginSourcePath(repoSourcePaths, plugin);
-    const sourcePluginRoot = join(sourceBaseRoot, sourcePath);
+    const sourcePluginRoot = join(sourceInfo.sourceBaseRoot, sourcePath);
     const repoPluginRoot = join(repoBaseRoot, repoSourcePath);
     const expected = listSkills(sourcePluginRoot, ".");
     const repoPluginPresent = existsSync(repoPluginRoot);
-    const cacheRoot = join(home, "plugins", "cache", CACHE_NAMESPACE, plugin, "0.1.0");
+    const sourcePluginPresent = existsSync(sourcePluginRoot);
+    const listedInMarketplaceManifest = sourceInfo.marketplacePresent ? sourceInfo.marketplaceSourcePaths.has(plugin) : null;
+    const cacheVersion = pluginCacheVersion(home, plugin, sourcePluginRoot, repoPluginRoot);
+    const cacheRoot = join(home, "plugins", "cache", CACHE_NAMESPACE, plugin, cacheVersion);
     const cached = listSkills(cacheRoot, ".");
     const missing = expected.filter((skill) => !cached.includes(skill));
     const extra = cached.filter((skill) => !expected.includes(skill));
@@ -238,7 +344,8 @@ function profileReport(name, home, plugins, { sourceBaseRoot, sourcePaths, repoB
     const requiredForOk = internalRuntime
       ? configuredEnabled || requiredByDependency || requireAllPlugins
       : configuredEnabled || requireAllPlugins;
-    if (requiredForOk && (!inSync || repoInSync === false || (!internalRuntime && !enabled))) ok = false;
+    const missingFromMarketplaceManifest = sourceInfo.marketplacePresent && !listedInMarketplaceManifest;
+    if (requiredForOk && (!inSync || repoInSync === false || missingFromMarketplaceManifest || (!internalRuntime && !enabled))) ok = false;
     pluginReports[plugin] = {
       internal_runtime: internalRuntime,
       configured_enabled: configuredEnabled,
@@ -246,7 +353,11 @@ function profileReport(name, home, plugins, { sourceBaseRoot, sourcePaths, repoB
       required_for_ok: requiredForOk,
       enabled,
       source_path: sourcePath,
+      source_present: sourcePluginPresent,
+      source_manifest_present: sourceInfo.marketplacePresent,
+      listed_in_marketplace_manifest: listedInMarketplaceManifest,
       repo_source_path: repoSourcePath,
+      cache_version: cacheVersion,
       cache_path: cacheRoot,
       cache_in_sync: inSync,
       repo_present: repoPluginPresent,
@@ -293,6 +404,17 @@ function disabledRequiredPluginNames(profiles) {
   return Array.from(names).sort(comparePathStrings);
 }
 
+function unhealthyRequiredInternalRuntimeNames(profiles) {
+  const names = new Set();
+  for (const profile of Object.values(profiles)) {
+    for (const [plugin, report] of Object.entries(profile.plugins)) {
+      if (!report.required_for_ok || !report.internal_runtime) continue;
+      if (!report.cache_in_sync || report.repo_cache_in_sync === false || report.listed_in_marketplace_manifest === false) names.add(plugin);
+    }
+  }
+  return Array.from(names).sort(comparePathStrings);
+}
+
 function main() {
   const args = parseArgs(process.argv.slice(2));
   if (args.help) {
@@ -302,14 +424,12 @@ function main() {
   const repo = resolve(args.repo ?? process.cwd());
   const primaryHome = resolve(args["codex-home"] ?? process.env.CODEX_HOME ?? join(homedir(), ".codex"));
   const secondHome = args["second-codex-home"] ? resolve(args["second-codex-home"]) : null;
-  const marketplaceRoot = join(primaryHome, ".tmp", "marketplaces", MARKETPLACE);
-  const marketplacePresent = existsSync(marketplaceRoot);
   const repoSourcePaths = readMarketplaceSourcePaths(repo);
-  const marketplaceSourcePaths = marketplacePresent ? readMarketplaceSourcePaths(marketplaceRoot) : new Map();
-  const sourceBaseRoot = marketplacePresent ? marketplaceRoot : repo;
-  const sourcePaths = marketplacePresent ? marketplaceSourcePaths : repoSourcePaths;
+  const primarySourceInfo = sourceInfoForHome(primaryHome, repo, repoSourcePaths);
+  const secondSourceInfo = secondHome ? sourceInfoForHome(secondHome, repo, repoSourcePaths) : null;
   const defaultPlugins = defaultPluginNames(
-    marketplaceSourcePaths.keys(),
+    primarySourceInfo.marketplaceSourcePaths.keys(),
+    secondSourceInfo?.marketplaceSourcePaths.keys(),
     repoSourcePaths.keys(),
     enabledPluginNamesFromConfig(primaryHome),
     secondHome ? enabledPluginNamesFromConfig(secondHome) : [],
@@ -318,9 +438,7 @@ function main() {
   );
   const requestedPlugins = args.plugins.length > 0 ? args.plugins : defaultPlugins;
   const plugins = expandPluginsWithDependencies(requestedPlugins);
-  const profileOptions = {
-    sourceBaseRoot,
-    sourcePaths,
+  const sharedProfileOptions = {
     repoBaseRoot: repo,
     repoSourcePaths,
     requireAllPlugins: args.plugins.length > 0,
@@ -328,15 +446,25 @@ function main() {
   };
 
   const profiles = {
-    primary: profileReport("primary", primaryHome, plugins, profileOptions),
+    primary: profileReport("primary", primaryHome, plugins, {
+      ...sharedProfileOptions,
+      sourceInfo: primarySourceInfo,
+    }),
   };
-  if (secondHome) profiles.second = profileReport("second", secondHome, plugins, profileOptions);
+  if (secondHome) {
+    profiles.second = profileReport("second", secondHome, plugins, {
+      ...sharedProfileOptions,
+      sourceInfo: secondSourceInfo,
+    });
+  }
 
   const ok = Object.values(profiles).every((profile) => profile.ok);
   const nextActions = [];
-  if (!existsSync(marketplaceRoot)) {
+  const profileSourceInfos = [primarySourceInfo, secondSourceInfo].filter(Boolean);
+  if (profileSourceInfos.some((info) => !info.marketplacePresent)) {
     nextActions.push(`Add the marketplace with \`codex plugin marketplace add ${MARKETPLACE_REPOSITORY}\`.`);
-  } else {
+  }
+  if (profileSourceInfos.some((info) => info.marketplacePresent)) {
     nextActions.push(`Refresh Git marketplace installs with \`codex plugin marketplace upgrade ${MARKETPLACE}\`.`);
   }
   nextActions.push("If repo working tree differs from installed plugin cache, commit/publish or refresh marketplace/cache before opening new Codex sessions.");
@@ -344,6 +472,10 @@ function main() {
   const disabledRequired = disabledRequiredPluginNames(profiles);
   if (disabledRequired.length > 0) {
     nextActions.push(`Enable required disabled plugins (${disabledRequired.join(", ")}) in \`/plugins\` or config.toml for the Codex profile that will run reviews.`);
+  }
+  const unhealthyInternalRuntimes = unhealthyRequiredInternalRuntimeNames(profiles);
+  if (unhealthyInternalRuntimes.length > 0) {
+    nextActions.push(`Refresh required internal runtime caches (${unhealthyInternalRuntimes.join(", ")}) by upgrading ${MARKETPLACE} before running direct API reviews.`);
   }
   nextActions.push("Restart already-open Codex TUI sessions; skill picker inventory is loaded in memory.");
   nextActions.push("Verify with `codex debug prompt-input 'list skills'` from the target CODEX_HOME.");
@@ -354,9 +486,10 @@ function main() {
     marketplace: {
       name: MARKETPLACE,
       cache_namespace: CACHE_NAMESPACE,
-      root: marketplaceRoot,
-      present: marketplacePresent,
-      source_root: sourceBaseRoot,
+      root: primarySourceInfo.marketplaceRoot,
+      manifest_path: primarySourceInfo.marketplaceManifestPath,
+      present: primarySourceInfo.marketplacePresent,
+      source_root: primarySourceInfo.sourceBaseRoot,
     },
     profiles,
     next_actions: nextActions,

--- a/scripts/codex-plugin-cache-doctor.mjs
+++ b/scripts/codex-plugin-cache-doctor.mjs
@@ -101,19 +101,26 @@ function marketplaceManifestPath(root) {
   return join(root, ".agents", "plugins", "marketplace.json");
 }
 
-function readMarketplaceSourcePaths(root) {
+function readMarketplaceEntries(root) {
   const file = marketplaceManifestPath(root);
-  const paths = new Map();
-  if (!existsSync(file)) return paths;
+  const entries = new Map();
+  if (!existsSync(file)) return entries;
 
   const marketplace = JSON.parse(readFileSync(file, "utf8"));
-  if (!Array.isArray(marketplace.plugins)) return paths;
+  if (!Array.isArray(marketplace.plugins)) return entries;
   for (const plugin of marketplace.plugins) {
     if (typeof plugin?.name !== "string") continue;
     const sourcePath = typeof plugin.source?.path === "string" ? plugin.source.path : fallbackSourcePath(plugin.name);
-    paths.set(plugin.name, normalizeSourcePath(sourcePath));
+    entries.set(plugin.name, {
+      sourcePath: normalizeSourcePath(sourcePath),
+      version: typeof plugin.version === "string" && plugin.version.length > 0 ? plugin.version : null,
+    });
   }
-  return paths;
+  return entries;
+}
+
+function sourcePathsFromMarketplaceEntries(entries) {
+  return new Map(Array.from(entries, ([plugin, entry]) => [plugin, entry.sourcePath]));
 }
 
 function pluginSourcePath(paths, plugin, fallbackPaths = new Map()) {
@@ -269,13 +276,28 @@ function readPluginVersion(pluginRoot) {
   return null;
 }
 
-function pluginCacheVersion(home, plugin, sourcePluginRoot, repoPluginRoot) {
+function cacheFilesForVersion(home, plugin, version) {
+  return listComparableFiles(join(home, "plugins", "cache", CACHE_NAMESPACE, plugin, version));
+}
+
+function pluginCacheVersion(home, plugin, sourcePluginRoot, repoPluginRoot, manifestVersion, sourceFiles) {
   const sourceVersion = readPluginVersion(sourcePluginRoot);
   if (sourceVersion) return sourceVersion;
+  if (manifestVersion) return manifestVersion;
   const versions = cacheVersionNames(home, plugin);
   const repoVersion = readPluginVersion(repoPluginRoot);
-  if (repoVersion && versions.includes(repoVersion)) return repoVersion;
   if (versions.length === 1) return versions[0];
+  if (versions.length > 1 && sourceFiles.size > 0) {
+    const matchingVersions = versions.filter((version) => {
+      const comparison = compareFileHashes(sourceFiles, cacheFilesForVersion(home, plugin, version));
+      return comparison.missing_files.length === 0
+        && comparison.extra_files.length === 0
+        && comparison.changed_files.length === 0;
+    });
+    if (matchingVersions.length === 1) return matchingVersions[0];
+    if (repoVersion && matchingVersions.includes(repoVersion)) return repoVersion;
+  }
+  if (repoVersion && versions.includes(repoVersion)) return repoVersion;
   if (versions.includes("0.1.0")) return "0.1.0";
   return repoVersion ?? versions[0] ?? "0.1.0";
 }
@@ -299,11 +321,13 @@ function sourceInfoForHome(home, repo, repoSourcePaths) {
   const marketplaceRoot = join(home, ".tmp", "marketplaces", MARKETPLACE);
   const manifestPath = marketplaceManifestPath(marketplaceRoot);
   const marketplacePresent = existsSync(manifestPath);
-  const marketplaceSourcePaths = marketplacePresent ? readMarketplaceSourcePaths(marketplaceRoot) : new Map();
+  const marketplaceEntries = marketplacePresent ? readMarketplaceEntries(marketplaceRoot) : new Map();
+  const marketplaceSourcePaths = sourcePathsFromMarketplaceEntries(marketplaceEntries);
   return {
     marketplaceRoot,
     marketplaceManifestPath: manifestPath,
     marketplacePresent,
+    marketplaceEntries,
     marketplaceSourcePaths,
     sourceBaseRoot: marketplacePresent ? marketplaceRoot : repo,
     sourcePaths: marketplacePresent ? marketplaceSourcePaths : repoSourcePaths,
@@ -323,12 +347,14 @@ function profileReport(name, home, plugins, { sourceInfo, repoBaseRoot, repoSour
     const repoPluginPresent = existsSync(repoPluginRoot);
     const sourcePluginPresent = existsSync(sourcePluginRoot);
     const listedInMarketplaceManifest = sourceInfo.marketplacePresent ? sourceInfo.marketplaceSourcePaths.has(plugin) : null;
-    const cacheVersion = pluginCacheVersion(home, plugin, sourcePluginRoot, repoPluginRoot);
+    const sourceFiles = listComparableFiles(sourcePluginRoot);
+    const manifestVersion = sourceInfo.marketplaceEntries.get(plugin)?.version ?? null;
+    const cacheVersion = pluginCacheVersion(home, plugin, sourcePluginRoot, repoPluginRoot, manifestVersion, sourceFiles);
     const cacheRoot = join(home, "plugins", "cache", CACHE_NAMESPACE, plugin, cacheVersion);
     const cached = listSkills(cacheRoot, ".");
     const missing = expected.filter((skill) => !cached.includes(skill));
     const extra = cached.filter((skill) => !expected.includes(skill));
-    const fileComparison = compareFileHashes(listComparableFiles(sourcePluginRoot), listComparableFiles(cacheRoot));
+    const fileComparison = compareFileHashes(sourceFiles, listComparableFiles(cacheRoot));
     const repoFileComparison = compareFileHashes(listComparableFiles(repoPluginRoot), listComparableFiles(cacheRoot));
     const filesInSync = fileComparison.missing_files.length === 0
       && fileComparison.extra_files.length === 0
@@ -361,6 +387,7 @@ function profileReport(name, home, plugins, { sourceInfo, repoBaseRoot, repoSour
       source_manifest_present: sourceInfo.marketplacePresent,
       listed_in_marketplace_manifest: listedInMarketplaceManifest,
       repo_source_path: repoSourcePath,
+      marketplace_manifest_version: manifestVersion,
       cache_version: cacheVersion,
       cache_path: cacheRoot,
       cache_in_sync: inSync,
@@ -447,7 +474,7 @@ function main() {
   const repo = resolve(args.repo ?? process.cwd());
   const primaryHome = resolve(args["codex-home"] ?? process.env.CODEX_HOME ?? join(homedir(), ".codex"));
   const secondHome = args["second-codex-home"] ? resolve(args["second-codex-home"]) : null;
-  const repoSourcePaths = readMarketplaceSourcePaths(repo);
+  const repoSourcePaths = sourcePathsFromMarketplaceEntries(readMarketplaceEntries(repo));
   const primarySourceInfo = sourceInfoForHome(primaryHome, repo, repoSourcePaths);
   const secondSourceInfo = secondHome ? sourceInfoForHome(secondHome, repo, repoSourcePaths) : null;
   const defaultPlugins = defaultPluginNames(

--- a/scripts/codex-plugin-cache-doctor.mjs
+++ b/scripts/codex-plugin-cache-doctor.mjs
@@ -270,10 +270,14 @@ function readPluginVersion(pluginRoot) {
 }
 
 function pluginCacheVersion(home, plugin, sourcePluginRoot, repoPluginRoot) {
-  return readPluginVersion(sourcePluginRoot)
-    ?? readPluginVersion(repoPluginRoot)
-    ?? cacheVersionNames(home, plugin)[0]
-    ?? "0.1.0";
+  const sourceVersion = readPluginVersion(sourcePluginRoot);
+  if (sourceVersion) return sourceVersion;
+  const versions = cacheVersionNames(home, plugin);
+  const repoVersion = readPluginVersion(repoPluginRoot);
+  if (repoVersion && versions.includes(repoVersion)) return repoVersion;
+  if (versions.length === 1) return versions[0];
+  if (versions.includes("0.1.0")) return "0.1.0";
+  return repoVersion ?? versions[0] ?? "0.1.0";
 }
 
 function defaultPluginNames(...nameLists) {
@@ -404,15 +408,34 @@ function disabledRequiredPluginNames(profiles) {
   return Array.from(names).sort(comparePathStrings);
 }
 
+function unlistedRequiredPluginNames(profiles) {
+  const names = new Set();
+  for (const profile of Object.values(profiles)) {
+    for (const [plugin, report] of Object.entries(profile.plugins)) {
+      if (report.required_for_ok && report.listed_in_marketplace_manifest === false) names.add(plugin);
+    }
+  }
+  return Array.from(names).sort(comparePathStrings);
+}
+
 function unhealthyRequiredInternalRuntimeNames(profiles) {
   const names = new Set();
   for (const profile of Object.values(profiles)) {
     for (const [plugin, report] of Object.entries(profile.plugins)) {
       if (!report.required_for_ok || !report.internal_runtime) continue;
-      if (!report.cache_in_sync || report.repo_cache_in_sync === false || report.listed_in_marketplace_manifest === false) names.add(plugin);
+      if (!report.cache_in_sync || report.repo_cache_in_sync === false) names.add(plugin);
     }
   }
   return Array.from(names).sort(comparePathStrings);
+}
+
+function marketplaceReport(info) {
+  return {
+    root: info.marketplaceRoot,
+    manifest_path: info.marketplaceManifestPath,
+    present: info.marketplacePresent,
+    source_root: info.sourceBaseRoot,
+  };
 }
 
 function main() {
@@ -473,6 +496,10 @@ function main() {
   if (disabledRequired.length > 0) {
     nextActions.push(`Enable required disabled plugins (${disabledRequired.join(", ")}) in \`/plugins\` or config.toml for the Codex profile that will run reviews.`);
   }
+  const unlistedRequired = unlistedRequiredPluginNames(profiles);
+  if (unlistedRequired.length > 0) {
+    nextActions.push(`Refresh ${MARKETPLACE} so required plugins appear in the installed marketplace manifest: ${unlistedRequired.join(", ")}.`);
+  }
   const unhealthyInternalRuntimes = unhealthyRequiredInternalRuntimeNames(profiles);
   if (unhealthyInternalRuntimes.length > 0) {
     nextActions.push(`Refresh required internal runtime caches (${unhealthyInternalRuntimes.join(", ")}) by upgrading ${MARKETPLACE} before running direct API reviews.`);
@@ -486,11 +513,12 @@ function main() {
     marketplace: {
       name: MARKETPLACE,
       cache_namespace: CACHE_NAMESPACE,
-      root: primarySourceInfo.marketplaceRoot,
-      manifest_path: primarySourceInfo.marketplaceManifestPath,
-      present: primarySourceInfo.marketplacePresent,
-      source_root: primarySourceInfo.sourceBaseRoot,
+      ...marketplaceReport(primarySourceInfo),
     },
+    marketplaces: Object.fromEntries([
+      ["primary", marketplaceReport(primarySourceInfo)],
+      ...(secondSourceInfo ? [["second", marketplaceReport(secondSourceInfo)]] : []),
+    ]),
     profiles,
     next_actions: nextActions,
   }, null, 2)}\n`);

--- a/scripts/codex-plugin-cache-doctor.mjs
+++ b/scripts/codex-plugin-cache-doctor.mjs
@@ -8,10 +8,15 @@ const MARKETPLACE = "relay-for-codex";
 const MARKETPLACE_REPOSITORY = "relay-org/relay";
 const CACHE_NAMESPACE = MARKETPLACE;
 const INTERNAL_RUNTIME_PLUGINS = new Set(["api-reviewers"]);
-const DEFAULT_PLUGINS = [
+const PLUGIN_DEPENDENCIES = new Map([
+  ["relay-deepseek", ["api-reviewers"]],
+  ["relay-glm", ["api-reviewers"]],
+]);
+const FALLBACK_DEFAULT_PLUGINS = [
   "relay-claude",
   "relay-gemini",
   "relay-kimi",
+  "relay-agy",
   "relay-grok",
   "relay-glm",
   "relay-deepseek",
@@ -32,6 +37,10 @@ Options:
 
 function comparePathStrings(a, b) {
   return a.localeCompare(b);
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function parseArgs(argv) {
@@ -83,8 +92,7 @@ function readMarketplaceSourcePaths(root) {
   if (!Array.isArray(marketplace.plugins)) return paths;
   for (const plugin of marketplace.plugins) {
     if (typeof plugin?.name !== "string") continue;
-    const sourcePath = plugin.source?.path;
-    if (typeof sourcePath !== "string") continue;
+    const sourcePath = typeof plugin.source?.path === "string" ? plugin.source.path : join("plugins", plugin.name);
     paths.set(plugin.name, normalizeSourcePath(sourcePath));
   }
   return paths;
@@ -140,17 +148,64 @@ function compareFileHashes(expected, cached) {
   };
 }
 
-function enabledInConfig(home, plugin) {
+function pluginConfigEntries(home) {
   const config = join(home, "config.toml");
-  if (!existsSync(config)) return false;
+  const entries = new Map();
+  if (!existsSync(config)) return entries;
   const text = readFileSync(config, "utf8");
-  const escaped = `${plugin}@${MARKETPLACE}`.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const match = new RegExp(`\\[plugins\\."${escaped}"\\]([\\s\\S]*?)(?:\\n\\[|$)`).exec(text);
-  return match ? /\benabled\s*=\s*true\b/.test(match[1]) : false;
+  const escapedMarketplace = escapeRegExp(MARKETPLACE);
+  const sectionPattern = new RegExp(`\\[plugins\\."([^"\\n]+)@${escapedMarketplace}"\\]([\\s\\S]*?)(?=\\n\\[|$)`, "g");
+  for (const match of text.matchAll(sectionPattern)) {
+    entries.set(match[1], /\benabled\s*=\s*true\b/.test(match[2]));
+  }
+  return entries;
 }
 
-function profileReport(name, home, plugins, { sourceBaseRoot, sourcePaths, repoBaseRoot, repoSourcePaths }) {
+function expandPluginsWithDependencies(plugins) {
+  const seen = new Set();
+  const expanded = [];
+  function visit(plugin) {
+    if (seen.has(plugin)) return;
+    seen.add(plugin);
+    expanded.push(plugin);
+    for (const dependency of PLUGIN_DEPENDENCIES.get(plugin) ?? []) visit(dependency);
+  }
+  for (const plugin of plugins) visit(plugin);
+  return expanded;
+}
+
+function enabledPluginNamesFromConfig(home) {
+  return Array.from(pluginConfigEntries(home).entries())
+    .filter(([, enabled]) => enabled)
+    .map(([plugin]) => plugin);
+}
+
+function installedCachePluginNames(home) {
+  const root = join(home, "plugins", "cache", CACHE_NAMESPACE);
+  if (!existsSync(root)) return [];
+  return readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name);
+}
+
+function defaultPluginNames(...nameLists) {
+  const names = new Set(FALLBACK_DEFAULT_PLUGINS);
+  for (const nameList of nameLists) {
+    for (const plugin of nameList ?? []) names.add(plugin);
+  }
+  return Array.from(names).sort(comparePathStrings);
+}
+
+function requiredByEnabledPlugin(configEntries, plugin) {
+  for (const [dependent, dependencies] of PLUGIN_DEPENDENCIES.entries()) {
+    if (dependencies.includes(plugin) && configEntries.get(dependent) === true) return true;
+  }
+  return false;
+}
+
+function profileReport(name, home, plugins, { sourceBaseRoot, sourcePaths, repoBaseRoot, repoSourcePaths, requireAllPlugins, summaryPlugin }) {
   const pluginReports = {};
+  const configEntries = pluginConfigEntries(home);
   let ok = true;
   for (const plugin of plugins) {
     const sourcePath = pluginSourcePath(sourcePaths, plugin, repoSourcePaths);
@@ -177,10 +232,18 @@ function profileReport(name, home, plugins, { sourceBaseRoot, sourcePaths, repoB
     const inSync = missing.length === 0 && extra.length === 0 && hasExpectedSurface && filesInSync;
     const repoInSync = repoPluginPresent ? repoFilesInSync : null;
     const internalRuntime = INTERNAL_RUNTIME_PLUGINS.has(plugin);
-    const enabled = internalRuntime ? true : enabledInConfig(home, plugin);
-    if (!inSync || repoInSync === false || (!internalRuntime && !enabled)) ok = false;
+    const configuredEnabled = configEntries.get(plugin) === true;
+    const requiredByDependency = requiredByEnabledPlugin(configEntries, plugin);
+    const enabled = internalRuntime ? true : configuredEnabled;
+    const requiredForOk = internalRuntime
+      ? configuredEnabled || requiredByDependency || requireAllPlugins
+      : configuredEnabled || requireAllPlugins;
+    if (requiredForOk && (!inSync || repoInSync === false || (!internalRuntime && !enabled))) ok = false;
     pluginReports[plugin] = {
       internal_runtime: internalRuntime,
+      configured_enabled: configuredEnabled,
+      required_by_enabled_plugin: requiredByDependency,
+      required_for_ok: requiredForOk,
       enabled,
       source_path: sourcePath,
       repo_source_path: repoSourcePath,
@@ -199,21 +262,35 @@ function profileReport(name, home, plugins, { sourceBaseRoot, sourcePaths, repoB
       repo_changed_files: repoFileComparison.changed_files,
     };
   }
+  const summary = summaryPlugin && pluginReports[summaryPlugin]
+    ? pluginReports[summaryPlugin]
+    : (plugins.length === 1 ? pluginReports[plugins[0]] : null);
   return {
     name,
     home,
-    enabled: plugins.length === 1 ? pluginReports[plugins[0]].enabled : undefined,
-    cache_in_sync: plugins.length === 1 ? pluginReports[plugins[0]].cache_in_sync : undefined,
-    repo_present: plugins.length === 1 ? pluginReports[plugins[0]].repo_present : undefined,
-    repo_cache_in_sync: plugins.length === 1 ? pluginReports[plugins[0]].repo_cache_in_sync : undefined,
-    missing_skills: plugins.length === 1 ? pluginReports[plugins[0]].missing_skills : undefined,
-    missing_files: plugins.length === 1 ? pluginReports[plugins[0]].missing_files : undefined,
-    extra_files: plugins.length === 1 ? pluginReports[plugins[0]].extra_files : undefined,
-    changed_files: plugins.length === 1 ? pluginReports[plugins[0]].changed_files : undefined,
-    repo_changed_files: plugins.length === 1 ? pluginReports[plugins[0]].repo_changed_files : undefined,
+    summary_plugin: summary ? (summaryPlugin ?? plugins[0]) : undefined,
+    enabled: summary?.enabled,
+    cache_in_sync: summary?.cache_in_sync,
+    repo_present: summary?.repo_present,
+    repo_cache_in_sync: summary?.repo_cache_in_sync,
+    missing_skills: summary?.missing_skills,
+    missing_files: summary?.missing_files,
+    extra_files: summary?.extra_files,
+    changed_files: summary?.changed_files,
+    repo_changed_files: summary?.repo_changed_files,
     plugins: pluginReports,
     ok,
   };
+}
+
+function disabledRequiredPluginNames(profiles) {
+  const names = new Set();
+  for (const profile of Object.values(profiles)) {
+    for (const [plugin, report] of Object.entries(profile.plugins)) {
+      if (report.required_for_ok && !report.internal_runtime && !report.enabled) names.add(plugin);
+    }
+  }
+  return Array.from(names).sort(comparePathStrings);
 }
 
 function main() {
@@ -225,14 +302,30 @@ function main() {
   const repo = resolve(args.repo ?? process.cwd());
   const primaryHome = resolve(args["codex-home"] ?? process.env.CODEX_HOME ?? join(homedir(), ".codex"));
   const secondHome = args["second-codex-home"] ? resolve(args["second-codex-home"]) : null;
-  const plugins = args.plugins.length > 0 ? args.plugins : DEFAULT_PLUGINS;
   const marketplaceRoot = join(primaryHome, ".tmp", "marketplaces", MARKETPLACE);
   const marketplacePresent = existsSync(marketplaceRoot);
   const repoSourcePaths = readMarketplaceSourcePaths(repo);
   const marketplaceSourcePaths = marketplacePresent ? readMarketplaceSourcePaths(marketplaceRoot) : new Map();
   const sourceBaseRoot = marketplacePresent ? marketplaceRoot : repo;
   const sourcePaths = marketplacePresent ? marketplaceSourcePaths : repoSourcePaths;
-  const profileOptions = { sourceBaseRoot, sourcePaths, repoBaseRoot: repo, repoSourcePaths };
+  const defaultPlugins = defaultPluginNames(
+    marketplaceSourcePaths.keys(),
+    repoSourcePaths.keys(),
+    enabledPluginNamesFromConfig(primaryHome),
+    secondHome ? enabledPluginNamesFromConfig(secondHome) : [],
+    installedCachePluginNames(primaryHome),
+    secondHome ? installedCachePluginNames(secondHome) : [],
+  );
+  const requestedPlugins = args.plugins.length > 0 ? args.plugins : defaultPlugins;
+  const plugins = expandPluginsWithDependencies(requestedPlugins);
+  const profileOptions = {
+    sourceBaseRoot,
+    sourcePaths,
+    repoBaseRoot: repo,
+    repoSourcePaths,
+    requireAllPlugins: args.plugins.length > 0,
+    summaryPlugin: args.plugins.length === 1 ? args.plugins[0] : null,
+  };
 
   const profiles = {
     primary: profileReport("primary", primaryHome, plugins, profileOptions),
@@ -248,7 +341,10 @@ function main() {
   }
   nextActions.push("If repo working tree differs from installed plugin cache, commit/publish or refresh marketplace/cache before opening new Codex sessions.");
   nextActions.push("If upgrade reports `not configured as a Git marketplace`, remove and re-add the marketplace from GitHub.");
-  nextActions.push("Enable missing plugins in `/plugins` or config.toml for the Codex profile that will run reviews.");
+  const disabledRequired = disabledRequiredPluginNames(profiles);
+  if (disabledRequired.length > 0) {
+    nextActions.push(`Enable required disabled plugins (${disabledRequired.join(", ")}) in \`/plugins\` or config.toml for the Codex profile that will run reviews.`);
+  }
   nextActions.push("Restart already-open Codex TUI sessions; skill picker inventory is loaded in memory.");
   nextActions.push("Verify with `codex debug prompt-input 'list skills'` from the target CODEX_HOME.");
 

--- a/tests/property/sanitization-properties.test.mjs
+++ b/tests/property/sanitization-properties.test.mjs
@@ -330,9 +330,9 @@ describe("I4 — Bearer tokens are redacted with JSON syntax intact", () => {
           // Embed in a JSON-shaped string.
           const host = `{"auth":"Bearer ${token}${suffix}rest":1}`;
           const sanitized = sanitize(host, { architecture, env: {} });
-          // Token gone, suffix character (the byte immediately after)
-          // preserved exactly once at its position.
-          return !sanitized.includes(token)
+          // The Bearer token occurrence is gone, while the suffix character
+          // (the byte immediately after the token) is preserved at its position.
+          return !sanitized.includes(`Bearer ${token}${suffix}`)
             && sanitized.includes(`Bearer ${REDACTED}${suffix}`);
         },
       ),

--- a/tests/unit/plugin-cache-doctor.test.mjs
+++ b/tests/unit/plugin-cache-doctor.test.mjs
@@ -10,6 +10,15 @@ const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..
 const DOCTOR = path.join(REPO_ROOT, "scripts", "codex-plugin-cache-doctor.mjs");
 const MARKETPLACE = "relay-for-codex";
 const CACHE_NAMESPACE = MARKETPLACE;
+const CORE_MARKETPLACE_PLUGINS = [
+  "relay-claude",
+  "relay-gemini",
+  "relay-kimi",
+  "relay-grok",
+  "relay-glm",
+  "relay-deepseek",
+  "api-reviewers",
+];
 
 function writeSkill(root, plugin, skill) {
   const dir = path.join(root, plugin, "skills", skill);
@@ -44,6 +53,17 @@ function writeConfig(home, plugin, enabled = true) {
   );
 }
 
+function writeConfigEntries(home, entries) {
+  mkdirSync(home, { recursive: true });
+  writeFileSync(
+    path.join(home, "config.toml"),
+    entries.map(([plugin, enabled]) => (
+      `[plugins."${plugin}@${MARKETPLACE}"]\nenabled = ${enabled ? "true" : "false"}\n`
+    )).join("\n"),
+    "utf8",
+  );
+}
+
 function writeMarketplaceManifest(root, plugins) {
   const file = path.join(root, ".agents", "plugins", "marketplace.json");
   mkdirSync(path.dirname(file), { recursive: true });
@@ -60,6 +80,485 @@ function writeMarketplaceManifest(root, plugins) {
     "utf8",
   );
 }
+
+test("codex plugin cache doctor does not fail default profile for disabled uninstalled marketplace plugins", () => {
+  const repo = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-disabled-repo-"));
+  const primary = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-disabled-home-"));
+  const marketplaceRoot = path.join(primary, ".tmp", "marketplaces", MARKETPLACE);
+  const plugins = CORE_MARKETPLACE_PLUGINS;
+  const activePlugins = plugins.filter((plugin) => plugin !== "relay-gemini");
+
+  writeMarketplaceManifest(repo, plugins.map((plugin) => [plugin, `./plugins/${plugin}`]));
+  writeMarketplaceManifest(marketplaceRoot, plugins.map((plugin) => [plugin, `./plugins/${plugin}`]));
+  for (const plugin of plugins) {
+    writePluginFile(path.join(repo, "plugins"), plugin, "scripts/runtime.mjs", "export const version = 'source';\n");
+    writePluginFile(path.join(marketplaceRoot, "plugins"), plugin, "scripts/runtime.mjs", "export const version = 'source';\n");
+    if (plugin !== "api-reviewers") {
+      writeSkill(path.join(repo, "plugins"), plugin, `${plugin}-review`);
+      writeSkill(path.join(marketplaceRoot, "plugins"), plugin, `${plugin}-review`);
+    }
+  }
+  for (const plugin of activePlugins) {
+    writeCachedPluginFile(primary, plugin, "scripts/runtime.mjs", "export const version = 'source';\n");
+    if (plugin !== "api-reviewers") writeCachedSkill(primary, plugin, `${plugin}-review`);
+  }
+  writeConfigEntries(primary, activePlugins
+    .filter((plugin) => plugin !== "api-reviewers")
+    .map((plugin) => [plugin, true]));
+
+  const stdout = execFileSync(process.execPath, [
+    DOCTOR,
+    "--repo", repo,
+    "--codex-home", primary,
+  ], { encoding: "utf8" });
+  const report = JSON.parse(stdout);
+  const profile = report.profiles.primary;
+
+  assert.equal(report.ok, true);
+  assert.equal(profile.ok, true);
+  assert.equal(profile.plugins["relay-gemini"].enabled, false);
+  assert.equal(profile.plugins["relay-gemini"].required_for_ok, false);
+  assert.equal(profile.plugins["relay-gemini"].cache_in_sync, false);
+  assert.equal(profile.plugins["relay-gemini"].repo_cache_in_sync, false);
+  assert.equal(profile.plugins["relay-grok"].required_for_ok, true);
+  assert.equal(profile.plugins["relay-grok"].cache_in_sync, true);
+  assert.equal(profile.plugins["api-reviewers"].required_for_ok, true);
+  assert.equal(profile.plugins["api-reviewers"].cache_in_sync, true);
+  assert.doesNotMatch(report.next_actions.join("\n"), /enable missing plugins/i);
+  assert.doesNotMatch(report.next_actions.join("\n"), /Enable required disabled plugins/i);
+});
+
+test("codex plugin cache doctor requires api-reviewers only when direct API reviewers are enabled", () => {
+  const repo = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-api-runtime-optional-repo-"));
+  const primary = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-api-runtime-optional-home-"));
+  const marketplaceRoot = path.join(primary, ".tmp", "marketplaces", MARKETPLACE);
+  const plugins = CORE_MARKETPLACE_PLUGINS;
+
+  writeMarketplaceManifest(repo, plugins.map((plugin) => [plugin, `./plugins/${plugin}`]));
+  writeMarketplaceManifest(marketplaceRoot, plugins.map((plugin) => [plugin, `./plugins/${plugin}`]));
+  for (const plugin of plugins) {
+    writePluginFile(path.join(repo, "plugins"), plugin, "scripts/runtime.mjs", "export const version = 'source';\n");
+    writePluginFile(path.join(marketplaceRoot, "plugins"), plugin, "scripts/runtime.mjs", "export const version = 'source';\n");
+    if (plugin !== "api-reviewers") {
+      writeSkill(path.join(repo, "plugins"), plugin, `${plugin}-review`);
+      writeSkill(path.join(marketplaceRoot, "plugins"), plugin, `${plugin}-review`);
+    }
+  }
+  writeCachedPluginFile(primary, "relay-claude", "scripts/runtime.mjs", "export const version = 'source';\n");
+  writeCachedSkill(primary, "relay-claude", "relay-claude-review");
+  writeConfig(primary, "relay-claude", true);
+
+  const stdout = execFileSync(process.execPath, [
+    DOCTOR,
+    "--repo", repo,
+    "--codex-home", primary,
+  ], { encoding: "utf8" });
+  const report = JSON.parse(stdout);
+  const profile = report.profiles.primary;
+
+  assert.equal(report.ok, true);
+  assert.equal(profile.ok, true);
+  assert.equal(profile.plugins["relay-claude"].required_for_ok, true);
+  assert.equal(profile.plugins["relay-deepseek"].enabled, false);
+  assert.equal(profile.plugins["relay-glm"].enabled, false);
+  assert.equal(profile.plugins["api-reviewers"].enabled, true);
+  assert.equal(profile.plugins["api-reviewers"].configured_enabled, false);
+  assert.equal(profile.plugins["api-reviewers"].required_by_enabled_plugin, false);
+  assert.equal(profile.plugins["api-reviewers"].required_for_ok, false);
+  assert.equal(profile.plugins["api-reviewers"].cache_in_sync, false);
+  assert.doesNotMatch(report.next_actions.join("\n"), /enable missing plugins/i);
+  assert.doesNotMatch(report.next_actions.join("\n"), /Enable required disabled plugins/i);
+});
+
+test("codex plugin cache doctor default profile includes enabled marketplace plugins outside the core list", () => {
+  const repo = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-marketplace-derived-repo-"));
+  const primary = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-marketplace-derived-home-"));
+  const marketplaceRoot = path.join(primary, ".tmp", "marketplaces", MARKETPLACE);
+  const plugins = ["relay-claude", "relay-agy"];
+
+  writeMarketplaceManifest(repo, plugins.map((plugin) => [plugin, `./plugins/${plugin}`]));
+  writeMarketplaceManifest(marketplaceRoot, plugins.map((plugin) => [plugin, `./plugins/${plugin}`]));
+  for (const plugin of plugins) {
+    writePluginFile(path.join(repo, "plugins"), plugin, "scripts/runtime.mjs", "export const version = 'source';\n");
+    writePluginFile(path.join(marketplaceRoot, "plugins"), plugin, "scripts/runtime.mjs", "export const version = 'source';\n");
+    writeSkill(path.join(repo, "plugins"), plugin, `${plugin}-review`);
+    writeSkill(path.join(marketplaceRoot, "plugins"), plugin, `${plugin}-review`);
+  }
+  writeCachedPluginFile(primary, "relay-claude", "scripts/runtime.mjs", "export const version = 'source';\n");
+  writeCachedSkill(primary, "relay-claude", "relay-claude-review");
+  writeConfigEntries(primary, [
+    ["relay-claude", true],
+    ["relay-agy", true],
+  ]);
+
+  const stdout = execFileSync(process.execPath, [
+    DOCTOR,
+    "--repo", repo,
+    "--codex-home", primary,
+  ], { encoding: "utf8" });
+  const report = JSON.parse(stdout);
+  const profile = report.profiles.primary;
+
+  assert.equal(report.ok, false);
+  assert.equal(profile.plugins["relay-agy"].enabled, true);
+  assert.equal(profile.plugins["relay-agy"].required_for_ok, true);
+  assert.equal(profile.plugins["relay-agy"].cache_in_sync, false);
+});
+
+test("codex plugin cache doctor default profile includes repo-manifest plugins missing from a stale marketplace clone", () => {
+  const repo = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-stale-clone-repo-"));
+  const primary = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-stale-clone-home-"));
+  const marketplaceRoot = path.join(primary, ".tmp", "marketplaces", MARKETPLACE);
+
+  writeMarketplaceManifest(repo, [
+    ["relay-claude", "./plugins/relay-claude"],
+    ["relay-agy", "./plugins/relay-agy"],
+  ]);
+  writeMarketplaceManifest(marketplaceRoot, [["relay-claude", "./plugins/relay-claude"]]);
+  for (const plugin of ["relay-claude", "relay-agy"]) {
+    writePluginFile(path.join(repo, "plugins"), plugin, "scripts/runtime.mjs", "export const version = 'source';\n");
+    writeSkill(path.join(repo, "plugins"), plugin, `${plugin}-review`);
+  }
+  writePluginFile(path.join(marketplaceRoot, "plugins"), "relay-claude", "scripts/runtime.mjs", "export const version = 'source';\n");
+  writeSkill(path.join(marketplaceRoot, "plugins"), "relay-claude", "relay-claude-review");
+  writeCachedPluginFile(primary, "relay-claude", "scripts/runtime.mjs", "export const version = 'source';\n");
+  writeCachedSkill(primary, "relay-claude", "relay-claude-review");
+  writeConfigEntries(primary, [
+    ["relay-claude", true],
+    ["relay-agy", true],
+  ]);
+
+  const stdout = execFileSync(process.execPath, [
+    DOCTOR,
+    "--repo", repo,
+    "--codex-home", primary,
+  ], { encoding: "utf8" });
+  const report = JSON.parse(stdout);
+  const profile = report.profiles.primary;
+
+  assert.equal(report.ok, false);
+  assert.equal(profile.plugins["relay-agy"].enabled, true);
+  assert.equal(profile.plugins["relay-agy"].required_for_ok, true);
+  assert.equal(profile.plugins["relay-agy"].cache_in_sync, false);
+});
+
+test("codex plugin cache doctor default profile includes config-enabled plugins absent from manifests", () => {
+  const repo = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-config-enabled-repo-"));
+  const primary = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-config-enabled-home-"));
+  const marketplaceRoot = path.join(primary, ".tmp", "marketplaces", MARKETPLACE);
+
+  writeMarketplaceManifest(repo, [["relay-claude", "./plugins/relay-claude"]]);
+  writeMarketplaceManifest(marketplaceRoot, [["relay-claude", "./plugins/relay-claude"]]);
+  writePluginFile(path.join(repo, "plugins"), "relay-claude", "scripts/runtime.mjs", "export const version = 'source';\n");
+  writePluginFile(path.join(repo, "plugins"), "relay-deepseek", "scripts/runtime.mjs", "export const version = 'source';\n");
+  writePluginFile(path.join(repo, "plugins"), "api-reviewers", "scripts/runtime.mjs", "export const version = 'source';\n");
+  writePluginFile(path.join(marketplaceRoot, "plugins"), "relay-claude", "scripts/runtime.mjs", "export const version = 'source';\n");
+  writeSkill(path.join(repo, "plugins"), "relay-claude", "relay-claude-review");
+  writeSkill(path.join(repo, "plugins"), "relay-deepseek", "deepseek-review");
+  writeSkill(path.join(marketplaceRoot, "plugins"), "relay-claude", "relay-claude-review");
+  writeCachedPluginFile(primary, "relay-claude", "scripts/runtime.mjs", "export const version = 'source';\n");
+  writeCachedSkill(primary, "relay-claude", "relay-claude-review");
+  writeCachedPluginFile(primary, "relay-deepseek", "scripts/runtime.mjs", "export const version = 'stale';\n");
+  writeCachedSkill(primary, "relay-deepseek", "deepseek-review");
+  writeConfigEntries(primary, [
+    ["relay-claude", true],
+    ["relay-deepseek", true],
+  ]);
+
+  const stdout = execFileSync(process.execPath, [
+    DOCTOR,
+    "--repo", repo,
+    "--codex-home", primary,
+  ], { encoding: "utf8" });
+  const report = JSON.parse(stdout);
+  const profile = report.profiles.primary;
+
+  assert.equal(report.ok, false);
+  assert.equal(profile.plugins["relay-deepseek"].enabled, true);
+  assert.equal(profile.plugins["relay-deepseek"].required_for_ok, true);
+  assert.equal(profile.plugins["relay-deepseek"].cache_in_sync, false);
+  assert.equal(profile.plugins["api-reviewers"].required_by_enabled_plugin, true);
+  assert.equal(profile.plugins["api-reviewers"].required_for_ok, true);
+});
+
+test("codex plugin cache doctor fallback default list includes relay-agy when manifests are unavailable", () => {
+  const repo = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-fallback-agy-repo-"));
+  const primary = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-fallback-agy-home-"));
+
+  writePluginFile(path.join(repo, "plugins"), "relay-agy", "scripts/runtime.mjs", "export const version = 'source';\n");
+  writeSkill(path.join(repo, "plugins"), "relay-agy", "relay-agy-review");
+  writeConfig(primary, "relay-agy", true);
+
+  const stdout = execFileSync(process.execPath, [
+    DOCTOR,
+    "--repo", repo,
+    "--codex-home", primary,
+  ], { encoding: "utf8" });
+  const report = JSON.parse(stdout);
+  const profile = report.profiles.primary;
+
+  assert.equal(report.ok, false);
+  assert.equal(profile.plugins["relay-agy"].enabled, true);
+  assert.equal(profile.plugins["relay-agy"].required_for_ok, true);
+  assert.equal(profile.plugins["relay-agy"].cache_in_sync, false);
+});
+
+test("codex plugin cache doctor checks api-reviewers when an explicit direct API reviewer is requested", () => {
+  const repo = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-explicit-direct-api-repo-"));
+  const primary = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-explicit-direct-api-home-"));
+  const marketplaceRoot = path.join(primary, ".tmp", "marketplaces", MARKETPLACE);
+  const plugins = ["relay-deepseek", "api-reviewers"];
+
+  writeMarketplaceManifest(repo, plugins.map((plugin) => [plugin, `./plugins/${plugin}`]));
+  writeMarketplaceManifest(marketplaceRoot, plugins.map((plugin) => [plugin, `./plugins/${plugin}`]));
+  for (const plugin of plugins) {
+    writePluginFile(path.join(repo, "plugins"), plugin, "scripts/runtime.mjs", "export const version = 'source';\n");
+    writePluginFile(path.join(marketplaceRoot, "plugins"), plugin, "scripts/runtime.mjs", "export const version = 'source';\n");
+  }
+  writeSkill(path.join(repo, "plugins"), "relay-deepseek", "deepseek-review");
+  writeSkill(path.join(marketplaceRoot, "plugins"), "relay-deepseek", "deepseek-review");
+  writeCachedPluginFile(primary, "relay-deepseek", "scripts/runtime.mjs", "export const version = 'source';\n");
+  writeCachedSkill(primary, "relay-deepseek", "deepseek-review");
+  writeConfig(primary, "relay-deepseek", true);
+
+  const stdout = execFileSync(process.execPath, [
+    DOCTOR,
+    "--repo", repo,
+    "--codex-home", primary,
+    "--plugin", "relay-deepseek",
+  ], { encoding: "utf8" });
+  const report = JSON.parse(stdout);
+  const profile = report.profiles.primary;
+
+  assert.equal(report.ok, false);
+  assert.equal(profile.enabled, true);
+  assert.equal(profile.cache_in_sync, true);
+  assert.equal(profile.plugins["relay-deepseek"].required_for_ok, true);
+  assert.equal(profile.plugins["relay-deepseek"].cache_in_sync, true);
+  assert.equal(profile.plugins["api-reviewers"].required_for_ok, true);
+  assert.equal(profile.plugins["api-reviewers"].cache_in_sync, false);
+  assert.deepEqual(profile.plugins["api-reviewers"].missing_files, ["scripts/runtime.mjs"]);
+});
+
+test("codex plugin cache doctor checks api-reviewers when explicit glm reviewer is requested", () => {
+  const repo = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-explicit-glm-repo-"));
+  const primary = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-explicit-glm-home-"));
+  const marketplaceRoot = path.join(primary, ".tmp", "marketplaces", MARKETPLACE);
+  const plugins = ["relay-glm", "api-reviewers"];
+
+  writeMarketplaceManifest(repo, plugins.map((plugin) => [plugin, `./plugins/${plugin}`]));
+  writeMarketplaceManifest(marketplaceRoot, plugins.map((plugin) => [plugin, `./plugins/${plugin}`]));
+  for (const plugin of plugins) {
+    writePluginFile(path.join(repo, "plugins"), plugin, "scripts/runtime.mjs", "export const version = 'source';\n");
+    writePluginFile(path.join(marketplaceRoot, "plugins"), plugin, "scripts/runtime.mjs", "export const version = 'source';\n");
+  }
+  writeSkill(path.join(repo, "plugins"), "relay-glm", "glm-review");
+  writeSkill(path.join(marketplaceRoot, "plugins"), "relay-glm", "glm-review");
+  writeCachedPluginFile(primary, "relay-glm", "scripts/runtime.mjs", "export const version = 'source';\n");
+  writeCachedSkill(primary, "relay-glm", "glm-review");
+  writeConfig(primary, "relay-glm", true);
+
+  const stdout = execFileSync(process.execPath, [
+    DOCTOR,
+    "--repo", repo,
+    "--codex-home", primary,
+    "--plugin", "relay-glm",
+  ], { encoding: "utf8" });
+  const report = JSON.parse(stdout);
+  const profile = report.profiles.primary;
+
+  assert.equal(report.ok, false);
+  assert.equal(profile.summary_plugin, "relay-glm");
+  assert.equal(profile.enabled, true);
+  assert.equal(profile.cache_in_sync, true);
+  assert.equal(profile.plugins["relay-glm"].required_for_ok, true);
+  assert.equal(profile.plugins["api-reviewers"].required_for_ok, true);
+  assert.equal(profile.plugins["api-reviewers"].cache_in_sync, false);
+});
+
+test("codex plugin cache doctor honors explicit api-reviewers config enablement", () => {
+  const repo = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-api-runtime-config-repo-"));
+  const primary = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-api-runtime-config-home-"));
+  const marketplaceRoot = path.join(primary, ".tmp", "marketplaces", MARKETPLACE);
+  const plugins = CORE_MARKETPLACE_PLUGINS;
+
+  writeMarketplaceManifest(repo, plugins.map((plugin) => [plugin, `./plugins/${plugin}`]));
+  writeMarketplaceManifest(marketplaceRoot, plugins.map((plugin) => [plugin, `./plugins/${plugin}`]));
+  for (const plugin of plugins) {
+    writePluginFile(path.join(repo, "plugins"), plugin, "scripts/runtime.mjs", "export const version = 'source';\n");
+    writePluginFile(path.join(marketplaceRoot, "plugins"), plugin, "scripts/runtime.mjs", "export const version = 'source';\n");
+    if (plugin !== "api-reviewers") {
+      writeSkill(path.join(repo, "plugins"), plugin, `${plugin}-review`);
+      writeSkill(path.join(marketplaceRoot, "plugins"), plugin, `${plugin}-review`);
+    }
+  }
+  writeCachedPluginFile(primary, "relay-claude", "scripts/runtime.mjs", "export const version = 'source';\n");
+  writeCachedSkill(primary, "relay-claude", "relay-claude-review");
+  writeConfigEntries(primary, [
+    ["relay-claude", true],
+    ["relay-deepseek", false],
+    ["relay-glm", false],
+    ["api-reviewers", true],
+  ]);
+
+  const stdout = execFileSync(process.execPath, [
+    DOCTOR,
+    "--repo", repo,
+    "--codex-home", primary,
+  ], { encoding: "utf8" });
+  const report = JSON.parse(stdout);
+  const profile = report.profiles.primary;
+
+  assert.equal(report.ok, false);
+  assert.equal(profile.plugins["relay-claude"].required_for_ok, true);
+  assert.equal(profile.plugins["relay-deepseek"].enabled, false);
+  assert.equal(profile.plugins["relay-glm"].enabled, false);
+  assert.equal(profile.plugins["api-reviewers"].enabled, true);
+  assert.equal(profile.plugins["api-reviewers"].required_for_ok, true);
+  assert.equal(profile.plugins["api-reviewers"].cache_in_sync, false);
+});
+
+test("codex plugin cache doctor fails default profile when enabled direct API reviewer has stale api-reviewers runtime", () => {
+  const repo = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-default-direct-api-stale-repo-"));
+  const primary = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-default-direct-api-stale-home-"));
+  const marketplaceRoot = path.join(primary, ".tmp", "marketplaces", MARKETPLACE);
+  const plugins = CORE_MARKETPLACE_PLUGINS;
+
+  writeMarketplaceManifest(repo, plugins.map((plugin) => [plugin, `./plugins/${plugin}`]));
+  writeMarketplaceManifest(marketplaceRoot, plugins.map((plugin) => [plugin, `./plugins/${plugin}`]));
+  for (const plugin of plugins) {
+    writePluginFile(path.join(repo, "plugins"), plugin, "scripts/runtime.mjs", "export const version = 'source';\n");
+    writePluginFile(path.join(marketplaceRoot, "plugins"), plugin, "scripts/runtime.mjs", "export const version = 'source';\n");
+    if (plugin !== "api-reviewers") {
+      writeSkill(path.join(repo, "plugins"), plugin, `${plugin}-review`);
+      writeSkill(path.join(marketplaceRoot, "plugins"), plugin, `${plugin}-review`);
+    }
+  }
+  writeCachedPluginFile(primary, "relay-deepseek", "scripts/runtime.mjs", "export const version = 'source';\n");
+  writeCachedSkill(primary, "relay-deepseek", "relay-deepseek-review");
+  writeCachedPluginFile(primary, "api-reviewers", "scripts/runtime.mjs", "export const version = 'stale';\n");
+  writeConfig(primary, "relay-deepseek", true);
+
+  const stdout = execFileSync(process.execPath, [
+    DOCTOR,
+    "--repo", repo,
+    "--codex-home", primary,
+  ], { encoding: "utf8" });
+  const report = JSON.parse(stdout);
+  const profile = report.profiles.primary;
+
+  assert.equal(report.ok, false);
+  assert.equal(profile.plugins["relay-deepseek"].required_for_ok, true);
+  assert.equal(profile.plugins["relay-deepseek"].cache_in_sync, true);
+  assert.equal(profile.plugins["api-reviewers"].configured_enabled, false);
+  assert.equal(profile.plugins["api-reviewers"].required_by_enabled_plugin, true);
+  assert.equal(profile.plugins["api-reviewers"].required_for_ok, true);
+  assert.equal(profile.plugins["api-reviewers"].cache_in_sync, false);
+  assert.deepEqual(profile.plugins["api-reviewers"].changed_files, ["scripts/runtime.mjs"]);
+});
+
+test("codex plugin cache doctor applies api-reviewers dependency per Codex home", () => {
+  const repo = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-api-runtime-home-split-repo-"));
+  const primary = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-api-runtime-home-split-primary-"));
+  const second = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-api-runtime-home-split-second-"));
+  const marketplaceRoot = path.join(primary, ".tmp", "marketplaces", MARKETPLACE);
+  const plugins = CORE_MARKETPLACE_PLUGINS;
+
+  writeMarketplaceManifest(repo, plugins.map((plugin) => [plugin, `./plugins/${plugin}`]));
+  writeMarketplaceManifest(marketplaceRoot, plugins.map((plugin) => [plugin, `./plugins/${plugin}`]));
+  for (const plugin of plugins) {
+    writePluginFile(path.join(repo, "plugins"), plugin, "scripts/runtime.mjs", "export const version = 'source';\n");
+    writePluginFile(path.join(marketplaceRoot, "plugins"), plugin, "scripts/runtime.mjs", "export const version = 'source';\n");
+    if (plugin !== "api-reviewers") {
+      writeSkill(path.join(repo, "plugins"), plugin, `${plugin}-review`);
+      writeSkill(path.join(marketplaceRoot, "plugins"), plugin, `${plugin}-review`);
+    }
+  }
+  writeCachedPluginFile(primary, "relay-deepseek", "scripts/runtime.mjs", "export const version = 'source';\n");
+  writeCachedSkill(primary, "relay-deepseek", "relay-deepseek-review");
+  writeCachedPluginFile(primary, "api-reviewers", "scripts/runtime.mjs", "export const version = 'stale';\n");
+  writeCachedPluginFile(second, "relay-claude", "scripts/runtime.mjs", "export const version = 'source';\n");
+  writeCachedSkill(second, "relay-claude", "relay-claude-review");
+  writeConfig(primary, "relay-deepseek", true);
+  writeConfig(second, "relay-claude", true);
+
+  const stdout = execFileSync(process.execPath, [
+    DOCTOR,
+    "--repo", repo,
+    "--codex-home", primary,
+    "--second-codex-home", second,
+  ], { encoding: "utf8" });
+  const report = JSON.parse(stdout);
+
+  assert.equal(report.ok, false);
+  assert.equal(report.profiles.primary.ok, false);
+  assert.equal(report.profiles.primary.plugins["api-reviewers"].required_by_enabled_plugin, true);
+  assert.equal(report.profiles.primary.plugins["api-reviewers"].required_for_ok, true);
+  assert.equal(report.profiles.primary.plugins["api-reviewers"].cache_in_sync, false);
+  assert.equal(report.profiles.second.ok, true);
+  assert.equal(report.profiles.second.plugins["api-reviewers"].required_by_enabled_plugin, false);
+  assert.equal(report.profiles.second.plugins["api-reviewers"].required_for_ok, false);
+});
+
+test("codex plugin cache doctor fails default profile when an enabled regular plugin is stale", () => {
+  const repo = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-default-regular-stale-repo-"));
+  const primary = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-default-regular-stale-home-"));
+  const marketplaceRoot = path.join(primary, ".tmp", "marketplaces", MARKETPLACE);
+  const plugins = ["relay-grok"];
+
+  writeMarketplaceManifest(repo, plugins.map((plugin) => [plugin, `./plugins/${plugin}`]));
+  writeMarketplaceManifest(marketplaceRoot, plugins.map((plugin) => [plugin, `./plugins/${plugin}`]));
+  writePluginFile(path.join(repo, "plugins"), "relay-grok", "scripts/runtime.mjs", "export const version = 'source';\n");
+  writePluginFile(path.join(marketplaceRoot, "plugins"), "relay-grok", "scripts/runtime.mjs", "export const version = 'source';\n");
+  writeSkill(path.join(repo, "plugins"), "relay-grok", "grok-review");
+  writeSkill(path.join(marketplaceRoot, "plugins"), "relay-grok", "grok-review");
+  writeCachedPluginFile(primary, "relay-grok", "scripts/runtime.mjs", "export const version = 'stale';\n");
+  writeCachedSkill(primary, "relay-grok", "grok-review");
+  writeConfig(primary, "relay-grok", true);
+
+  const stdout = execFileSync(process.execPath, [
+    DOCTOR,
+    "--repo", repo,
+    "--codex-home", primary,
+  ], { encoding: "utf8" });
+  const report = JSON.parse(stdout);
+  const profile = report.profiles.primary;
+
+  assert.equal(report.ok, false);
+  assert.equal(profile.plugins["relay-grok"].enabled, true);
+  assert.equal(profile.plugins["relay-grok"].required_for_ok, true);
+  assert.equal(profile.plugins["relay-grok"].cache_in_sync, false);
+});
+
+test("codex plugin cache doctor names explicitly required disabled plugins in next actions", () => {
+  const repo = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-disabled-required-action-repo-"));
+  const primary = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-disabled-required-action-home-"));
+  const marketplaceRoot = path.join(primary, ".tmp", "marketplaces", MARKETPLACE);
+  const plugins = ["relay-gemini"];
+
+  writeMarketplaceManifest(repo, plugins.map((plugin) => [plugin, `./plugins/${plugin}`]));
+  writeMarketplaceManifest(marketplaceRoot, plugins.map((plugin) => [plugin, `./plugins/${plugin}`]));
+  writePluginFile(path.join(repo, "plugins"), "relay-gemini", "scripts/runtime.mjs", "export const version = 'source';\n");
+  writePluginFile(path.join(marketplaceRoot, "plugins"), "relay-gemini", "scripts/runtime.mjs", "export const version = 'source';\n");
+  writeSkill(path.join(repo, "plugins"), "relay-gemini", "gemini-review");
+  writeSkill(path.join(marketplaceRoot, "plugins"), "relay-gemini", "gemini-review");
+  writeCachedPluginFile(primary, "relay-gemini", "scripts/runtime.mjs", "export const version = 'source';\n");
+  writeCachedSkill(primary, "relay-gemini", "gemini-review");
+  writeConfig(primary, "relay-gemini", false);
+
+  const stdout = execFileSync(process.execPath, [
+    DOCTOR,
+    "--repo", repo,
+    "--codex-home", primary,
+    "--plugin", "relay-gemini",
+  ], { encoding: "utf8" });
+  const report = JSON.parse(stdout);
+  const nextActions = report.next_actions.join("\n");
+
+  assert.equal(report.ok, false);
+  assert.match(nextActions, /Enable required disabled plugins/i);
+  assert.match(nextActions, /relay-gemini/);
+});
 
 test("codex plugin cache doctor follows marketplace source.path for public plugin names", () => {
   const repo = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-mapped-repo-"));
@@ -149,9 +648,11 @@ test("codex plugin cache doctor reports stale cache, enablement, and restart gui
   assert.equal(report.ok, false);
   assert.equal(report.marketplace.present, true);
   assert.equal(report.profiles.primary.enabled, true);
+  assert.equal(report.profiles.primary.plugins["relay-grok"].required_for_ok, true);
   assert.equal(report.profiles.primary.cache_in_sync, false);
   assert.deepEqual(report.profiles.primary.missing_skills, ["grok-review"]);
   assert.equal(report.profiles.second.enabled, false);
+  assert.equal(report.profiles.second.plugins["relay-grok"].required_for_ok, true);
   assert.equal(report.profiles.second.cache_in_sync, true);
   assert.equal(report.marketplace.name, MARKETPLACE);
   assert.equal(report.marketplace.cache_namespace, CACHE_NAMESPACE);

--- a/tests/unit/plugin-cache-doctor.test.mjs
+++ b/tests/unit/plugin-cache-doctor.test.mjs
@@ -71,11 +71,15 @@ function writeMarketplaceManifest(root, plugins) {
     file,
     `${JSON.stringify({
       name: MARKETPLACE,
-      plugins: plugins.map(([name, sourcePath]) => ({
-        name,
-        source: { source: "local", path: sourcePath },
-        policy: { installation: "AVAILABLE", authentication: "ON_USE" },
-      })),
+      plugins: plugins.map(([name, sourcePath, version]) => {
+        const entry = {
+          name,
+          source: { source: "local", path: sourcePath },
+          policy: { installation: "AVAILABLE", authentication: "ON_USE" },
+        };
+        if (version) entry.version = version;
+        return entry;
+      }),
     }, null, 2)}\n`,
     "utf8",
   );
@@ -433,6 +437,35 @@ test("codex plugin cache doctor reads non-default cache version from source meta
   assert.equal(profile.plugins["relay-grok"].cache_in_sync, true);
 });
 
+test("codex plugin cache doctor reads cache version from marketplace manifest when source metadata is absent", () => {
+  const repo = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-manifest-version-repo-"));
+  const primary = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-manifest-version-home-"));
+  const marketplaceRoot = path.join(primary, ".tmp", "marketplaces", MARKETPLACE);
+
+  writeMarketplaceManifest(repo, [["relay-grok", "./plugins/grok"]]);
+  writeMarketplaceManifest(marketplaceRoot, [["relay-grok", "./plugins/grok", "0.2.0"]]);
+  writePluginFile(path.join(repo, "plugins"), "grok", "scripts/runtime.mjs", "export const version = 'repo-new';\n");
+  writePluginFile(path.join(marketplaceRoot, "plugins"), "grok", "scripts/runtime.mjs", "export const version = 'marketplace';\n");
+  writeCachedPluginFile(primary, "relay-grok", "scripts/runtime.mjs", "export const version = 'marketplace';\n", "0.2.0");
+  writeCachedPluginFile(primary, "relay-grok", "scripts/runtime.mjs", "export const version = 'stale';\n", "0.1.0");
+  writeConfig(primary, "relay-grok", true);
+
+  const stdout = execFileSync(process.execPath, [
+    DOCTOR,
+    "--repo", repo,
+    "--codex-home", primary,
+  ], { encoding: "utf8" });
+  const report = JSON.parse(stdout);
+  const profile = report.profiles.primary;
+
+  assert.equal(report.ok, false);
+  assert.equal(profile.plugins["relay-grok"].marketplace_manifest_version, "0.2.0");
+  assert.equal(profile.plugins["relay-grok"].cache_version, "0.2.0");
+  assert.equal(profile.plugins["relay-grok"].cache_in_sync, true);
+  assert.equal(profile.plugins["relay-grok"].repo_cache_in_sync, false);
+  assert.deepEqual(profile.plugins["relay-grok"].repo_changed_files, ["scripts/runtime.mjs"]);
+});
+
 test("codex plugin cache doctor uses installed cache version when active source lacks version metadata", () => {
   const repo = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-cache-version-repo-"));
   const primary = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-cache-version-home-"));
@@ -456,6 +489,35 @@ test("codex plugin cache doctor uses installed cache version when active source 
 
   assert.equal(report.ok, false);
   assert.equal(profile.plugins["relay-grok"].cache_version, "0.1.0");
+  assert.equal(profile.plugins["relay-grok"].cache_in_sync, true);
+  assert.equal(profile.plugins["relay-grok"].repo_cache_in_sync, false);
+  assert.deepEqual(profile.plugins["relay-grok"].repo_changed_files, ["scripts/runtime.mjs"]);
+});
+
+test("codex plugin cache doctor matches active source when version metadata is absent and multiple cache dirs exist", () => {
+  const repo = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-cache-match-repo-"));
+  const primary = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-cache-match-home-"));
+  const marketplaceRoot = path.join(primary, ".tmp", "marketplaces", MARKETPLACE);
+
+  writeMarketplaceManifest(repo, [["relay-grok", "./plugins/grok"]]);
+  writeMarketplaceManifest(marketplaceRoot, [["relay-grok", "./plugins/grok"]]);
+  writePluginFile(path.join(repo, "plugins"), "grok", ".codex-plugin/plugin.json", `{"name":"relay-grok","version":"0.1.0"}\n`);
+  writePluginFile(path.join(repo, "plugins"), "grok", "scripts/runtime.mjs", "export const version = 'repo-old';\n");
+  writePluginFile(path.join(marketplaceRoot, "plugins"), "grok", "scripts/runtime.mjs", "export const version = 'marketplace-new';\n");
+  writeCachedPluginFile(primary, "relay-grok", "scripts/runtime.mjs", "export const version = 'repo-old';\n", "0.1.0");
+  writeCachedPluginFile(primary, "relay-grok", "scripts/runtime.mjs", "export const version = 'marketplace-new';\n", "0.2.0");
+  writeConfig(primary, "relay-grok", true);
+
+  const stdout = execFileSync(process.execPath, [
+    DOCTOR,
+    "--repo", repo,
+    "--codex-home", primary,
+  ], { encoding: "utf8" });
+  const report = JSON.parse(stdout);
+  const profile = report.profiles.primary;
+
+  assert.equal(report.ok, false);
+  assert.equal(profile.plugins["relay-grok"].cache_version, "0.2.0");
   assert.equal(profile.plugins["relay-grok"].cache_in_sync, true);
   assert.equal(profile.plugins["relay-grok"].repo_cache_in_sync, false);
   assert.deepEqual(profile.plugins["relay-grok"].repo_changed_files, ["scripts/runtime.mjs"]);

--- a/tests/unit/plugin-cache-doctor.test.mjs
+++ b/tests/unit/plugin-cache-doctor.test.mjs
@@ -242,6 +242,40 @@ test("codex plugin cache doctor default profile includes repo-manifest plugins m
   assert.equal(profile.plugins["relay-agy"].cache_in_sync, false);
 });
 
+test("codex plugin cache doctor fails required plugins missing from the active marketplace manifest", () => {
+  const repo = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-manifest-membership-repo-"));
+  const primary = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-manifest-membership-home-"));
+  const marketplaceRoot = path.join(primary, ".tmp", "marketplaces", MARKETPLACE);
+
+  writeMarketplaceManifest(repo, [
+    ["relay-claude", "./plugins/relay-claude"],
+    ["relay-agy", "./plugins/agy"],
+  ]);
+  writeMarketplaceManifest(marketplaceRoot, [["relay-claude", "./plugins/relay-claude"]]);
+  writePluginFile(path.join(repo, "plugins"), "agy", "scripts/runtime.mjs", "export const version = 'source';\n");
+  writePluginFile(path.join(marketplaceRoot, "plugins"), "agy", "scripts/runtime.mjs", "export const version = 'source';\n");
+  writeSkill(path.join(repo, "plugins"), "agy", "relay-agy-review");
+  writeSkill(path.join(marketplaceRoot, "plugins"), "agy", "relay-agy-review");
+  writeCachedPluginFile(primary, "relay-agy", "scripts/runtime.mjs", "export const version = 'source';\n");
+  writeCachedSkill(primary, "relay-agy", "relay-agy-review");
+  writeConfig(primary, "relay-agy", true);
+
+  const stdout = execFileSync(process.execPath, [
+    DOCTOR,
+    "--repo", repo,
+    "--codex-home", primary,
+  ], { encoding: "utf8" });
+  const report = JSON.parse(stdout);
+  const profile = report.profiles.primary;
+
+  assert.equal(report.ok, false);
+  assert.equal(profile.plugins["relay-agy"].enabled, true);
+  assert.equal(profile.plugins["relay-agy"].required_for_ok, true);
+  assert.equal(profile.plugins["relay-agy"].cache_in_sync, true);
+  assert.equal(profile.plugins["relay-agy"].repo_cache_in_sync, true);
+  assert.equal(profile.plugins["relay-agy"].listed_in_marketplace_manifest, false);
+});
+
 test("codex plugin cache doctor default profile includes config-enabled plugins absent from manifests", () => {
   const repo = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-config-enabled-repo-"));
   const primary = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-config-enabled-home-"));
@@ -281,12 +315,49 @@ test("codex plugin cache doctor default profile includes config-enabled plugins 
   assert.equal(profile.plugins["api-reviewers"].required_for_ok, true);
 });
 
-test("codex plugin cache doctor fallback default list includes relay-agy when manifests are unavailable", () => {
+test("codex plugin cache doctor ignores commented enabled values and accepts spaced section headers", () => {
+  const repo = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-config-comments-repo-"));
+  const primary = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-config-comments-home-"));
+  const marketplaceRoot = path.join(primary, ".tmp", "marketplaces", MARKETPLACE);
+
+  writeMarketplaceManifest(repo, [["relay-grok", "./plugins/grok"]]);
+  writeMarketplaceManifest(marketplaceRoot, [["relay-grok", "./plugins/grok"]]);
+  writePluginFile(path.join(repo, "plugins"), "grok", "scripts/runtime.mjs", "export const version = 'source';\n");
+  writePluginFile(path.join(marketplaceRoot, "plugins"), "grok", "scripts/runtime.mjs", "export const version = 'source';\n");
+  writeSkill(path.join(repo, "plugins"), "grok", "relay-grok-review");
+  writeSkill(path.join(marketplaceRoot, "plugins"), "grok", "relay-grok-review");
+  writeCachedPluginFile(primary, "relay-grok", "scripts/runtime.mjs", "export const version = 'stale';\n");
+  writeCachedSkill(primary, "relay-grok", "relay-grok-review");
+  mkdirSync(primary, { recursive: true });
+  writeFileSync(
+    path.join(primary, "config.toml"),
+    `  [ plugins . "relay-grok@${MARKETPLACE}" ]\n# enabled = true\nenabled = false\n`,
+    "utf8",
+  );
+
+  const stdout = execFileSync(process.execPath, [
+    DOCTOR,
+    "--repo", repo,
+    "--codex-home", primary,
+  ], { encoding: "utf8" });
+  const report = JSON.parse(stdout);
+  const profile = report.profiles.primary;
+
+  assert.equal(report.ok, true);
+  assert.equal(profile.plugins["relay-grok"].configured_enabled, false);
+  assert.equal(profile.plugins["relay-grok"].enabled, false);
+  assert.equal(profile.plugins["relay-grok"].required_for_ok, false);
+  assert.equal(profile.plugins["relay-grok"].cache_in_sync, false);
+});
+
+test("codex plugin cache doctor fallback default list includes relay-agy with its canonical source path", () => {
   const repo = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-fallback-agy-repo-"));
   const primary = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-fallback-agy-home-"));
 
-  writePluginFile(path.join(repo, "plugins"), "relay-agy", "scripts/runtime.mjs", "export const version = 'source';\n");
-  writeSkill(path.join(repo, "plugins"), "relay-agy", "relay-agy-review");
+  writePluginFile(path.join(repo, "plugins"), "agy", "scripts/runtime.mjs", "export const version = 'source';\n");
+  writeSkill(path.join(repo, "plugins"), "agy", "relay-agy-review");
+  writeCachedPluginFile(primary, "relay-agy", "scripts/runtime.mjs", "export const version = 'source';\n");
+  writeCachedSkill(primary, "relay-agy", "relay-agy-review");
   writeConfig(primary, "relay-agy", true);
 
   const stdout = execFileSync(process.execPath, [
@@ -297,10 +368,38 @@ test("codex plugin cache doctor fallback default list includes relay-agy when ma
   const report = JSON.parse(stdout);
   const profile = report.profiles.primary;
 
-  assert.equal(report.ok, false);
+  assert.equal(report.ok, true);
   assert.equal(profile.plugins["relay-agy"].enabled, true);
   assert.equal(profile.plugins["relay-agy"].required_for_ok, true);
-  assert.equal(profile.plugins["relay-agy"].cache_in_sync, false);
+  assert.equal(profile.plugins["relay-agy"].source_path, "plugins/agy");
+  assert.equal(profile.plugins["relay-agy"].cache_in_sync, true);
+});
+
+test("codex plugin cache doctor falls back to repo source when marketplace directory has no manifest", () => {
+  const repo = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-empty-marketplace-repo-"));
+  const primary = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-empty-marketplace-home-"));
+  const marketplaceRoot = path.join(primary, ".tmp", "marketplaces", MARKETPLACE);
+  mkdirSync(marketplaceRoot, { recursive: true });
+
+  writeMarketplaceManifest(repo, [["relay-grok", "./plugins/grok"]]);
+  writePluginFile(path.join(repo, "plugins"), "grok", "scripts/runtime.mjs", "export const version = 'source';\n");
+  writeSkill(path.join(repo, "plugins"), "grok", "relay-grok-review");
+  writeCachedPluginFile(primary, "relay-grok", "scripts/runtime.mjs", "export const version = 'source';\n");
+  writeCachedSkill(primary, "relay-grok", "relay-grok-review");
+  writeConfig(primary, "relay-grok", true);
+
+  const stdout = execFileSync(process.execPath, [
+    DOCTOR,
+    "--repo", repo,
+    "--codex-home", primary,
+  ], { encoding: "utf8" });
+  const report = JSON.parse(stdout);
+  const profile = report.profiles.primary;
+
+  assert.equal(report.marketplace.present, false);
+  assert.equal(report.ok, true);
+  assert.equal(profile.plugins["relay-grok"].source_path, "plugins/grok");
+  assert.equal(profile.plugins["relay-grok"].cache_in_sync, true);
 });
 
 test("codex plugin cache doctor checks api-reviewers when an explicit direct API reviewer is requested", () => {
@@ -500,6 +599,38 @@ test("codex plugin cache doctor applies api-reviewers dependency per Codex home"
   assert.equal(report.profiles.second.plugins["api-reviewers"].required_for_ok, false);
 });
 
+test("codex plugin cache doctor compares each Codex home against its own marketplace clone", () => {
+  const repo = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-home-source-split-repo-"));
+  const primary = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-home-source-split-primary-"));
+  const second = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-home-source-split-second-"));
+  const primaryMarketplaceRoot = path.join(primary, ".tmp", "marketplaces", MARKETPLACE);
+  const secondMarketplaceRoot = path.join(second, ".tmp", "marketplaces", MARKETPLACE);
+  mkdirSync(primaryMarketplaceRoot, { recursive: true });
+
+  writeMarketplaceManifest(secondMarketplaceRoot, [["relay-grok", "./plugins/grok"]]);
+  writePluginFile(path.join(secondMarketplaceRoot, "plugins"), "grok", "scripts/runtime.mjs", "export const version = 'source';\n");
+  writeSkill(path.join(secondMarketplaceRoot, "plugins"), "grok", "relay-grok-review");
+  writeCachedPluginFile(second, "relay-grok", "scripts/runtime.mjs", "export const version = 'source';\n");
+  writeCachedSkill(second, "relay-grok", "relay-grok-review");
+  writeConfig(second, "relay-grok", true);
+
+  const stdout = execFileSync(process.execPath, [
+    DOCTOR,
+    "--repo", repo,
+    "--codex-home", primary,
+    "--second-codex-home", second,
+  ], { encoding: "utf8" });
+  const report = JSON.parse(stdout);
+
+  assert.equal(report.ok, true);
+  assert.equal(report.profiles.primary.ok, true);
+  assert.equal(report.profiles.second.ok, true);
+  assert.equal(report.profiles.second.plugins["relay-grok"].enabled, true);
+  assert.equal(report.profiles.second.plugins["relay-grok"].required_for_ok, true);
+  assert.equal(report.profiles.second.plugins["relay-grok"].source_path, "plugins/grok");
+  assert.equal(report.profiles.second.plugins["relay-grok"].cache_in_sync, true);
+});
+
 test("codex plugin cache doctor fails default profile when an enabled regular plugin is stale", () => {
   const repo = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-default-regular-stale-repo-"));
   const primary = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-default-regular-stale-home-"));
@@ -627,8 +758,11 @@ test("codex plugin cache doctor reports stale cache, enablement, and restart gui
   const repo = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-repo-"));
   const primary = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-primary-"));
   const second = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-second-"));
-  const marketplace = path.join(primary, ".tmp", "marketplaces", MARKETPLACE, "plugins");
+  const marketplaceRoot = path.join(primary, ".tmp", "marketplaces", MARKETPLACE);
+  const marketplace = path.join(marketplaceRoot, "plugins");
 
+  writeMarketplaceManifest(repo, [["relay-grok", "./plugins/relay-grok"]]);
+  writeMarketplaceManifest(marketplaceRoot, [["relay-grok", "./plugins/relay-grok"]]);
   writeSkill(path.join(repo, "plugins"), "relay-grok", "grok-review");
   writeSkill(marketplace, "relay-grok", "grok-review");
   writeCachedSkill(primary, "relay-grok", "grok-delegation");
@@ -665,6 +799,7 @@ test("codex plugin cache doctor reports stale runtime files even when skill name
   const repo = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-runtime-repo-"));
   const primary = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-runtime-home-"));
 
+  writeMarketplaceManifest(repo, [["relay-grok", "./plugins/relay-grok"]]);
   writeSkill(path.join(repo, "plugins"), "relay-grok", "grok-review");
   writeCachedSkill(primary, "relay-grok", "grok-review");
   writePluginFile(path.join(repo, "plugins"), "relay-grok", "scripts/grok-web-reviewer.mjs", "export const version = 'source';\n");
@@ -714,8 +849,11 @@ test("codex plugin cache doctor reports stale packaged bin shims", () => {
 test("codex plugin cache doctor flags repo changes even when marketplace cache is in sync", () => {
   const repo = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-dirty-repo-"));
   const primary = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-dirty-home-"));
-  const marketplace = path.join(primary, ".tmp", "marketplaces", MARKETPLACE, "plugins");
+  const marketplaceRoot = path.join(primary, ".tmp", "marketplaces", MARKETPLACE);
+  const marketplace = path.join(marketplaceRoot, "plugins");
 
+  writeMarketplaceManifest(repo, [["api-reviewers", "./plugins/api-reviewers"]]);
+  writeMarketplaceManifest(marketplaceRoot, [["api-reviewers", "./plugins/api-reviewers"]]);
   writeSkill(path.join(repo, "plugins"), "api-reviewers", "deepseek-setup");
   writeSkill(marketplace, "api-reviewers", "deepseek-setup");
   writeCachedSkill(primary, "api-reviewers", "deepseek-setup");
@@ -743,8 +881,11 @@ test("codex plugin cache doctor flags repo changes even when marketplace cache i
 test("codex plugin cache doctor checks internal api-reviewers runtime without requiring enablement", () => {
   const repo = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-runtime-repo-"));
   const primary = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-runtime-home-"));
-  const marketplace = path.join(primary, ".tmp", "marketplaces", MARKETPLACE, "plugins");
+  const marketplaceRoot = path.join(primary, ".tmp", "marketplaces", MARKETPLACE);
+  const marketplace = path.join(marketplaceRoot, "plugins");
 
+  writeMarketplaceManifest(repo, [["api-reviewers", "./plugins/api-reviewers"]]);
+  writeMarketplaceManifest(marketplaceRoot, [["api-reviewers", "./plugins/api-reviewers"]]);
   writePluginFile(path.join(repo, "plugins"), "api-reviewers", "scripts/api-reviewer.mjs", "source runtime\n");
   writePluginFile(marketplace, "api-reviewers", "scripts/api-reviewer.mjs", "source runtime\n");
   writeCachedPluginFile(primary, "api-reviewers", "scripts/api-reviewer.mjs", "source runtime\n");
@@ -769,8 +910,10 @@ test("codex plugin cache doctor checks internal api-reviewers runtime without re
 test("codex plugin cache doctor does not fail repo-cache check when repo plugin source is absent", () => {
   const repo = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-no-repo-"));
   const primary = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-no-repo-home-"));
-  const marketplace = path.join(primary, ".tmp", "marketplaces", MARKETPLACE, "plugins");
+  const marketplaceRoot = path.join(primary, ".tmp", "marketplaces", MARKETPLACE);
+  const marketplace = path.join(marketplaceRoot, "plugins");
 
+  writeMarketplaceManifest(marketplaceRoot, [["relay-grok", "./plugins/relay-grok"]]);
   writeSkill(marketplace, "relay-grok", "grok-review");
   writeCachedSkill(primary, "relay-grok", "grok-review");
   writePluginFile(marketplace, "relay-grok", "scripts/grok-web-reviewer.mjs", "export const version = 'marketplace';\n");

--- a/tests/unit/plugin-cache-doctor.test.mjs
+++ b/tests/unit/plugin-cache-doctor.test.mjs
@@ -26,8 +26,8 @@ function writeSkill(root, plugin, skill) {
   writeFileSync(path.join(dir, "SKILL.md"), `---\nname: ${skill}\n---\n`, "utf8");
 }
 
-function writeCachedSkill(home, plugin, skill) {
-  const dir = path.join(home, "plugins", "cache", CACHE_NAMESPACE, plugin, "0.1.0", "skills", skill);
+function writeCachedSkill(home, plugin, skill, version = "0.1.0") {
+  const dir = path.join(home, "plugins", "cache", CACHE_NAMESPACE, plugin, version, "skills", skill);
   mkdirSync(dir, { recursive: true });
   writeFileSync(path.join(dir, "SKILL.md"), `---\nname: ${skill}\n---\n`, "utf8");
 }
@@ -38,8 +38,8 @@ function writePluginFile(root, plugin, rel, content) {
   writeFileSync(file, content, "utf8");
 }
 
-function writeCachedPluginFile(home, plugin, rel, content) {
-  const file = path.join(home, "plugins", "cache", CACHE_NAMESPACE, plugin, "0.1.0", rel);
+function writeCachedPluginFile(home, plugin, rel, content, version = "0.1.0") {
+  const file = path.join(home, "plugins", "cache", CACHE_NAMESPACE, plugin, version, rel);
   mkdirSync(path.dirname(file), { recursive: true });
   writeFileSync(file, content, "utf8");
 }
@@ -274,6 +274,7 @@ test("codex plugin cache doctor fails required plugins missing from the active m
   assert.equal(profile.plugins["relay-agy"].cache_in_sync, true);
   assert.equal(profile.plugins["relay-agy"].repo_cache_in_sync, true);
   assert.equal(profile.plugins["relay-agy"].listed_in_marketplace_manifest, false);
+  assert.match(report.next_actions.join("\n"), /required plugins appear in the installed marketplace manifest: relay-agy/);
 });
 
 test("codex plugin cache doctor default profile includes config-enabled plugins absent from manifests", () => {
@@ -400,6 +401,64 @@ test("codex plugin cache doctor falls back to repo source when marketplace direc
   assert.equal(report.ok, true);
   assert.equal(profile.plugins["relay-grok"].source_path, "plugins/grok");
   assert.equal(profile.plugins["relay-grok"].cache_in_sync, true);
+});
+
+test("codex plugin cache doctor reads non-default cache version from source metadata", () => {
+  const repo = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-source-version-repo-"));
+  const primary = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-source-version-home-"));
+  const marketplaceRoot = path.join(primary, ".tmp", "marketplaces", MARKETPLACE);
+  const pluginJson = `{"name":"relay-grok","version":"0.2.0"}\n`;
+
+  writeMarketplaceManifest(repo, [["relay-grok", "./plugins/grok"]]);
+  writeMarketplaceManifest(marketplaceRoot, [["relay-grok", "./plugins/grok"]]);
+  writePluginFile(path.join(repo, "plugins"), "grok", ".codex-plugin/plugin.json", pluginJson);
+  writePluginFile(path.join(repo, "plugins"), "grok", "scripts/runtime.mjs", "export const version = 'source';\n");
+  writePluginFile(path.join(marketplaceRoot, "plugins"), "grok", ".codex-plugin/plugin.json", pluginJson);
+  writePluginFile(path.join(marketplaceRoot, "plugins"), "grok", "scripts/runtime.mjs", "export const version = 'source';\n");
+  writeCachedPluginFile(primary, "relay-grok", ".codex-plugin/plugin.json", pluginJson, "0.2.0");
+  writeCachedPluginFile(primary, "relay-grok", "scripts/runtime.mjs", "export const version = 'source';\n", "0.2.0");
+  writeConfig(primary, "relay-grok", true);
+
+  const stdout = execFileSync(process.execPath, [
+    DOCTOR,
+    "--repo", repo,
+    "--codex-home", primary,
+  ], { encoding: "utf8" });
+  const report = JSON.parse(stdout);
+  const profile = report.profiles.primary;
+
+  assert.equal(report.ok, true);
+  assert.equal(profile.plugins["relay-grok"].cache_version, "0.2.0");
+  assert.match(profile.plugins["relay-grok"].cache_path, /relay-grok\/0\.2\.0$/);
+  assert.equal(profile.plugins["relay-grok"].cache_in_sync, true);
+});
+
+test("codex plugin cache doctor uses installed cache version when active source lacks version metadata", () => {
+  const repo = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-cache-version-repo-"));
+  const primary = mkdtempSync(path.join(tmpdir(), "plugin-cache-doctor-cache-version-home-"));
+  const marketplaceRoot = path.join(primary, ".tmp", "marketplaces", MARKETPLACE);
+
+  writeMarketplaceManifest(repo, [["relay-grok", "./plugins/grok"]]);
+  writeMarketplaceManifest(marketplaceRoot, [["relay-grok", "./plugins/grok"]]);
+  writePluginFile(path.join(repo, "plugins"), "grok", ".codex-plugin/plugin.json", `{"name":"relay-grok","version":"0.2.0"}\n`);
+  writePluginFile(path.join(repo, "plugins"), "grok", "scripts/runtime.mjs", "export const version = 'repo-new';\n");
+  writePluginFile(path.join(marketplaceRoot, "plugins"), "grok", "scripts/runtime.mjs", "export const version = 'marketplace';\n");
+  writeCachedPluginFile(primary, "relay-grok", "scripts/runtime.mjs", "export const version = 'marketplace';\n", "0.1.0");
+  writeConfig(primary, "relay-grok", true);
+
+  const stdout = execFileSync(process.execPath, [
+    DOCTOR,
+    "--repo", repo,
+    "--codex-home", primary,
+  ], { encoding: "utf8" });
+  const report = JSON.parse(stdout);
+  const profile = report.profiles.primary;
+
+  assert.equal(report.ok, false);
+  assert.equal(profile.plugins["relay-grok"].cache_version, "0.1.0");
+  assert.equal(profile.plugins["relay-grok"].cache_in_sync, true);
+  assert.equal(profile.plugins["relay-grok"].repo_cache_in_sync, false);
+  assert.deepEqual(profile.plugins["relay-grok"].repo_changed_files, ["scripts/runtime.mjs"]);
 });
 
 test("codex plugin cache doctor checks api-reviewers when an explicit direct API reviewer is requested", () => {
@@ -623,6 +682,10 @@ test("codex plugin cache doctor compares each Codex home against its own marketp
   const report = JSON.parse(stdout);
 
   assert.equal(report.ok, true);
+  assert.equal(report.marketplace.present, false);
+  assert.equal(report.marketplaces.primary.present, false);
+  assert.equal(report.marketplaces.second.present, true);
+  assert.equal(report.marketplaces.second.source_root, secondMarketplaceRoot);
   assert.equal(report.profiles.primary.ok, true);
   assert.equal(report.profiles.second.ok, true);
   assert.equal(report.profiles.second.plugins["relay-grok"].enabled, true);


### PR DESCRIPTION
## Summary
- derive cache doctor default plugin checks from fallback defaults, marketplace and repo manifests, enabled config entries, and installed cache dirs
- keep disabled optional plugins informational while failing stale or missing enabled plugins and required api-reviewers runtimes
- document aggregate health fields and add regression coverage for stale clone, config-only, fallback, and dependency cases

## Verification
- node --test tests/unit/plugin-cache-doctor.test.mjs
- node --test tests/unit/docs-contracts.test.mjs
- npm run lint